### PR TITLE
feat: 사용자 이름 캐싱으로 홈 placeholder 즉시 노출

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/screen/HomeTabScreen.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/HomeTabScreen.kt
@@ -38,7 +38,13 @@ import com.afternote.feature.mindrecord.presentation.hometab.homeTabMindRecordMe
 import com.afternote.feature.mindrecord.presentation.hometab.homeTabMindRecordQuestionAndCategories
 
 sealed interface HomeTabUiState {
-    data object Loading : HomeTabUiState
+    /**
+     * @property cachedUserName 마지막 성공 응답에서 디스크 캐시된 이름. 콜드스타트 시 GET /users/me
+     * 응답이 도착하기 전 placeholder로 즉시 노출하기 위해 사용한다. 신규 로그인 등 캐시가 없으면 null.
+     */
+    data class Loading(
+        val cachedUserName: String? = null,
+    ) : HomeTabUiState
 
     @Immutable
     data class Success(
@@ -102,7 +108,7 @@ private object HomeTabActionsNoop : HomeTabActions {
 @Composable
 fun HomeTabScreen(
     modifier: Modifier = Modifier,
-    uiState: HomeTabUiState = HomeTabUiState.Loading,
+    uiState: HomeTabUiState = HomeTabUiState.Loading(),
     actions: HomeTabActions = HomeTabActionsNoop,
 ) {
     Scaffold(
@@ -114,7 +120,7 @@ fun HomeTabScreen(
             is HomeTabUiState.Loading -> {
                 HomeTabScrollContent(
                     paddingValues = paddingValues,
-                    userName = "\u2026",
+                    userName = uiState.cachedUserName ?: "\u2026",
                     isRecipientDesignated = false,
                     categoryCounts = MindRecordCategory.entries.associateWith { 0 },
                     categoryCountsLoading = true,

--- a/app/src/main/java/com/afternote/afternote_fe/screen/HomeTabViewModel.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/HomeTabViewModel.kt
@@ -3,6 +3,7 @@ package com.afternote.afternote_fe.screen
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.afternote.afternote_fe.usecase.GetHomeSummaryUseCase
+import com.afternote.core.domain.repository.UserRepository
 import com.afternote.core.model.HomeSummary
 import com.afternote.core.model.MindRecordCategory
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -18,8 +19,9 @@ class HomeTabViewModel
     @Inject
     constructor(
         private val getHomeSummary: GetHomeSummaryUseCase,
+        private val userRepository: UserRepository,
     ) : ViewModel() {
-        private val _uiState = MutableStateFlow<HomeTabUiState>(HomeTabUiState.Loading)
+        private val _uiState = MutableStateFlow<HomeTabUiState>(HomeTabUiState.Loading())
         val uiState: StateFlow<HomeTabUiState> = _uiState.asStateFlow()
 
         /** 진행 중인 API 요청. 상태 대신 Job으로 가드하여 초기 Loading 딜레마를 회피한다. */
@@ -46,8 +48,9 @@ class HomeTabViewModel
                         // 새로고침: 기존 화면을 유지하고 상단 스피너만 표시한다.
                         _uiState.value = currentState.copy(isRefreshing = true)
                     } else {
-                        // 초기 진입 또는 에러 재시도: 전체 로딩 화면을 표시한다.
-                        _uiState.value = HomeTabUiState.Loading
+                        // 초기 진입 또는 에러 재시도: 캐시된 이름이 있으면 placeholder로 즉시 노출한다.
+                        _uiState.value =
+                            HomeTabUiState.Loading(cachedUserName = userRepository.getCachedUserName())
                     }
 
                     getHomeSummary()

--- a/core/data/src/main/java/com/afternote/core/data/repoimpl/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/afternote/core/data/repoimpl/UserRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.afternote.core.data.repoimpl
 
 import android.util.Log
 import com.afternote.core.data.mapper.user.UserMapper
+import com.afternote.core.datastore.UserProfileDataSource
 import com.afternote.core.domain.repository.UserRepository
 import com.afternote.core.model.ReceiverDailyQuestionsResult
 import com.afternote.core.model.ReceiverMindRecordsResult
@@ -25,6 +26,7 @@ class UserRepositoryImpl
     @Inject
     constructor(
         private val api: UserApiService,
+        private val profileCache: UserProfileDataSource,
     ) : UserRepository {
         override suspend fun getMyProfile(): Result<UserProfileModel> =
             runCatching {
@@ -40,8 +42,15 @@ class UserRepositoryImpl
                     TAG,
                     "getMyProfile: mapped profile name='${profile.name}' email='${profile.email}'",
                 )
+                profileCache.saveUserName(profile.name)
                 profile
             }
+
+        override suspend fun getCachedUserName(): String? = profileCache.getCachedUserName()
+
+        override suspend fun clearCachedProfile() {
+            profileCache.clear()
+        }
 
         override suspend fun updateMyProfile(
             name: String?,
@@ -60,7 +69,9 @@ class UserRepositoryImpl
                             ),
                     )
                 Log.d(TAG, "updateMyProfile: response=$response")
-                UserMapper.toUserProfile(response.requireData())
+                val profile = UserMapper.toUserProfile(response.requireData())
+                profileCache.saveUserName(profile.name)
+                profile
             }
 
         override suspend fun withdrawAccount(): Result<Unit> =
@@ -68,6 +79,7 @@ class UserRepositoryImpl
                 Log.d(TAG, "withdrawAccount: request")
                 val response = api.withdrawAccount()
                 response.requireStatus()
+                profileCache.clear()
                 Log.d(TAG, "withdrawAccount: success")
             }
 

--- a/core/datastore/src/main/java/com/afternote/core/datastore/UserProfileDataSource.kt
+++ b/core/datastore/src/main/java/com/afternote/core/datastore/UserProfileDataSource.kt
@@ -1,0 +1,55 @@
+package com.afternote.core.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.afternote.core.datastore.di.UserProfileDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * 사용자 프로필 캐시 로컬 저장소. 현재는 이름 한 필드만 보관한다.
+ * 홈 진입 시 GET /users/me 응답이 도착하기 전 placeholder로 즉시 노출하기 위함이다.
+ *
+ * 읽기 스트림은 [IOException] 시 [emptyPreferences]로 복구한다.
+ */
+@Singleton
+class UserProfileDataSource
+    @Inject
+    constructor(
+        @param:UserProfileDataStore private val dataStore: DataStore<Preferences>,
+    ) {
+        private object Keys {
+            val USER_NAME = stringPreferencesKey("user_name")
+        }
+
+        private val preferencesFlow: Flow<Preferences> =
+            dataStore.data
+                .catch { exception ->
+                    if (exception is IOException) {
+                        emit(emptyPreferences())
+                    } else {
+                        throw exception
+                    }
+                }
+
+        suspend fun getCachedUserName(): String? = preferencesFlow.first()[Keys.USER_NAME]
+
+        suspend fun saveUserName(name: String) {
+            dataStore.edit { prefs ->
+                prefs[Keys.USER_NAME] = name
+            }
+        }
+
+        suspend fun clear() {
+            dataStore.edit { prefs ->
+                prefs.clear()
+            }
+        }
+    }

--- a/core/datastore/src/main/java/com/afternote/core/datastore/UserProfilePreferencesDataStore.kt
+++ b/core/datastore/src/main/java/com/afternote/core/datastore/UserProfilePreferencesDataStore.kt
@@ -1,0 +1,19 @@
+package com.afternote.core.datastore
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+/**
+ * 사용자 프로필 캐시용 Preferences DataStore.
+ *
+ * 프로필 정보(이름 등)는 거의 변하지 않으므로, 콜드스타트 시 GET /users/me RTT(약 1.3초)를
+ * 기다리지 않고 즉시 표시할 수 있도록 마지막 응답을 디스크에 보관한다.
+ *
+ * [com.afternote.core.datastore.UserProfileDataSource]와
+ * [com.afternote.core.datastore.di.UserProfileDataStoreModule]에서 동일 인스턴스를 참조한다.
+ */
+internal val Context.userProfilePreferencesDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "UserProfile",
+)

--- a/core/datastore/src/main/java/com/afternote/core/datastore/di/UserProfileDataStore.kt
+++ b/core/datastore/src/main/java/com/afternote/core/datastore/di/UserProfileDataStore.kt
@@ -1,0 +1,8 @@
+package com.afternote.core.datastore.di
+
+import javax.inject.Qualifier
+
+/** Hilt 한정자: 사용자 프로필 캐시 전용 [androidx.datastore.core.DataStore] 바인딩. */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class UserProfileDataStore

--- a/core/datastore/src/main/java/com/afternote/core/datastore/di/UserProfileDataStoreModule.kt
+++ b/core/datastore/src/main/java/com/afternote/core/datastore/di/UserProfileDataStoreModule.kt
@@ -1,0 +1,23 @@
+package com.afternote.core.datastore.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import com.afternote.core.datastore.userProfilePreferencesDataStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object UserProfileDataStoreModule {
+    @Provides
+    @Singleton
+    @UserProfileDataStore
+    fun provideUserProfileDataStore(
+        @ApplicationContext context: Context,
+    ): DataStore<Preferences> = context.userProfilePreferencesDataStore
+}

--- a/core/domain/src/main/java/com/afternote/core/domain/repository/UserRepository.kt
+++ b/core/domain/src/main/java/com/afternote/core/domain/repository/UserRepository.kt
@@ -13,6 +13,15 @@ import com.afternote.core.model.user.UserProfileModel
 interface UserRepository {
     suspend fun getMyProfile(): Result<UserProfileModel>
 
+    /**
+     * 마지막으로 성공한 [getMyProfile]/[updateMyProfile]에서 캐싱한 사용자 이름을 즉시 반환한다.
+     * 홈 콜드스타트 placeholder 용도이며, 캐시 미존재 또는 읽기 실패 시 null.
+     */
+    suspend fun getCachedUserName(): String?
+
+    /** 로그아웃·회원 탈퇴 시 호출해 사용자 프로필 캐시를 비운다. */
+    suspend fun clearCachedProfile()
+
     suspend fun updateMyProfile(
         name: String?,
         phone: String?,

--- a/feature/setting/presentation/src/main/kotlin/com/afternote/feature/setting/presentation/viewmodel/SettingViewModel.kt
+++ b/feature/setting/presentation/src/main/kotlin/com/afternote/feature/setting/presentation/viewmodel/SettingViewModel.kt
@@ -66,6 +66,7 @@ class SettingViewModel
             viewModelScope.launch {
                 runCatching { authRepository.logout() }
                 authRepository.clearSession()
+                userRepository.clearCachedProfile()
                 _logoutCompleted.value = true
             }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,8 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
-org.gradle.caching=true
+# Studio/JDK 업데이트나 빌드 중 OOM 등으로 input 해시는 같지만 산출물이 손상된 cache
+# 엔트리가 hit되는 사례가 있어 비활성화. UP-TO-DATE 체크와 kotlin.incremental은
+# 그대로라 일반 증분 빌드 속도는 동일하다.
+org.gradle.caching=false
 kotlin.incremental=true


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #136

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `:core:datastore` 에 `UserProfileDataStore` / `UserProfileDataSource` / Hilt module 추가 (기존 `TokenDataStore` 패턴 준수)
- `UserRepository.getCachedUserName()` / `clearCachedProfile()` 추가, `getMyProfile`·`updateMyProfile` 성공 시 자동 write-through, `withdrawAccount` 시 캐시 클리어
- `SettingViewModel.logout()` 에서 토큰 클리어 직후 프로필 캐시도 클리어 (다른 계정 로그인 시 직전 사용자 이름 노출 방지)
- `HomeTabUiState.Loading` 을 `data class Loading(val cachedUserName: String? = null)` 로 변경, `HomeTabViewModel` 이 Loading 발행 시 캐시값을 placeholder 로 즉시 노출
- 별도 commit (`ac04ff29`): `gradle.properties` 의 `org.gradle.caching=false`. Studio/JDK 업데이트나 빌드 OOM 으로 cache 산출물이 손상된 채 hit 되는 사례 재발 방지. UP-TO-DATE 체크와 `kotlin.incremental` 은 그대로라 일반 증분 빌드 속도는 동일

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
N/A — 콜드스타트 인사 텍스트의 `…` placeholder 시간이 단축되는 미세 변화. 캐시 hit(앱 강제종료 후 재실행) 시 이름 즉시 노출 디바이스 확인.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- **베이스 브랜치**: `feat/133`. 변경 파일 5개 중 4개(`UserRepository` / `UserRepositoryImpl` / `HomeTabViewModel` / `SettingViewModel`)가 #133 에서 이미 손댄 파일이라 develop 베이스로 분리 시 충돌. #134(`feat/133` 의 PR) 머지 후 본 PR 머지 권장
- **측정 결과 정정**: 본 작업의 출발 진단이었던 "서버 RTT ~1.35s" 는 디버깅 도중 발견된 **macOS 호스트 DNS 문제**(첫 nameserver `202.30.38.101` 가 recursion 거부 → fallback timeout)가 정체였음. DNS 정상화 후 실측 RTT 는 25-60ms. 즉 평상 시 본 패치 체감 효과는 작고, **모바일 데이터 / 해외 / 오프라인 / 서버 부하** 케이스에 의미 있음
- **build cache 비활성화 commit 동봉 이유**: 이번 작업 도중 빌드 OOM 직후 `mergeProjectDexDebug` 의 깨진 산출물이 build cache 에 박혀 `MainActivity` 가 dex 에서 누락된 APK 가 **일관되게** 생성되는 버그를 만남. `--no-build-cache` 로 우회 후 영구 비활성화. 자세한 영향 분석은 해당 commit 메시지 참고
- **검증**: `./gradlew :app:assembleDebug` 통과. 디바이스 — (1) 콜드스타트 재진입 시 이름 즉시 노출, (2) 로그아웃 → 재로그인 시 캐시 의도대로 비워져 placeholder 잠깐 노출 후 새 응답으로 갱신
- **후속 검토 사항**: 측정 정정 결과 본 작업이 over-engineering 일 여지가 있음. 같은 화면의 다른 슬라이스(receiver / 카운트)는 여전히 "Loading vs Success" 이분법이라 hybrid 형태이고, RTT 25ms 기준이면 캐싱 도입 전후 사용자 체감이 거의 동일. 통일된 디자인은 별도 리팩토링 사안이지만, 환경 변동(모바일/오프라인) 대비 보험 가치는 있다고 판단하여 유지