### PR TITLE
chore(workflow): PR 생성 시 Copilot Code Review 자동 요청 step 추가

### DIFF
--- a/.github/workflows/PRassign.yml
+++ b/.github/workflows/PRassign.yml
@@ -16,3 +16,52 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: ${{ github.actor }}
           reviewers: 1hyok, koongmai, Sadturtleman
+
+      # GitHub Copilot Code Review 봇은 collaborator 가 아니라
+      # REST `POST /pulls/{n}/requested_reviewers` 가 422 로 막힌다.
+      # GraphQL `suggestedActors` 로 봇 ID 를 동적 조회한 뒤
+      # `requestReviews` mutation 으로 요청한다.
+      # organization 에서 Copilot Code Review 가 활성화돼야 봇 ID 가 노출된다.
+      - name: Request Copilot Code Review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          PR_NODE_ID: ${{ github.event.pull_request.node_id }}
+        run: |
+          set -euo pipefail
+
+          BOT_ID=$(gh api graphql \
+            -F owner="$OWNER" \
+            -F name="$REPO_NAME" \
+            -f query='
+              query($owner: String!, $name: String!) {
+                repository(owner: $owner, name: $name) {
+                  suggestedActors(capabilities: [CAN_BE_ASSIGNED], first: 100) {
+                    nodes {
+                      __typename
+                      ... on Bot { id login }
+                      ... on User { id login }
+                    }
+                  }
+                }
+              }' \
+            --jq '.data.repository.suggestedActors.nodes[]
+                  | select(.__typename == "Bot" and (.login | ascii_downcase | contains("copilot")))
+                  | .id' | head -n1)
+
+          if [ -z "$BOT_ID" ]; then
+            echo "::warning::Copilot reviewer not exposed in suggestedActors. organization 설정에서 Copilot Code Review 활성화 여부 확인 필요."
+            exit 0
+          fi
+
+          echo "Requesting Copilot review (bot id: $BOT_ID)"
+          gh api graphql \
+            -F prId="$PR_NODE_ID" \
+            -F botId="$BOT_ID" \
+            -f query='
+              mutation($prId: ID!, $botId: ID!) {
+                requestReviews(input: { pullRequestId: $prId, userIds: [$botId] }) {
+                  pullRequest { id }
+                }
+              }'


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #131

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `.github/workflows/PRassign.yml` 에 `Request Copilot Code Review` step 추가
- GraphQL `suggestedActors` 로 Copilot 봇 ID 동적 조회 후 `requestReviews` mutation 으로 요청
- 봇이 노출되지 않으면(`organization` 미활성 등) `::warning::` 로그만 남기고 워크플로 자체는 통과

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
워크플로 변경. 본 PR 자체가 첫 동작 검증 — assign job 의 `Request Copilot Code Review` step 로그를 확인하면 봇이 정상 추가됐는지 알 수 있다.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 동기: PR #127, #130 작업 중 `gh api ... requested_reviewers` 로 Copilot 추가 시도 시 `Reviews may only be requested from collaborators` (422) 응답을 받았음. REST 는 collaborator 만 받지만 GraphQL `requestReviews` 는 Bot 도 `userIds` 로 허용하므로 우회 가능
- 기존 `hkusu/review-assign-action@v1` step 은 그대로 두고 Copilot 만 별도 step 으로 분리. 사람 reviewer 자동 할당 동작은 변경 없음
- 머지 후 새 PR 부터 Copilot 이 자동 reviewer 로 등록되어야 한다. 만약 워크플로 로그에 `Copilot reviewer not exposed in suggestedActors` 경고가 뜨면 organization Settings 의 Copilot Code Review 활성화 여부 확인 필요
- #127, #130 는 본 워크플로 머지 전 생성된 PR 이라 자동 추가가 적용되지 않음. 두 PR 은 GitHub UI 에서 수동 추가 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)