### PR TITLE
fix(onboarding): 이메일 입력에 클라이언트 사전 형식 검증 추가

### DIFF
--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
@@ -68,6 +68,7 @@ fun NavGraphBuilder.onboardingNavGraph(
                 verificationCodeState = signUpViewModel.verificationCodeState,
                 isVerificationSent = signUpViewModel.isVerificationSent,
                 isSendingCode = signUpViewModel.isSendingCode,
+                isEmailFormatValid = signUpViewModel.isEmailFormatValid,
                 isNextEnabled = signUpViewModel.isStep1NextEnabled,
                 snackbarHostState = snackbarHostState,
                 onRequestVerification = signUpViewModel::requestVerification,

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpScreen.kt
@@ -31,6 +31,7 @@ fun SignUpScreen(
     verificationCodeState: TextFieldState,
     isVerificationSent: Boolean,
     isSendingCode: Boolean,
+    isEmailFormatValid: Boolean,
     isNextEnabled: Boolean,
     snackbarHostState: SnackbarHostState,
     onRequestVerification: () -> Unit,
@@ -38,14 +39,13 @@ fun SignUpScreen(
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val isEmailNotBlank = emailState.text.isNotBlank()
     val verificationButtonText =
         when {
             isSendingCode -> stringResource(R.string.signup_verification_requesting)
             isVerificationSent -> stringResource(R.string.signup_verification_resend)
             else -> stringResource(R.string.signup_verification_request)
         }
-    val isVerificationButtonEnabled = !isSendingCode && isEmailNotBlank
+    val isVerificationButtonEnabled = !isSendingCode && isEmailFormatValid
 
     ProgressBarScaffold(
         currentStep = 1,
@@ -110,6 +110,7 @@ private fun SignUpScreenPreview() {
             verificationCodeState = rememberTextFieldState(),
             isVerificationSent = true,
             isSendingCode = false,
+            isEmailFormatValid = false,
             isNextEnabled = false,
             snackbarHostState = remember { SnackbarHostState() },
             onRequestVerification = {},

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
@@ -2,6 +2,7 @@ package com.afternote.feature.onboarding.presentation.signup
 
 import android.net.Uri
 import android.util.Log
+import android.util.Patterns
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -101,10 +102,16 @@ class SignUpViewModel
         var isLoading by mutableStateOf(false)
             private set
 
+        /** 이메일 형식 유효성. "인증번호 받기" / "다음" 활성화 조건의 사전 가드. */
+        val isEmailFormatValid by derivedStateOf {
+            val email = emailState.text.toString()
+            email.isNotBlank() && Patterns.EMAIL_ADDRESS.matcher(email).matches()
+        }
+
         /** Step 1 — 이메일·인증번호 입력 후 다음 단계 진행 가능 여부 */
         val isStep1NextEnabled by derivedStateOf {
             !isVerifyingEmail &&
-                emailState.text.isNotBlank() &&
+                isEmailFormatValid &&
                 verificationCodeState.text.length >= MIN_VERIFICATION_CODE_LENGTH
         }
 


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed fix: Step 1 이메일 입력에 클라이언트 사전 형식 검증 추가 #150

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `SignUpViewModel.isEmailFormatValid` derivedStateOf 신설 — `android.util.Patterns.EMAIL_ADDRESS` 정규식으로 검증
- `isStep1NextEnabled` 가 `emailState.text.isNotBlank()` 대신 `isEmailFormatValid` 를 보도록 변경
- `SignUpScreen` 의 "인증번호 받기" 버튼 enabled 조건도 동일하게 강화 (`isEmailNotBlank` → `isEmailFormatValid`)
- NavGraph 에서 새 props (`isEmailFormatValid`) 전달

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경은 버튼 enable/disable 상태 토글뿐. `abc`, `user@` 같은 무효 형식 입력 시 인증번호 받기 버튼 disable, `user@gmail.com` 같은 유효 형식 입력 시 enable.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- Base: `fix/142` (PR #146) — stack PR. `fix/141` → `fix/143` → `fix/142` → `fix/150` 순
- 빌드 검증: `./gradlew :feature:onboarding:presentation:assembleDebug :feature:onboarding:presentation:lintDebug` BUILD SUCCESSFUL