### PR TITLE
fix(home): /diary 카운트 조회 시 date 누락으로 500 — 오늘 날짜로 호출

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/usecase/GetHomeSummaryUseCase.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/usecase/GetHomeSummaryUseCase.kt
@@ -6,6 +6,7 @@ import com.afternote.feature.mindrecord.domain.repository.DeepThoughtRepository
 import com.afternote.feature.mindrecord.domain.repository.DiaryRepository
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import java.time.LocalDate
 import javax.inject.Inject
 
 /**
@@ -28,9 +29,12 @@ class GetHomeSummaryUseCase
         suspend operator fun invoke(): Result<HomeSummary> =
             runCatching {
                 coroutineScope {
+                    val today = LocalDate.now().toString() // yyyy-MM-dd
                     val profileDeferred = async { userRepository.getMyProfile() }
                     val receiversDeferred = async { userRepository.getReceivers() }
-                    val diaryDeferred = async { diaryRepository.getList() }
+                    // 백엔드가 `date` 를 필수 쿼리로 요구하므로 오늘 날짜로 호출.
+                    // 결과적으로 카운트는 "오늘 작성된 일기 수" 의미가 됨.
+                    val diaryDeferred = async { diaryRepository.getList(date = today) }
                     val deepThoughtDeferred = async { deepThoughtRepository.getList() }
 
                     val profile = profileDeferred.await().getOrThrow()


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed fix: 홈 카운트 조립 시 /diary 호출에 date 누락으로 500 — 오늘 날짜로 호출 #147

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `GetHomeSummaryUseCase` 에서 `diaryRepository.getList()` → `diaryRepository.getList(date = LocalDate.now().toString())` 로 변경
- 백엔드가 `/diary` 의 `date` 쿼리를 필수로 요구해서 클라이언트가 빈 호출 시 500 응답하던 문제 해결
- `feature/mindrecord` 의 기존 `java.time.LocalDate.now()` 패턴과 일관성 유지 (디바이스 로컬 타임존)

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음. Home 진입 시 `GET /api/v1/diary?date=2026-05-16` 형태로 호출되어 200 응답, 로그에서 500 사라짐.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- `HomeSummary.diaryCategoryCount` 의 의미가 "전체 일기 수" → "오늘 작성된 일기 수" 로 좁아짐. 디자인/PM 의도가 "전체" 였다면 백엔드에 `/diary` 가 date 없이도 전체 리스트 반환하도록 요청 필요 (`/deep-thought` 와 일관성)
- 부수 메모: 백엔드가 필수 쿼리 누락에 500 던지는 것은 본 이슈와 별개로 일반적으론 400 이 적절 — 추후 별도 논의
- 빌드 검증: `./gradlew :app:assembleDebug :app:lintDebug` BUILD SUCCESSFUL