### PR TITLE
fix(onboarding): 회원가입 직후 401 해소 — 자동 로그인 연동

### DIFF
--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.afternote.core.domain.repository.account.AccountRepository
+import com.afternote.core.domain.usecase.auth.LoginType
+import com.afternote.core.domain.usecase.auth.LoginUseCase
 import com.afternote.feature.onboarding.presentation.terms.TermsState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
@@ -32,6 +34,7 @@ class SignUpViewModel
     @Inject
     constructor(
         private val accountRepository: AccountRepository,
+        private val loginUseCase: LoginUseCase,
     ) : ViewModel() {
         companion object {
             /** 주민등록번호 앞자리(생년월일) 자릿수 */
@@ -216,14 +219,26 @@ class SignUpViewModel
                 }
 
                 isLoading = true
+                val email = emailState.text.toString()
+                val password = signUpPasswordState.text.toString()
                 accountRepository
                     .signUp(
-                        email = emailState.text.toString(),
-                        password = signUpPasswordState.text.toString(),
+                        email = email,
+                        password = password,
                         name = name,
                         profileUrl = _profileImageUri.value?.toString(),
                     ).onSuccess {
-                        eventChannel.send(SignUpEvent.SignUpSuccess)
+                        // 회원가입 API 는 토큰을 내려주지 않으므로 같은 자격증명으로 자동 로그인.
+                        loginUseCase(LoginType.Email(email = email, password = password))
+                            .onSuccess {
+                                eventChannel.send(SignUpEvent.SignUpSuccess)
+                            }.onFailure { error ->
+                                eventChannel.send(
+                                    SignUpEvent.ShowError(
+                                        error.message ?: "자동 로그인에 실패했어요. 로그인 화면에서 다시 시도해주세요.",
+                                    ),
+                                )
+                            }
                     }.onFailure { error ->
                         eventChannel.send(
                             SignUpEvent.ShowError(error.message ?: "회원가입 실패"),


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed fix: 회원가입 직후 401 — 토큰 발급/연결 흐름 누락 #142

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `SignUpViewModel` 에 `LoginUseCase` 주입 (`core.domain.usecase.auth.LoginUseCase`)
- `submitSignUp().onSuccess` 안에서 같은 email/password 로 `LoginUseCase(LoginType.Email(...))` 호출
  - 성공 → `SignUpEvent.SignUpSuccess` emit (Home 이동, 토큰 저장된 상태)
  - 실패 → `SignUpEvent.ShowError("자동 로그인에 실패했어요. 로그인 화면에서 다시 시도해주세요.")` — Profile 화면에 잔류

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음. 회원가입 직후 Home 진입 시 `/users/me` 등이 401 안 떨어지는 것으로 검증.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 백엔드 회원가입 API 가 토큰을 응답에 안 내려주는 설계 (`{"data":{"userId":7,"email":"..."}}`). 별도 `/auth/login` 호출이 필요해 클라이언트가 자동 로그인 처리
- 자동 로그인 실패는 흔치 않은 케이스 → Snackbar 안내 + Profile 잔류로 충분. 사용자가 뒤로 가서 로그인 화면 진입 가능
- 빌드 검증: `./gradlew :feature:onboarding:presentation:assembleDebug :feature:onboarding:presentation:lintDebug` BUILD SUCCESSFUL