### PR TITLE
fix(onboarding): 이메일 중복/인증번호 검증을 Step 1에서 즉시 노출

### DIFF
--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/OnboardingProfileEntry.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/OnboardingProfileEntry.kt
@@ -43,6 +43,8 @@ fun OnboardingProfileEntry(
                     )
                 }
             }
+
+            SignUpEvent.NavigateToResidentNumber -> Unit // SignUp Step 1 화면에서 처리
         }
     }
 

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
@@ -1,21 +1,27 @@
 package com.afternote.feature.onboarding.presentation.navigation
 
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
+import com.afternote.core.ui.ObserveAsEvents
 import com.afternote.core.ui.Route
 import com.afternote.feature.onboarding.presentation.OnboardingProfileEntry
 import com.afternote.feature.onboarding.presentation.WelcomeScreen
 import com.afternote.feature.onboarding.presentation.login.LoginEntry
+import com.afternote.feature.onboarding.presentation.signup.SignUpEvent
 import com.afternote.feature.onboarding.presentation.signup.SignUpPasswordScreen
 import com.afternote.feature.onboarding.presentation.signup.SignUpResidentNumberScreen
 import com.afternote.feature.onboarding.presentation.signup.SignUpScreen
 import com.afternote.feature.onboarding.presentation.signup.SignUpViewModel
 import com.afternote.feature.onboarding.presentation.terms.OnboardingTermsScreen
