### PR TITLE
feat(onboarding): 인증번호 재전송 30초 쿨다운 + 카운트다운 표시

### DIFF
--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
@@ -70,6 +70,7 @@ fun NavGraphBuilder.onboardingNavGraph(
                 isVerificationSent = signUpViewModel.isVerificationSent,
                 isSendingCode = signUpViewModel.isSendingCode,
                 isEmailFormatValid = signUpViewModel.isEmailFormatValid,
+                resendCooldownSeconds = signUpViewModel.resendCooldownSeconds,
                 isNextEnabled = signUpViewModel.isStep1NextEnabled,
                 snackbarHostState = snackbarHostState,
                 onRequestVerification = signUpViewModel::requestVerification,

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpScreen.kt
@@ -32,6 +32,7 @@ fun SignUpScreen(
     isVerificationSent: Boolean,
     isSendingCode: Boolean,
     isEmailFormatValid: Boolean,
+    resendCooldownSeconds: Int,
     isNextEnabled: Boolean,
     snackbarHostState: SnackbarHostState,
     onRequestVerification: () -> Unit,
@@ -42,10 +43,13 @@ fun SignUpScreen(
     val verificationButtonText =
         when {
             isSendingCode -> stringResource(R.string.signup_verification_requesting)
+            resendCooldownSeconds > 0 ->
+                stringResource(R.string.signup_verification_resend_cooldown, resendCooldownSeconds)
             isVerificationSent -> stringResource(R.string.signup_verification_resend)
             else -> stringResource(R.string.signup_verification_request)
         }
-    val isVerificationButtonEnabled = !isSendingCode && isEmailFormatValid
+    val isVerificationButtonEnabled =
+        !isSendingCode && resendCooldownSeconds == 0 && isEmailFormatValid
 
     ProgressBarScaffold(
         currentStep = 1,
@@ -111,6 +115,7 @@ private fun SignUpScreenPreview() {
             isVerificationSent = true,
             isSendingCode = false,
             isEmailFormatValid = false,
+            resendCooldownSeconds = 0,
             isNextEnabled = false,
             snackbarHostState = remember { SnackbarHostState() },
             onRequestVerification = {},

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
@@ -6,6 +6,7 @@ import android.util.Patterns
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
@@ -15,7 +16,9 @@ import com.afternote.core.domain.usecase.auth.LoginType
 import com.afternote.core.domain.usecase.auth.LoginUseCase
 import com.afternote.feature.onboarding.presentation.terms.TermsState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -46,6 +49,9 @@ class SignUpViewModel
 
             private const val MIN_VERIFICATION_CODE_LENGTH = 6
 
+            /** "재전송" 클릭 후 다음 요청까지 강제 대기 초. 서버 비용·SMS 발송량 보호. */
+            private const val RESEND_COOLDOWN_SECONDS = 30
+
             /** 8~16자, 영문 대소문자 + 숫자 + 특수문자 각 1개 이상. */
             private val PASSWORD_REGEX =
                 Regex("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{8,16}$")
@@ -67,6 +73,12 @@ class SignUpViewModel
         /** 이메일/인증번호 검증 요청 진행 중. Step 1 "다음" 중복 클릭 방지. */
         var isVerifyingEmail by mutableStateOf(false)
             private set
+
+        /** 재전송 쿨다운 남은 초. 0 이면 즉시 재요청 가능. */
+        var resendCooldownSeconds by mutableIntStateOf(0)
+            private set
+
+        private var cooldownJob: Job? = null
 
         // Step 2: 주민등록번호
         val frontNumberState = TextFieldState()
@@ -138,19 +150,34 @@ class SignUpViewModel
         }
 
         fun requestVerification() {
-            if (isSendingCode) return
+            if (isSendingCode || resendCooldownSeconds > 0) return
             viewModelScope.launch {
                 isSendingCode = true
                 accountRepository
                     .sendEmailCode(emailState.text.toString())
-                    .onSuccess { isVerificationSent = true }
-                    .onFailure { error ->
+                    .onSuccess {
+                        isVerificationSent = true
+                        startResendCooldown()
+                    }.onFailure { error ->
                         eventChannel.send(
                             SignUpEvent.ShowError(error.message ?: "인증번호 요청 실패"),
                         )
                     }
                 isSendingCode = false
             }
+        }
+
+        /** 인증번호 발송 성공 직후 호출. 60초 카운트다운을 시작해 재전송 연타를 막는다. */
+        private fun startResendCooldown() {
+            cooldownJob?.cancel()
+            cooldownJob =
+                viewModelScope.launch {
+                    resendCooldownSeconds = RESEND_COOLDOWN_SECONDS
+                    while (resendCooldownSeconds > 0) {
+                        delay(1000)
+                        resendCooldownSeconds -= 1
+                    }
+                }
         }
 
         /**

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.viewModelScope
 import com.afternote.core.domain.repository.account.AccountRepository
 import com.afternote.core.domain.usecase.auth.LoginType
 import com.afternote.core.domain.usecase.auth.LoginUseCase
+import com.afternote.feature.onboarding.presentation.signup.SignUpViewModel.Companion.RESEND_COOLDOWN_SECONDS
 import com.afternote.feature.onboarding.presentation.terms.TermsState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -167,7 +168,7 @@ class SignUpViewModel
             }
         }
 
-        /** 인증번호 발송 성공 직후 호출. 60초 카운트다운을 시작해 재전송 연타를 막는다. */
+        /** 인증번호 발송 성공 직후 호출. [RESEND_COOLDOWN_SECONDS] 동안 카운트다운하며 재전송 연타를 막는다. */
         private fun startResendCooldown() {
             cooldownJob?.cancel()
             cooldownJob =

--- a/feature/onboarding/presentation/src/main/res/values/strings.xml
+++ b/feature/onboarding/presentation/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="signup_verification_request">인증번호 받기</string>
     <string name="signup_verification_requesting">전송 중…</string>
     <string name="signup_verification_resend">재전송</string>
+    <string name="signup_verification_resend_cooldown">재전송 (%1$ds)</string>
     <string name="signup_next">다음</string>
     <string name="signup_resident_number_label">주민등록번호</string>
     <string name="signup_resident_number_placeholder">주민등록번호</string>


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed feat: 인증번호 재전송 60초 쿨다운 + 카운트다운 표시 #152

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `SignUpViewModel`:
  - companion 에 `RESEND_COOLDOWN_SECONDS = 30` 상수 (업계 표준 30~60초 중 30 선택, 이메일 발송 지연 + 연타 방지 균형)
  - `resendCooldownSeconds: Int` (`mutableIntStateOf`) + private `cooldownJob: Job`
  - `requestVerification()` 진입부 가드 강화 — `isSendingCode || resendCooldownSeconds > 0` 면 무시
  - `sendEmailCode` 성공 시 `startResendCooldown()` 호출
  - `startResendCooldown()` private — 기존 job 취소 후 1초씩 감소하는 코루틴 시작
- `SignUpScreen`:
  - `resendCooldownSeconds: Int` 파라미터 추가
  - 텍스트 토글 우선순위: `전송 중…` > `재전송 (45s)` > `재전송` > `인증번호 받기`
  - enabled 조건: `!isSendingCode && resendCooldownSeconds == 0 && isEmailFormatValid`
- `strings.xml`: `signup_verification_resend_cooldown` (`재전송 (%1$ds)`) 추가
- `OnboardingNavGraph`: 새 props 전달

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

"인증번호 받기" → 발송 성공 시 버튼이 `재전송 (30s)` → `재전송 (29s)` → ... → 0 도달 시 `재전송` 으로 복귀. 카운트다운 중에는 버튼 disable (회색).

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 이슈 제목은 60초이나 실제 구현은 30초. 업계 표준(카카오/네이버/토스 30~60초) 과 이메일 발송 지연을 고려해 결정. 다른 값으로 조정이 필요하면 알려주세요
- Base: `fix/151` (PR #156) — stack PR
- 빌드 검증: `./gradlew :feature:onboarding:presentation:assembleDebug :feature:onboarding:presentation:lintDebug` BUILD SUCCESSFUL