### PR TITLE
chore(build-logic): ktlint-gradle 의 ktlint 버전을 libs.versions.toml 에 핀

### DIFF
--- a/build-logic/src/main/kotlin/AndroidLintConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidLintConventionPlugin.kt
@@ -9,7 +9,15 @@ class AndroidLintConventionPlugin : Plugin<Project> {
         with(target) {
             pluginManager.apply("org.jlleitschuh.gradle.ktlint")
 
+            // VersionCatalog 명시적 접근
+            val libs = extensions
+                .getByType<VersionCatalogsExtension>()
+                .named("libs")
+
             extensions.configure(KtlintExtension::class.java) {
+                // ktlint-gradle 의 default 버전 대신 libs.versions.toml 의 ktlint 버전을
+                // 명시적으로 사용해 CI(ScaCap/action-ktlint) 와 룰셋을 일치시킨다.
+                version.set(libs.findVersion("ktlint").get().requiredVersion)
                 debug.set(false)
                 verbose.set(true)
                 android.set(true)
@@ -19,11 +27,6 @@ class AndroidLintConventionPlugin : Plugin<Project> {
                     exclude { it.file.path.contains("build/") }
                 }
             }
-
-            // VersionCatalog 명시적 접근
-            val libs = extensions
-                .getByType<VersionCatalogsExtension>()
-                .named("libs")
 
             dependencies.add(
                 "ktlintRuleset",


### PR DESCRIPTION
## Summary

`KtlintExtension` 에 `version.set(...)` 한 줄 추가해 로컬 gradle ktlint 도 CI(`ScaCap/action-ktlint`) 와 동일한 ktlint 1.8.0 룰셋을 쓰게 한다.

## 배경

기존엔 ktlint 버전이 명목상으로만 통일돼 있었다.

| 환경 | 도구 | 적용 ktlint 버전 |
|---|---|---|
| **CI** | `ScaCap/action-ktlint` | `ktlint_version: "1.8.0"` 인자 → 1.8.0 사용 |
| **로컬** | `org.jlleitschuh.gradle.ktlint` 14.2.0 | `KtlintExtension.version` 미지정 → **ktlint-gradle 14.2.0 의 default ktlint** 사용 |

[libs.versions.toml](gradle/libs.versions.toml) 의 `ktlint = "1.8.0"` 은 `ktlint-cli` 의존성에만 쓰이고 gradle 플러그인엔 전달되지 않는 상태였다.

그래서 ktlint 1.6+ 부터 standard 로 승격된 룰들 (`when-entry-bracing`, `blank-line-between-when-conditions` 등) 이 로컬 `ktlintCheck` 에선 안 잡히고 PR 단계의 reviewdog 에서야 처음 잡혀 매번 한 번 더 commit 해야 하는 일이 발생했다 (#127 참고).

## 변경

```diff
+            // VersionCatalog 명시적 접근
+            val libs = extensions
+                .getByType<VersionCatalogsExtension>()
+                .named("libs")
+
             extensions.configure(KtlintExtension::class.java) {
+                // ktlint-gradle 의 default 버전 대신 libs.versions.toml 의 ktlint 버전을
+                // 명시적으로 사용해 CI(ScaCap/action-ktlint) 와 룰셋을 일치시킨다.
+                version.set(libs.findVersion("ktlint").get().requiredVersion)
                 debug.set(false)
                 ...
```

`val libs` 선언 위치만 위로 옮기고 `version.set` 한 줄 추가. 컨벤션 플러그인(`AndroidLintConventionPlugin`) 한 곳만 수정하면 모든 모듈에 일괄 반영된다.

## 효과

- **pre-commit hook 의 `ktlintCheck`** 가 CI 와 동일 룰셋으로 검사 → PR 올리기 전 로컬에서 모두 잡힌다
- ktlint 버전 단일 진실 = `libs.versions.toml`. 향후 ktlint 업그레이드 시 `libs.versions.toml` + CI workflow 두 곳만 동기화하면 된다 (현재도 두 곳에서 동기화 필요)

## Test plan

- [x] `./gradlew --stop && ./gradlew ktlintCheck` BUILD SUCCESSFUL (develop 코드 기준)
- [ ] 머지 후 다음 PR 부터 reviewdog 가 잡지 않는 새 위반 없이 통과하는지 모니터링

## 참고

이 변경은 #127 PR 작업 중 발견된 이슈의 근본 해결책으로, #127 과는 별개의 인프라 정리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)