### PR TITLE
fix(onboarding): 회원가입 검증·피드백 누락 3건 + IME 우회 차단

### DIFF
--- a/core/ui/src/main/kotlin/com/afternote/core/ui/TextFieldShort.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/TextFieldShort.kt
@@ -154,6 +154,7 @@ sealed interface TextFieldType {
     data class Variant7(
         val text: String = "인증번호 받기",
         val onClick: () -> Unit,
+        val enabled: Boolean = true,
     ) : TextFieldType
 
     // Variant8: 하이픈 + 뒷자리 첫 숫자(실제 [BasicTextField]) + 마스킹 점.
@@ -233,9 +234,19 @@ private fun SearchIcon() {
 private fun Variant7Suffix(type: TextFieldType.Variant7) {
     Text(
         text = type.text,
-        modifier = Modifier.clickable(onClick = type.onClick),
+        modifier =
+            if (type.enabled) {
+                Modifier.clickable(onClick = type.onClick)
+            } else {
+                Modifier
+            },
         style = AfternoteDesign.typography.captionLargeR,
-        color = AfternoteDesign.colors.gray7,
+        color =
+            if (type.enabled) {
+                AfternoteDesign.colors.gray7
+            } else {
+                AfternoteDesign.colors.gray4
+            },
     )
 }
 

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/OnboardingProfileEntry.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/OnboardingProfileEntry.kt
@@ -1,12 +1,17 @@
 package com.afternote.feature.onboarding.presentation
 
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.ObserveAsEvents
 import com.afternote.feature.onboarding.presentation.signup.SignUpEvent
 import com.afternote.feature.onboarding.presentation.signup.SignUpViewModel
+import kotlinx.coroutines.launch
 
 /**
  * 프로필 설정 Entry.
@@ -21,6 +26,8 @@ fun OnboardingProfileEntry(
     modifier: Modifier = Modifier,
 ) {
     val profileImageUri by viewModel.profileImageUri.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
 
     ObserveAsEvents(viewModel.eventFlow) { event ->
         when (event) {
@@ -29,7 +36,12 @@ fun OnboardingProfileEntry(
             }
 
             is SignUpEvent.ShowError -> {
-                // TODO: 스낵바 또는 토스트로 에러 표시
+                coroutineScope.launch {
+                    snackbarHostState.showSnackbar(
+                        message = event.message,
+                        duration = SnackbarDuration.Short,
+                    )
+                }
             }
         }
     }
@@ -37,6 +49,7 @@ fun OnboardingProfileEntry(
     OnboardingProfileScreen(
         nameState = viewModel.nameState,
         displayImageUri = profileImageUri,
+        snackbarHostState = snackbarHostState,
         onProfileImagePick = viewModel::onProfileImagePicked,
         onCompleteClick = viewModel::submitSignUp,
         onBackClick = onBackClick,

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/OnboardingProfileScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/OnboardingProfileScreen.kt
@@ -19,8 +19,11 @@ import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -44,6 +47,7 @@ import com.afternote.core.ui.topbar.DetailTopBar
 fun OnboardingProfileScreen(
     nameState: TextFieldState,
     displayImageUri: Uri?,
+    snackbarHostState: SnackbarHostState,
     onProfileImagePick: (Uri?) -> Unit,
     onBackClick: () -> Unit,
     onCompleteClick: () -> Unit,
@@ -68,6 +72,7 @@ fun OnboardingProfileScreen(
                 },
             )
         },
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
         containerColor = Color.Transparent,
     ) { innerPadding ->
         Column(
@@ -113,13 +118,18 @@ fun OnboardingProfileScreen(
                     },
                 )
 
+                val isNameProvided =
+                    nameState.text
+                        .toString()
+                        .trim()
+                        .isNotEmpty()
                 AfternoteButton(
                     text = stringResource(R.string.profile_complete),
                     onClick = {
                         focusManager.clearFocus()
                         onCompleteClick()
                     },
-                    type = AfternoteButtonType.Default,
+                    type = if (isNameProvided) AfternoteButtonType.Default else AfternoteButtonType.Un,
                 )
             }
         }
@@ -133,6 +143,7 @@ private fun OnboardingProfileScreenPreview() {
         OnboardingProfileScreen(
             nameState = rememberTextFieldState("Afternote"),
             displayImageUri = null,
+            snackbarHostState = remember { SnackbarHostState() },
             onProfileImagePick = {},
             onBackClick = {},
             onCompleteClick = {},

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
@@ -56,6 +56,8 @@ fun NavGraphBuilder.onboardingNavGraph(
                 emailState = signUpViewModel.emailState,
                 verificationCodeState = signUpViewModel.verificationCodeState,
                 isVerificationSent = signUpViewModel.isVerificationSent,
+                isSendingCode = signUpViewModel.isSendingCode,
+                isNextEnabled = signUpViewModel.isStep1NextEnabled,
                 onRequestVerification = signUpViewModel::requestVerification,
                 onNextClick = actions::onSignUpEmailNext,
                 onBackClick = actions::onSignUpEmailBack,
@@ -69,6 +71,7 @@ fun NavGraphBuilder.onboardingNavGraph(
             SignUpResidentNumberScreen(
                 frontNumberState = signUpViewModel.frontNumberState,
                 backNumberState = signUpViewModel.backNumberState,
+                isNextEnabled = signUpViewModel.isStep2NextEnabled,
                 onNextClick = actions::onSignUpResidentNext,
                 onBackClick = actions::onSignUpResidentBack,
             )
@@ -81,6 +84,8 @@ fun NavGraphBuilder.onboardingNavGraph(
             SignUpPasswordScreen(
                 passwordState = signUpViewModel.signUpPasswordState,
                 passwordConfirmState = signUpViewModel.signUpPasswordConfirmState,
+                isPasswordRuleSatisfied = signUpViewModel.isPasswordRuleSatisfied,
+                isNextEnabled = signUpViewModel.isStep3NextEnabled,
                 onNextClick = actions::onSignUpPasswordNext,
                 onBackClick = actions::onSignUpPasswordBack,
             )
@@ -92,6 +97,7 @@ fun NavGraphBuilder.onboardingNavGraph(
 
             OnboardingTermsScreen(
                 termsState = signUpViewModel.termsState,
+                isNextEnabled = signUpViewModel.isStep4NextEnabled,
                 onTermsToggle = signUpViewModel::toggleTermsAgreed,
                 onPrivacyToggle = signUpViewModel::togglePrivacyAgreed,
                 onMarketingToggle = signUpViewModel::toggleMarketingAgreed,

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpPasswordScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpPasswordScreen.kt
@@ -34,6 +34,8 @@ import com.afternote.feature.onboarding.presentation.signup.scaffold.ProgressBar
 fun SignUpPasswordScreen(
     passwordState: TextFieldState,
     passwordConfirmState: TextFieldState,
+    isPasswordRuleSatisfied: Boolean,
+    isNextEnabled: Boolean,
     onNextClick: () -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -45,6 +47,7 @@ fun SignUpPasswordScreen(
         onBackClick = onBackClick,
         onNextClick = onNextClick,
         modifier = modifier,
+        isNextEnabled = isNextEnabled,
         content = {
             Column(
                 modifier =
@@ -87,6 +90,7 @@ fun SignUpPasswordScreen(
                 // 안내 문구
                 PasswordRuleItem(
                     text = stringResource(R.string.signup_password_rule_combination),
+                    isSatisfied = isPasswordRuleSatisfied,
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 PasswordRuleItem(
@@ -101,7 +105,14 @@ fun SignUpPasswordScreen(
 private fun PasswordRuleItem(
     text: String,
     modifier: Modifier = Modifier,
+    isSatisfied: Boolean? = null,
 ) {
+    val color =
+        if (isSatisfied == false) {
+            AfternoteDesign.colors.gray5
+        } else {
+            AfternoteDesign.colors.b1
+        }
     Row(
         modifier =
             modifier
@@ -113,15 +124,13 @@ private fun PasswordRuleItem(
         Text(
             text = "\u2022",
             modifier = Modifier.clearAndSetSemantics {},
-            style =
-                AfternoteDesign.typography.captionLargeB,
-            color = AfternoteDesign.colors.b1,
+            style = AfternoteDesign.typography.captionLargeB,
+            color = color,
         )
         Text(
             text = text,
-            style =
-                AfternoteDesign.typography.captionLargeB,
-            color = AfternoteDesign.colors.b1,
+            style = AfternoteDesign.typography.captionLargeB,
+            color = color,
         )
     }
 }
@@ -133,6 +142,8 @@ private fun SignUpPasswordScreenPreview() {
         SignUpPasswordScreen(
             passwordState = rememberTextFieldState(),
             passwordConfirmState = rememberTextFieldState(),
+            isPasswordRuleSatisfied = false,
+            isNextEnabled = false,
             onNextClick = {},
             onBackClick = {},
         )

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpPasswordScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpPasswordScreen.kt
@@ -81,7 +81,7 @@ fun SignUpPasswordScreen(
                     imeAction = ImeAction.Done,
                     onImeAction = {
                         focusManager.clearFocus()
-                        onNextClick()
+                        if (isNextEnabled) onNextClick()
                     },
                 )
 

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpResidentNumberScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpResidentNumberScreen.kt
@@ -83,7 +83,7 @@ fun SignUpResidentNumberScreen(
                         ),
                     placeholder = stringResource(R.string.signup_resident_number_placeholder),
                     keyboardType = KeyboardType.Number,
-                    onImeAction = onNextClick,
+                    onImeAction = { if (isNextEnabled) onNextClick() },
                 )
             }
         },

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpResidentNumberScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpResidentNumberScreen.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.filter
 fun SignUpResidentNumberScreen(
     frontNumberState: TextFieldState,
     backNumberState: TextFieldState,
+    isNextEnabled: Boolean,
     onNextClick: () -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -55,6 +56,7 @@ fun SignUpResidentNumberScreen(
         onBackClick = onBackClick,
         onNextClick = onNextClick,
         modifier = modifier,
+        isNextEnabled = isNextEnabled,
         content = {
             Column(
                 modifier =
@@ -95,6 +97,7 @@ private fun SignUpResidentNumberScreenPreview() {
         SignUpResidentNumberScreen(
             frontNumberState = rememberTextFieldState(),
             backNumberState = rememberTextFieldState(),
+            isNextEnabled = false,
             onNextClick = {},
             onBackClick = {},
         )

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpScreen.kt
@@ -28,16 +28,28 @@ fun SignUpScreen(
     emailState: TextFieldState,
     verificationCodeState: TextFieldState,
     isVerificationSent: Boolean,
+    isSendingCode: Boolean,
+    isNextEnabled: Boolean,
     onRequestVerification: () -> Unit,
     onNextClick: () -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val isEmailNotBlank = emailState.text.isNotBlank()
+    val verificationButtonText =
+        when {
+            isSendingCode -> stringResource(R.string.signup_verification_requesting)
+            isVerificationSent -> stringResource(R.string.signup_verification_resend)
+            else -> stringResource(R.string.signup_verification_request)
+        }
+    val isVerificationButtonEnabled = !isSendingCode && isEmailNotBlank
+
     ProgressBarScaffold(
         currentStep = 1,
         onBackClick = onBackClick,
         onNextClick = onNextClick,
         modifier = modifier,
+        isNextEnabled = isNextEnabled,
         content = {
             Column(
                 modifier =
@@ -49,7 +61,12 @@ fun SignUpScreen(
             ) {
                 // 이메일 입력 + 인증번호 받기
                 AfternoteTextField(
-                    type = TextFieldType.Variant7(onClick = onRequestVerification),
+                    type =
+                        TextFieldType.Variant7(
+                            text = verificationButtonText,
+                            onClick = onRequestVerification,
+                            enabled = isVerificationButtonEnabled,
+                        ),
                     state = emailState,
                     placeholder = stringResource(R.string.signup_email_placeholder),
                     keyboardType = KeyboardType.Email,
@@ -88,6 +105,8 @@ private fun SignUpScreenPreview() {
             emailState = rememberTextFieldState(),
             verificationCodeState = rememberTextFieldState(),
             isVerificationSent = true,
+            isSendingCode = false,
+            isNextEnabled = false,
             onRequestVerification = {},
             onNextClick = {},
             onBackClick = {},

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpScreen.kt
@@ -80,7 +80,7 @@ fun SignUpScreen(
                     keyboardType = KeyboardType.Number,
                     imeAction = ImeAction.Done,
                     onImeAction = {
-                        onNextClick()
+                        if (isNextEnabled) onNextClick()
                     },
                 )
 

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
@@ -1,6 +1,7 @@
 package com.afternote.feature.onboarding.presentation.signup
 
 import android.net.Uri
+import android.util.Log
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -40,6 +41,10 @@ class SignUpViewModel
             const val RESIDENT_REGISTRATION_BACK_FIRST_DIGIT_COUNT = 1
 
             private const val MIN_VERIFICATION_CODE_LENGTH = 6
+
+            /** 8~16자, 영문 대소문자 + 숫자 + 특수문자 각 1개 이상. */
+            private val PASSWORD_REGEX =
+                Regex("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{8,16}$")
         }
 
         private val eventChannel = Channel<SignUpEvent>(Channel.BUFFERED)
@@ -49,6 +54,10 @@ class SignUpViewModel
         val emailState = TextFieldState()
         val verificationCodeState = TextFieldState()
         var isVerificationSent by mutableStateOf(false)
+            private set
+
+        /** 인증번호 전송 요청 진행 중. 버튼 중복 클릭 방지 + 로딩 텍스트 토글에 사용. */
+        var isSendingCode by mutableStateOf(false)
             private set
 
         // Step 2: 주민등록번호
@@ -65,6 +74,14 @@ class SignUpViewModel
 
         // Profile
         val nameState = TextFieldState()
+
+        init {
+            // TODO(fix/141): 이름 빈값 전송 재현 후 제거.
+            Log.d(
+                "SignUp/debug",
+                "VM created: vm=${System.identityHashCode(this)}, nameState=${System.identityHashCode(nameState)}",
+            )
+        }
 
         private val _profileImageUri = MutableStateFlow<Uri?>(null)
         val profileImageUri: StateFlow<Uri?> = _profileImageUri.asStateFlow()
@@ -89,9 +106,14 @@ class SignUpViewModel
                 backNumberState.text.length == RESIDENT_REGISTRATION_BACK_FIRST_DIGIT_COUNT
         }
 