+import kotlinx.coroutines.launch
 
 /**
  * 온보딩 피처의 네비게이션 그래프.
@@ -51,6 +57,11 @@ fun NavGraphBuilder.onboardingNavGraph(
         // ── SignUp Step 1: 이메일 & 인증번호 ──
         composable<OnboardingRoute.SignUpRoute> {
             val signUpViewModel = graphScopedSignUpViewModel(graphScopedParentEntry)
+            val snackbarHostState =
+                rememberSignUpEventHost(
+                    viewModel = signUpViewModel,
+                    onNavigateToResidentNumber = actions::onSignUpEmailNext,
+                )
 
             SignUpScreen(
                 emailState = signUpViewModel.emailState,
@@ -58,8 +69,9 @@ fun NavGraphBuilder.onboardingNavGraph(
                 isVerificationSent = signUpViewModel.isVerificationSent,
                 isSendingCode = signUpViewModel.isSendingCode,
                 isNextEnabled = signUpViewModel.isStep1NextEnabled,
+                snackbarHostState = snackbarHostState,
                 onRequestVerification = signUpViewModel::requestVerification,
-                onNextClick = actions::onSignUpEmailNext,
+                onNextClick = signUpViewModel::verifyEmailAndProceed,
                 onBackClick = actions::onSignUpEmailBack,
             )
         }
@@ -67,11 +79,13 @@ fun NavGraphBuilder.onboardingNavGraph(
         // ── SignUp Step 2: 주민등록번호 ──
         composable<OnboardingRoute.SignUpResidentNumberRoute> {
             val signUpViewModel = graphScopedSignUpViewModel(graphScopedParentEntry)
+            val snackbarHostState = rememberSignUpEventHost(signUpViewModel)
 
             SignUpResidentNumberScreen(
                 frontNumberState = signUpViewModel.frontNumberState,
                 backNumberState = signUpViewModel.backNumberState,
                 isNextEnabled = signUpViewModel.isStep2NextEnabled,
+                snackbarHostState = snackbarHostState,
                 onNextClick = actions::onSignUpResidentNext,
                 onBackClick = actions::onSignUpResidentBack,
             )
@@ -80,12 +94,14 @@ fun NavGraphBuilder.onboardingNavGraph(
         // ── SignUp Step 3: 비밀번호 설정 ──
         composable<OnboardingRoute.SignUpPasswordRoute> {
             val signUpViewModel = graphScopedSignUpViewModel(graphScopedParentEntry)
+            val snackbarHostState = rememberSignUpEventHost(signUpViewModel)
 
             SignUpPasswordScreen(
                 passwordState = signUpViewModel.signUpPasswordState,
                 passwordConfirmState = signUpViewModel.signUpPasswordConfirmState,
                 isPasswordRuleSatisfied = signUpViewModel.isPasswordRuleSatisfied,
                 isNextEnabled = signUpViewModel.isStep3NextEnabled,
+                snackbarHostState = snackbarHostState,
                 onNextClick = actions::onSignUpPasswordNext,
                 onBackClick = actions::onSignUpPasswordBack,
             )
@@ -94,10 +110,12 @@ fun NavGraphBuilder.onboardingNavGraph(
         // ── SignUp Step 4: 약관 동의 ──
         composable<OnboardingRoute.TermsRoute> {
             val signUpViewModel = graphScopedSignUpViewModel(graphScopedParentEntry)
+            val snackbarHostState = rememberSignUpEventHost(signUpViewModel)
 
             OnboardingTermsScreen(
                 termsState = signUpViewModel.termsState,
                 isNextEnabled = signUpViewModel.isStep4NextEnabled,
+                snackbarHostState = snackbarHostState,
                 onTermsToggle = signUpViewModel::toggleTermsAgreed,
                 onPrivacyToggle = signUpViewModel::togglePrivacyAgreed,
                 onMarketingToggle = signUpViewModel::toggleMarketingAgreed,
@@ -131,4 +149,34 @@ fun NavGraphBuilder.onboardingNavGraph(
 private fun graphScopedSignUpViewModel(graphScopedParentEntry: () -> NavBackStackEntry): SignUpViewModel {
     val parentEntry = remember { graphScopedParentEntry() }
     return hiltViewModel(parentEntry)
+}
+
+/**
+ * SignUp Step 화면 공통의 Snackbar 호스트 + 이벤트 수집기.
+ * 각 Step composable 에서 호출해 [SignUpEvent.ShowError] 를 일관되게 노출하고,
+ * Step 1 의 경우 [onNavigateToResidentNumber] 로 검증 통과 시 네비게이트한다.
+ */
+@Composable
+private fun rememberSignUpEventHost(
+    viewModel: SignUpViewModel,
+    onNavigateToResidentNumber: (() -> Unit)? = null,
+): SnackbarHostState {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+
+    ObserveAsEvents(viewModel.eventFlow) { event ->
+        when (event) {
+            SignUpEvent.NavigateToResidentNumber -> onNavigateToResidentNumber?.invoke()
+            is SignUpEvent.ShowError ->
+                coroutineScope.launch {
+                    snackbarHostState.showSnackbar(
+                        message = event.message,
+                        duration = SnackbarDuration.Short,
+                    )
+                }
+            SignUpEvent.SignUpSuccess -> Unit // Profile 화면(OnboardingProfileEntry)에서 처리
+        }
+    }
+
+    return snackbarHostState
 }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpEvent.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpEvent.kt
