### PR TITLE
chore(build-logic): ktlint-gradle 의 ktlint 버전을 libs.versions.toml 에 핀

### DIFF
--- a/build-logic/src/main/kotlin/AndroidLintConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidLintConventionPlugin.kt
@@ -9,7 +9,15 @@ class AndroidLintConventionPlugin : Plugin<Project> {
         with(target) {
             pluginManager.apply("org.jlleitschuh.gradle.ktlint")
 
+            // VersionCatalog 명시적 접근
+            val libs = extensions
+                .getByType<VersionCatalogsExtension>()
+                .named("libs")
+
             extensions.configure(KtlintExtension::class.java) {
+                // ktlint-gradle 의 default 버전 대신 libs.versions.toml 의 ktlint 버전을
+                // 명시적으로 사용해 CI(ScaCap/action-ktlint) 와 룰셋을 일치시킨다.
+                version.set(libs.findVersion("ktlint").get().requiredVersion)
                 debug.set(false)
                 verbose.set(true)
                 android.set(true)
@@ -19,11 +27,6 @@ class AndroidLintConventionPlugin : Plugin<Project> {
                     exclude { it.file.path.contains("build/") }
                 }
             }
-
-            // VersionCatalog 명시적 접근
-            val libs = extensions
-                .getByType<VersionCatalogsExtension>()
-                .named("libs")
 
             dependencies.add(
                 "ktlintRuleset",

--- a/build-logic/src/main/kotlin/AndroidLintConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidLintConventionPlugin.kt
@@ -10,9 +10,10 @@ class AndroidLintConventionPlugin : Plugin<Project> {
             pluginManager.apply("org.jlleitschuh.gradle.ktlint")
 
             // VersionCatalog 명시적 접근
-            val libs = extensions
-                .getByType<VersionCatalogsExtension>()
-                .named("libs")
+            val libs =
+                extensions
+                    .getByType<VersionCatalogsExtension>()
+                    .named("libs")
 
             extensions.configure(KtlintExtension::class.java) {
                 // ktlint-gradle 의 default 버전 대신 libs.versions.toml 의 ktlint 버전을


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #129

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `AndroidLintConventionPlugin` 의 `KtlintExtension` 에 `version.set(libs.findVersion("ktlint").get().requiredVersion)` 한 줄 추가
- `val libs` 선언 위치를 `KtlintExtension` 블록 위로 이동해 `version` 설정에서도 참조 가능하게 정리
- 컨벤션 플러그인 한 곳 수정으로 모든 모듈에 일괄 반영

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
런타임 동작 변경 없음 (빌드 인프라 정리).

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 기존엔 ktlint 버전이 명목상으로만 통일돼 있었음. `libs.versions.toml`(`ktlint = "1.8.0"`) 과 CI workflow(`ktlint_version: "1.8.0"`) 는 통일이지만, 로컬 gradle 의 `org.jlleitschuh.gradle.ktlint` 14.2.0 은 `KtlintExtension.version` 미지정으로 ktlint-gradle 의 default ktlint 버전을 사용 중. ktlint 1.6+ 부터 standard 로 승격된 룰들(`when-entry-bracing`, `blank-line-between-when-conditions` 등) 이 로컬 `ktlintCheck` 에선 안 잡히고 PR 단계의 reviewdog 에서야 처음 검출돼 매번 추가 commit 이 필요한 상태였음 (#127 참고).
- 이 PR 머지 후 pre-commit hook 의 `ktlintCheck` 가 CI 와 동일 룰셋(1.8.0)으로 검사 → PR 올리기 전 로컬에서 모두 잡힘
- 향후 ktlint 업그레이드 시 `libs.versions.toml` + `lint.yml` 두 곳만 같이 올리면 됨
- 검증: `./gradlew --stop && ./gradlew ktlintCheck` BUILD SUCCESSFUL (develop 코드 기준)