### PR TITLE
feat(onboarding): 약관 상세 보기 화면 연결

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
@@ -79,6 +79,14 @@ fun rememberOnboardingNavActions(navController: NavController): OnboardingNavAct
                 navController.popBackStack()
             }
 
+            override fun onViewTerms() {
+                navController.navigate(OnboardingRoute.TermsDetailRoute)
+            }
+
+            override fun onTermsDetailBack() {
+                navController.popBackStack()
+            }
+
             override fun onProfileBack() {
                 navController.popBackStack()
             }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavActions.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavActions.kt
@@ -32,5 +32,9 @@ interface OnboardingNavActions {
 
     fun onTermsBack()
 
+    fun onViewTerms()
+
+    fun onTermsDetailBack()
+
     fun onProfileBack()
 }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
@@ -21,6 +21,7 @@ import com.afternote.feature.onboarding.presentation.signup.SignUpResidentNumber
 import com.afternote.feature.onboarding.presentation.signup.SignUpScreen
 import com.afternote.feature.onboarding.presentation.signup.SignUpViewModel
 import com.afternote.feature.onboarding.presentation.terms.OnboardingTermsScreen
+import com.afternote.feature.onboarding.presentation.terms.TermsDetailScreen
 import kotlinx.coroutines.launch
 
 /**
@@ -121,11 +122,18 @@ fun NavGraphBuilder.onboardingNavGraph(
                 onPrivacyToggle = signUpViewModel::togglePrivacyAgreed,
                 onMarketingToggle = signUpViewModel::toggleMarketingAgreed,
                 onToggleAll = signUpViewModel::toggleAllTerms,
-                onViewTermsClick = {
-                    // TODO: 약관 상세 보기 웹뷰 또는 화면 연결
-                },
+                onViewTermsClick = { _ -> actions.onViewTerms() },
                 onNextClick = actions::onTermsNext,
                 onBackClick = actions::onTermsBack,
+            )
+        }
+
+        // ── 약관 상세 ──
+        composable<OnboardingRoute.TermsDetailRoute> {
+            TermsDetailScreen(
+                title = "",
+                onBackClick = actions::onTermsDetailBack,
+                onNextClick = actions::onTermsDetailBack,
             )
         }
 

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingRoute.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingRoute.kt
@@ -22,5 +22,8 @@ sealed interface OnboardingRoute {
     data object TermsRoute : OnboardingRoute
 
     @Serializable
+    data object TermsDetailRoute : OnboardingRoute
+
+    @Serializable
     data object ProfileRoute : OnboardingRoute
 }


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed feat: 약관 상세 보기 라우트 연결 — TermsDetailScreen 진입 #151

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `OnboardingRoute.TermsDetailRoute` (data object) 추가
- `OnboardingNavActions` 에 `onViewTerms()` / `onTermsDetailBack()` 추가
- `AppNavigationActions` 에 두 함수 구현 (navigate / popBackStack)
- `OnboardingNavGraph`:
  - 기존 `// TODO: 약관 상세 보기` 자리에 `actions.onViewTerms()` 연결
  - `composable<TermsDetailRoute>` 등록 — `TermsDetailScreen` 의 onBack/onNext 모두 `actions.onTermsDetailBack()` 으로 (사용자가 약관 동의 화면으로 복귀)

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

약관 동의 화면의 3개 항목 옆 "전체보기" 클릭 시 기존엔 동작이 없었는데 이제 약관 상세 화면으로 진입. 별도 UI 신설 없이 기존 `TermsDetailScreen` 컴포저블 연결만.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- `TermsDetailScreen` 은 이미 구현돼 있던 통합 페이지(섹션 1~6 한 화면) 라 `TermsType` 별 분기 없음. `onViewTermsClick: (TermsType) -> Unit` 의 type 인자는 무시하고 동일 화면으로 진입
- `TermsDetailScreen` 의 `title` 파라미터는 화면 내부에서 사용 안 되고 있어 빈 문자열 전달. type 별 다른 화면이 필요하면 별도 작업
- Base: `fix/150` (PR #155) — stack PR
- 빌드 검증: `./gradlew :app:assembleDebug :feature:onboarding:presentation:lintDebug` BUILD SUCCESSFUL