-        /** Step 3 — 서비스 비밀번호 설정(확인 일치) */
+        /** 비밀번호 정규식 충족 여부. 안내 문구 색상 토글에도 사용. */
+        val isPasswordRuleSatisfied by derivedStateOf {
+            PASSWORD_REGEX.matches(signUpPasswordState.text.toString())
+        }
+
+        /** Step 3 — 비밀번호 규칙 충족 + 확인 일치 */
         val isStep3NextEnabled by derivedStateOf {
-            signUpPasswordState.text.isNotEmpty() &&
+            isPasswordRuleSatisfied &&
                 signUpPasswordState.text.toString() == signUpPasswordConfirmState.text.toString()
         }
 
@@ -101,7 +123,9 @@ class SignUpViewModel
         }
 
         fun requestVerification() {
+            if (isSendingCode) return
             viewModelScope.launch {
+                isSendingCode = true
                 accountRepository
                     .sendEmailCode(emailState.text.toString())
                     .onSuccess { isVerificationSent = true }
@@ -110,11 +134,8 @@ class SignUpViewModel
                             SignUpEvent.ShowError(error.message ?: "인증번호 요청 실패"),
                         )
                     }
+                isSendingCode = false
             }
-        }
-
-        fun updateTermsState(newState: TermsState) {
-            termsState = newState
         }
 
         fun toggleTermsAgreed(agreed: Boolean) {
@@ -146,12 +167,27 @@ class SignUpViewModel
             viewModelScope.launch {
                 if (isLoading) return@launch
 
+                val rawName = nameState.text.toString()
+                // TODO(fix/141): 이름 빈값 전송 재현 후 제거.
+                Log.d(
+                    "SignUp/debug",
+                    "submitSignUp: vm=${System.identityHashCode(this@SignUpViewModel)}, " +
+                        "nameState=${System.identityHashCode(nameState)}, " +
+                        "text='$rawName', length=${rawName.length}",
+                )
+
+                val name = rawName.trim()
+                if (name.isEmpty()) {
+                    eventChannel.send(SignUpEvent.ShowError("이름을 입력해주세요"))
+                    return@launch
+                }
+
                 isLoading = true
                 accountRepository
                     .signUp(
                         email = emailState.text.toString(),
                         password = signUpPasswordState.text.toString(),
-                        name = nameState.text.toString(),
+                        name = name,
                         profileUrl = _profileImageUri.value?.toString(),
                     ).onSuccess {
                         eventChannel.send(SignUpEvent.SignUpSuccess)

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/scaffold/OnboardingScaffold.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/scaffold/OnboardingScaffold.kt
@@ -27,6 +27,7 @@ fun OnboardingScaffold(
     onBackClick: () -> Unit,
     onActionButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isActionEnabled: Boolean = true,
     content: @Composable () -> Unit, // 내부 콘텐츠 슬롯
 ) {
     val focusManager = LocalFocusManager.current
@@ -56,7 +57,7 @@ fun OnboardingScaffold(
                     focusManager.clearFocus()
                     onActionButtonClick()
                 },
-                type = AfternoteButtonType.Default,
+                type = if (isActionEnabled) AfternoteButtonType.Default else AfternoteButtonType.Un,
                 modifier =
                     Modifier
                         .padding(horizontal = horizontalPadding)

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/scaffold/ProgressBarScaffold.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/scaffold/ProgressBarScaffold.kt
@@ -19,6 +19,7 @@ internal fun ProgressBarScaffold(
     onBackClick: () -> Unit,
     onNextClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isNextEnabled: Boolean = true,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     OnboardingScaffold(
@@ -26,6 +27,7 @@ internal fun ProgressBarScaffold(
         onBackClick = onBackClick,
         onActionButtonClick = onNextClick,
         modifier = modifier,
+        isActionEnabled = isNextEnabled,
     ) {
         Column(
             modifier =

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/terms/OnboardingTermsScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/terms/OnboardingTermsScreen.kt
@@ -53,6 +53,7 @@ data class TermsState(
 @Composable
 fun OnboardingTermsScreen(
     termsState: TermsState,
+    isNextEnabled: Boolean,
     onTermsToggle: (Boolean) -> Unit,
     onPrivacyToggle: (Boolean) -> Unit,
     onMarketingToggle: (Boolean) -> Unit,
@@ -67,7 +68,8 @@ fun OnboardingTermsScreen(
         onBackClick = onBackClick,
         onNextClick = onNextClick,
         modifier = modifier,
-        {
+        isNextEnabled = isNextEnabled,
+        content = {
             Spacer(modifier = Modifier.height(32.dp))
 
             // 로고
@@ -224,6 +226,7 @@ private fun OnboardingTermsScreenPreview() {
     AfternoteTheme {
         OnboardingTermsScreen(
             termsState = state,
+            isNextEnabled = state.isTermsAgreed && state.isPrivacyAgreed,
             onTermsToggle = { state = state.copy(isTermsAgreed = it) },
             onPrivacyToggle = { state = state.copy(isPrivacyAgreed = it) },
             onMarketingToggle = { state = state.copy(isMarketingAgreed = it) },

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/terms/TermsDetailScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/terms/TermsDetailScreen.kt
@@ -30,7 +30,7 @@ fun TermsDetailScreen(
         onBackClick = onBackClick,
         onActionButtonClick = onNextClick,
         modifier = modifier,
-        {
+        content = {
             val scrollState = rememberScrollState()
 
             Column(

--- a/feature/onboarding/presentation/src/main/res/values/strings.xml
+++ b/feature/onboarding/presentation/src/main/res/values/strings.xml
@@ -26,6 +26,9 @@
     <string name="signup_password_placeholder">비밀번호</string>
     <string name="signup_verification_code_placeholder">인증번호</string>
     <string name="signup_verification_sent">인증번호가 전송되었습니다.\n수신 된 인증번호를 입력해 주세요.</string>
+    <string name="signup_verification_request">인증번호 받기</string>
+    <string name="signup_verification_requesting">전송 중…</string>
+    <string name="signup_verification_resend">재전송</string>
     <string name="signup_next">다음</string>
     <string name="signup_resident_number_label">주민등록번호</string>
     <string name="signup_resident_number_placeholder">주민등록번호</string>


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed fix: 간편 회원가입 검증·피드백 누락 (인증번호 로딩 / 비밀번호 정규식 / 이름 빈값) #141

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- 인증번호 받기 버튼 피드백: `SignUpViewModel.isSendingCode` 추가, `TextFieldType.Variant7.enabled` 신설로 송신 중/재전송 텍스트 토글 + 클릭 차단
- 비밀번호 정규식 검증: `PASSWORD_REGEX` (8~16자, 영문 대소문자/숫자/특수문자) + `isPasswordRuleSatisfied` derivedStateOf, 안내 문구 valid/invalid 색상 토글
- 이름 빈값 전송 차단: `submitSignUp()` 진입부 `trim().isEmpty()` 가드 + Profile 완료 버튼 `AfternoteButtonType.Un` 토글
- `OnboardingProfileEntry` 의 `ShowError` TODO 채움 → Snackbar 로 안내
- `isStepXNextEnabled` 가 UI 에 연결돼 있지 않던 결함도 같이 수정: `OnboardingScaffold.isActionEnabled` / `ProgressBarScaffold.isNextEnabled` 추가, Step 1~4 화면이 ViewModel 플래그를 실제 반영
- 키보드 Done IME 우회 차단: 각 Step 화면 `onImeAction` 에 `if (isNextEnabled) onNextClick()` 가드
- Dead code 제거: 호출되지 않던 `updateTermsState` 삭제
- 임시 디버그 Log (`SignUpViewModel.init` / `submitSignUp` 진입부, `TODO(fix/141): … 후 제거` 마커) — 가설 B(process death 휘발) 재현 확정용

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

회원가입 4단계 + Profile 화면의 입력 가드 / 텍스트 토글 변경. UI 변경은 작아 별도 스크린샷 없이 Compose Preview 와 실기기 회원가입 플로우로 검증.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 가설 B 확정용 디버그 Log 는 재현 후 별도 커밋으로 제거 예정. PR 머지 후 정리해도 무방
- 후속 이슈 분리: #142 (회원가입 직후 401), #143 (Step 1 verifyEmail 즉시 호출)
- 빌드 검증: `./gradlew :feature:onboarding:presentation:assembleDebug :feature:onboarding:presentation:lintDebug` BUILD SUCCESSFUL