@@ -8,6 +8,9 @@ package com.afternote.feature.onboarding.presentation.signup
 sealed interface SignUpEvent {
     data object SignUpSuccess : SignUpEvent
 
+    /** Step 1 이메일/인증번호 검증 통과 — 주민등록번호 단계로 이동 */
+    data object NavigateToResidentNumber : SignUpEvent
+
     data class ShowError(
         val message: String,
     ) : SignUpEvent

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpPasswordScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpPasswordScreen.kt
@@ -12,8 +12,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
@@ -36,6 +38,7 @@ fun SignUpPasswordScreen(
     passwordConfirmState: TextFieldState,
     isPasswordRuleSatisfied: Boolean,
     isNextEnabled: Boolean,
+    snackbarHostState: SnackbarHostState,
     onNextClick: () -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -48,6 +51,7 @@ fun SignUpPasswordScreen(
         onNextClick = onNextClick,
         modifier = modifier,
         isNextEnabled = isNextEnabled,
+        snackbarHostState = snackbarHostState,
         content = {
             Column(
                 modifier =
@@ -144,6 +148,7 @@ private fun SignUpPasswordScreenPreview() {
             passwordConfirmState = rememberTextFieldState(),
             isPasswordRuleSatisfied = false,
             isNextEnabled = false,
+            snackbarHostState = remember { SnackbarHostState() },
             onNextClick = {},
             onBackClick = {},
         )

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpResidentNumberScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpResidentNumberScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -32,6 +33,7 @@ fun SignUpResidentNumberScreen(
     frontNumberState: TextFieldState,
     backNumberState: TextFieldState,
     isNextEnabled: Boolean,
+    snackbarHostState: SnackbarHostState,
     onNextClick: () -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -57,6 +59,7 @@ fun SignUpResidentNumberScreen(
         onNextClick = onNextClick,
         modifier = modifier,
         isNextEnabled = isNextEnabled,
+        snackbarHostState = snackbarHostState,
         content = {
             Column(
                 modifier =
@@ -98,6 +101,7 @@ private fun SignUpResidentNumberScreenPreview() {
             frontNumberState = rememberTextFieldState(),
             backNumberState = rememberTextFieldState(),
             isNextEnabled = false,
+            snackbarHostState = remember { SnackbarHostState() },
             onNextClick = {},
             onBackClick = {},
         )

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpScreen.kt
@@ -8,8 +8,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -30,6 +32,7 @@ fun SignUpScreen(
     isVerificationSent: Boolean,
     isSendingCode: Boolean,
     isNextEnabled: Boolean,
+    snackbarHostState: SnackbarHostState,
     onRequestVerification: () -> Unit,
     onNextClick: () -> Unit,
     onBackClick: () -> Unit,
@@ -50,6 +53,7 @@ fun SignUpScreen(
         onNextClick = onNextClick,
         modifier = modifier,
         isNextEnabled = isNextEnabled,
+        snackbarHostState = snackbarHostState,
         content = {
             Column(
                 modifier =
@@ -107,6 +111,7 @@ private fun SignUpScreenPreview() {
             isVerificationSent = true,
             isSendingCode = false,
             isNextEnabled = false,
+            snackbarHostState = remember { SnackbarHostState() },
             onRequestVerification = {},
             onNextClick = {},
             onBackClick = {},

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
@@ -60,6 +60,10 @@ class SignUpViewModel
         var isSendingCode by mutableStateOf(false)
             private set
 
+        /** 이메일/인증번호 검증 요청 진행 중. Step 1 "다음" 중복 클릭 방지. */
+        var isVerifyingEmail by mutableStateOf(false)
+            private set
+
         // Step 2: 주민등록번호
         val frontNumberState = TextFieldState()
         val backNumberState = TextFieldState()
@@ -96,7 +100,8 @@ class SignUpViewModel
 
         /** Step 1 — 이메일·인증번호 입력 후 다음 단계 진행 가능 여부 */
         val isStep1NextEnabled by derivedStateOf {
-            emailState.text.isNotBlank() &&
+            !isVerifyingEmail &&
+                emailState.text.isNotBlank() &&
                 verificationCodeState.text.length >= MIN_VERIFICATION_CODE_LENGTH
         }
 
@@ -135,6 +140,34 @@ class SignUpViewModel
                         )
                     }
                 isSendingCode = false
+            }
+        }
+
+        /**
+         * Step 1 "다음" 클릭 시점에 호출.
+         * 이메일/인증번호를 서버에 검증해 성공 시 [SignUpEvent.NavigateToResidentNumber] 를,
+         * 실패/거부 시 [SignUpEvent.ShowError] 를 emit.
+         */
+        fun verifyEmailAndProceed() {
+            if (isVerifyingEmail) return
+            viewModelScope.launch {
+                isVerifyingEmail = true
+                accountRepository
+                    .verifyEmail(
+                        email = emailState.text.toString(),
+                        certificateCode = verificationCodeState.text.toString(),
+                    ).onSuccess { result ->
+                        if (result.isVerified) {
+                            eventChannel.send(SignUpEvent.NavigateToResidentNumber)
+                        } else {
+                            eventChannel.send(SignUpEvent.ShowError("인증번호가 일치하지 않습니다"))
+                        }
+                    }.onFailure { error ->
+                        eventChannel.send(
+                            SignUpEvent.ShowError(error.message ?: "이메일 인증 실패"),
+                        )
+                    }
+                isVerifyingEmail = false
             }
         }
 

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.afternote.core.domain.repository.account.AccountRepository
+import com.afternote.core.domain.usecase.auth.LoginType
+import com.afternote.core.domain.usecase.auth.LoginUseCase
 import com.afternote.feature.onboarding.presentation.terms.TermsState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
@@ -32,6 +34,7 @@ class SignUpViewModel
     @Inject
     constructor(
         private val accountRepository: AccountRepository,
+        private val loginUseCase: LoginUseCase,
     ) : ViewModel() {
         companion object {
             /** 주민등록번호 앞자리(생년월일) 자릿수 */
@@ -216,14 +219,26 @@ class SignUpViewModel
                 }
 
                 isLoading = true
+                val email = emailState.text.toString()
+                val password = signUpPasswordState.text.toString()
                 accountRepository
                     .signUp(
-                        email = emailState.text.toString(),
-                        password = signUpPasswordState.text.toString(),
+                        email = email,
+                        password = password,
                         name = name,
                         profileUrl = _profileImageUri.value?.toString(),
                     ).onSuccess {
-                        eventChannel.send(SignUpEvent.SignUpSuccess)
+                        // 회원가입 API 는 토큰을 내려주지 않으므로 같은 자격증명으로 자동 로그인.
+                        loginUseCase(LoginType.Email(email = email, password = password))
+                            .onSuccess {
+                                eventChannel.send(SignUpEvent.SignUpSuccess)
+                            }.onFailure { error ->
+                                eventChannel.send(
+                                    SignUpEvent.ShowError(
+                                        error.message ?: "자동 로그인에 실패했어요. 로그인 화면에서 다시 시도해주세요.",
+                                    ),
+                                )
+                            }
                     }.onFailure { error ->
                         eventChannel.send(
                             SignUpEvent.ShowError(error.message ?: "회원가입 실패"),

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/scaffold/OnboardingScaffold.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/scaffold/OnboardingScaffold.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -28,6 +30,7 @@ fun OnboardingScaffold(
     onActionButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
     isActionEnabled: Boolean = true,
+    snackbarHostState: SnackbarHostState? = null,
     content: @Composable () -> Unit, // 내부 콘텐츠 슬롯
 ) {
     val focusManager = LocalFocusManager.current
@@ -44,6 +47,9 @@ fun OnboardingScaffold(
                     onBackClick()
                 },
             )
+        },
+        snackbarHost = {
+            if (snackbarHostState != null) SnackbarHost(hostState = snackbarHostState)
         },
         bottomBar = {
             // 제스차 바를 쓰는 경우 화면 하단으로부터 49.dp, 구형 네비게이션 바를 쓰는 경우 바로부터 49.dp

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/scaffold/ProgressBarScaffold.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/scaffold/ProgressBarScaffold.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -20,6 +21,7 @@ internal fun ProgressBarScaffold(
     onNextClick: () -> Unit,
     modifier: Modifier = Modifier,
     isNextEnabled: Boolean = true,
+    snackbarHostState: SnackbarHostState? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     OnboardingScaffold(
@@ -28,6 +30,7 @@ internal fun ProgressBarScaffold(
         onActionButtonClick = onNextClick,
         modifier = modifier,
         isActionEnabled = isNextEnabled,
+        snackbarHostState = snackbarHostState,
     ) {
         Column(
             modifier =

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/terms/OnboardingTermsScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/terms/OnboardingTermsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
@@ -54,6 +55,7 @@ data class TermsState(
 fun OnboardingTermsScreen(
     termsState: TermsState,
     isNextEnabled: Boolean,
+    snackbarHostState: SnackbarHostState,
     onTermsToggle: (Boolean) -> Unit,
     onPrivacyToggle: (Boolean) -> Unit,
     onMarketingToggle: (Boolean) -> Unit,
@@ -69,6 +71,7 @@ fun OnboardingTermsScreen(
         onNextClick = onNextClick,
         modifier = modifier,
         isNextEnabled = isNextEnabled,
+        snackbarHostState = snackbarHostState,
         content = {
             Spacer(modifier = Modifier.height(32.dp))
 
@@ -227,6 +230,7 @@ private fun OnboardingTermsScreenPreview() {
         OnboardingTermsScreen(
             termsState = state,
             isNextEnabled = state.isTermsAgreed && state.isPrivacyAgreed,
+            snackbarHostState = remember { SnackbarHostState() },
             onTermsToggle = { state = state.copy(isTermsAgreed = it) },
             onPrivacyToggle = { state = state.copy(isPrivacyAgreed = it) },
             onMarketingToggle = { state = state.copy(isMarketingAgreed = it) },


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed fix: 회원가입 마지막에야 중복 이메일/미인증 알림 — Step 1 에서 verifyEmail 호출 #143

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `SignUpEvent.NavigateToResidentNumber` 추가
- `SignUpViewModel.verifyEmailAndProceed()` 신설 — `accountRepository.verifyEmail(email, code)` 호출 후 `isVerified == true` 면 `NavigateToResidentNumber` emit, 아니면 `ShowError` emit. `isVerifyingEmail` flag 로 중복 클릭 방지 + `isStep1NextEnabled` 와 결합
- SignUp Step 1~4 공통 Snackbar 인프라:
  - `OnboardingScaffold` / `ProgressBarScaffold` 에 `snackbarHostState: SnackbarHostState?` 통과 path 추가
  - Step 1~4 화면 시그니처에 `snackbarHostState` 추가
  - NavGraph 에 `rememberSignUpEventHost(viewModel, onNavigateToResidentNumber?)` private 헬퍼 — SnackbarHostState 생성 + `ObserveAsEvents` 로 `ShowError → Snackbar`, `NavigateToResidentNumber → navigate` 처리
- `OnboardingProfileEntry` 의 when 분기에 `NavigateToResidentNumber -> Unit` 추가 → exhaustive 보장

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘵𝘩𝘰𝘵

UI 자체 변경 없음. Snackbar 인프라만 연결. 실기기에서 잘못된 인증번호 입력 시 Snackbar 노출 확인.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- ⚠️ 본 PR 의 원래 가정("`/auth/email/send` 가 중복 이메일에 409 반환") 이 실측과 달랐음. 실제 백엔드 동작은 `email/send` / `email/verify` 모두 200 통과, 마지막 `/auth/sign-up` 에서야 409 반환. 따라서 본 PR 의 "중복 이메일 즉시 차단" 효과는 ❌
- 본 PR 이 살아남는 가치:
  1. `verifyEmail` 호출로 인증번호 자체의 유효성 검증 (이전엔 아무 6자리 숫자나 통과되던 결함 차단)
  2. SignUp Step 1~4 의 Snackbar 인프라
  3. 마지막 sign-up 409 시 ProfileEntry 의 ShowError → Snackbar 로 "이미 가입된 이메일입니다." 알림
- 중복 조기 차단은 백엔드 협조 필요 — 후속 이슈 #148 로 분리 (`/auth/email/send` 가 409 반환하거나 신규 `/check` API)
- 빌드 검증: `./gradlew :feature:onboarding:presentation:assembleDebug :feature:onboarding:presentation:lintDebug` BUILD SUCCESSFUL