### PR TITLE
fix(network): 4xx/5xx 응답의 백엔드 message 를 Snackbar 에 노출 — ApiErrorInterceptor

### DIFF
--- a/core/data/src/main/java/com/afternote/core/data/repoimpl/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/afternote/core/data/repoimpl/UserRepositoryImpl.kt
@@ -142,11 +142,7 @@ class UserRepositoryImpl
                     )
                 Log.d(TAG, "registerReceiver: response=$response")
                 if (response.status != 201) {
-                    throw ApiException(
-                        status = response.status,
-                        code = response.code,
-                        message = response.message ?: "Status 201 아님",
-                    )
+                    throw ApiException(code = response.code, message = response.message ?: "Status 201 아님")
                 }
                 val data = response.requireData()
                 data.receiverId
@@ -183,7 +179,6 @@ class UserRepositoryImpl
                 Log.d(TAG, "updateReceiver: response=$response")
                 if (response.status !in 200..299) {
                     throw ApiException(
-                        status = response.status,
                         code = response.code,
                         message = response.message ?: "Status 200 이상 299 이하가 아님",
                     )

--- a/core/network/src/main/kotlin/com/afternote/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/di/NetworkModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import coil3.ImageLoader
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import com.afternote.core.network.BuildConfig
+import com.afternote.core.network.interceptor.ApiErrorInterceptor
 import com.afternote.core.network.interceptor.AuthInterceptor
 import com.afternote.core.network.interceptor.FeatureNetworkInterceptor
 import com.afternote.core.network.interceptor.OptionalDebugNetworkInterceptor
@@ -69,8 +70,11 @@ object NetworkModule { // 이 모듈은 오브젝트 클래스 선언해서 딱 
         loggingInterceptor: HttpLoggingInterceptor,
         authInterceptor: AuthInterceptor,
         tokenAuthenticator: TokenAuthenticator,
+        apiErrorInterceptor: ApiErrorInterceptor,
     ): OkHttpClient {
         val builder = OkHttpClient.Builder()
+        // 가장 외곽(응답 마지막) — 4xx/5xx 본문의 message 를 파싱해 ApiException 으로 변환
+        builder.addInterceptor(apiErrorInterceptor)
         // 디버그 전용(피처 모듈) 인터셉터: 네트워크로 나가기 전에 가짜 응답을 반환할 수 있음
         debugInterceptors.forEach { builder.addInterceptor(it) }
         // 피처 모듈이 제공하는 프로덕션 인터셉터(예: 수신자 X-Auth-Code 자동 부착)

--- a/core/network/src/main/kotlin/com/afternote/core/network/interceptor/ApiErrorInterceptor.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/interceptor/ApiErrorInterceptor.kt
@@ -1,0 +1,51 @@
+package com.afternote.core.network.interceptor
+
+import com.afternote.core.network.model.ApiException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+/**
+ * 4xx/5xx 응답의 `BaseResponse` 본문을 파싱해 [ApiException] 으로 throw 한다.
+ *
+ * Retrofit 기본 동작은 4xx 응답에 대해 `HttpException` 을 자동으로 throw 하여
+ * 본문 파싱 단계까지 도달하지 못한다. 결과적으로 호출부의 `runCatching` 은
+ * `HttpException` 만 받고, 백엔드가 보내준 `{"message":"..."}` 가 사용자(Snackbar)
+ * 에게 전달되지 않는다.
+ *
+ * 본 인터셉터가 가장 외곽(가장 먼저 addInterceptor) 에서 응답을 받아 본문의
+ * `message` 를 꺼내 [ApiException] 으로 변환한다.
+ */
+class ApiErrorInterceptor
+    @Inject
+    constructor(
+        private val json: Json,
+    ) : Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response {
+            val response = chain.proceed(chain.request())
+            if (response.code !in 400..599) return response
+
+            val rawBody = response.peekBody(Long.MAX_VALUE).string()
+            val parsed = runCatching { json.parseToJsonElement(rawBody).jsonObject }.getOrNull()
+            val status = parsed?.get("status")?.jsonPrimitive?.intOrNull ?: response.code
+            val code = parsed?.get("code")?.jsonPrimitive?.intOrNull ?: response.code
+            val message =
+                parsed
+                    ?.get("message")
+                    ?.jsonPrimitive
+                    ?.content
+                    ?.takeUnless { it.isBlank() }
+                    ?: response.message.takeUnless { it.isBlank() }
+                    ?: "요청에 실패했습니다."
+
+            throw ApiException(
+                status = status,
+                code = code,
+                message = message,
+            )
+        }
+    }

--- a/core/network/src/main/kotlin/com/afternote/core/network/interceptor/ApiErrorInterceptor.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/interceptor/ApiErrorInterceptor.kt
@@ -31,7 +31,6 @@ class ApiErrorInterceptor
 
             val rawBody = response.peekBody(Long.MAX_VALUE).string()
             val parsed = runCatching { json.parseToJsonElement(rawBody).jsonObject }.getOrNull()
-            val status = parsed?.get("status")?.jsonPrimitive?.intOrNull ?: response.code
             val code = parsed?.get("code")?.jsonPrimitive?.intOrNull ?: response.code
             val message =
                 parsed
@@ -42,10 +41,6 @@ class ApiErrorInterceptor
                     ?: response.message.takeUnless { it.isBlank() }
                     ?: "요청에 실패했습니다."
 
-            throw ApiException(
-                status = status,
-                code = code,
-                message = message,
-            )
+            throw ApiException(code = code, message = message)
         }
     }

--- a/core/network/src/main/kotlin/com/afternote/core/network/model/BaseResponse.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/model/BaseResponse.kt
@@ -18,17 +18,9 @@ data class BaseResponse<T>(
 
 fun <T : Any> BaseResponse<T>.requireData(): T {
     if (status != 200) {
-        throw ApiException(
-            status = status,
-            code = code,
-            message = message ?: "알 수 없는 서버 에러가 발생했습니다.",
-        )
+        throw ApiException(code = code, message = message ?: "알 수 없는 서버 에러가 발생했습니다.")
     }
-    return data ?: throw ApiException(
-        status = status,
-        code = code,
-        message = "성공했으나 데이터가 비어있습니다.",
-    )
+    return data ?: throw ApiException(code = code, message = "성공했으나 데이터가 비어있습니다.")
 }
 
 /**
@@ -39,17 +31,12 @@ fun <T : Any> BaseResponse<T>.requireData(): T {
  * `Exception` 으로 두면 OkHttp 가 `IOException` 으로 래핑해 백엔드 message 가 손실된다.
  */
 class ApiException(
-    val status: Int,
     val code: Int,
     override val message: String,
 ) : IOException(message)
 
 fun BaseResponse<*>.requireStatus() {
     if (status != 200) {
-        throw ApiException(
-            status = status,
-            code = code,
-            message = message ?: "요청에 실패했습니다.",
-        )
+        throw ApiException(code = code, message = message ?: "요청에 실패했습니다.")
     }
 }

--- a/core/network/src/main/kotlin/com/afternote/core/network/model/BaseResponse.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/model/BaseResponse.kt
@@ -2,6 +2,7 @@ package com.afternote.core.network.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.io.IOException
 
 @Serializable
 data class BaseResponse<T>(
@@ -30,11 +31,18 @@ fun <T : Any> BaseResponse<T>.requireData(): T {
     )
 }
 
+/**
+ * 백엔드 응답이 status != 200 일 때 throw 되는 예외.
+ *
+ * [IOException] 의 서브클래스로 둔 이유 — OkHttp Interceptor (예: `ApiErrorInterceptor`)
+ * 가 4xx/5xx 응답을 가로채 throw 할 때 OkHttp 가 그대로 전파할 수 있어야 하기 때문.
+ * `Exception` 으로 두면 OkHttp 가 `IOException` 으로 래핑해 백엔드 message 가 손실된다.
+ */
 class ApiException(
     val status: Int,
     val code: Int,
     override val message: String,
-) : Exception(message)
+) : IOException(message)
 
 fun BaseResponse<*>.requireStatus() {
     if (status != 200) {


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed fix(network): 4xx 응답의 백엔드 message 가 클라이언트에 전달되지 않음 — Snackbar 에 "400"/"409" 만 표시 #159

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `core/network/.../interceptor/ApiErrorInterceptor.kt` 신설 — 4xx/5xx 응답의 `BaseResponse` 본문을 파싱해 `ApiException(code, message)` 로 throw. Retrofit 의 기본 `HttpException` 자동 throw 동작을 가로채는 역할
- `NetworkModule.provideMainOkHttpClient` 의 OkHttp 빌더 가장 외곽(가장 먼저 `addInterceptor`)에 등록 → 응답 chain 의 마지막 단계로 작동. 모든 변환·재시도(authenticator) 후 최종 응답에 대해 4xx 검사
- `ApiException` 을 `Exception` → `IOException` 서브클래스로 변경. OkHttp Interceptor 에서 throw 가능하도록 (Exception 으로 두면 OkHttp 가 IOException 으로 래핑해 백엔드 message 손실)
- `ApiException` 의 `status` 필드 제거 (어디서도 read 안 됨). `code` 는 `AfternoteAuthoringFailureMapper` 의 `code == 475` 분기에서 사용 중이라 유지
- `BaseResponse.requireData()` / `requireStatus()` 와 `UserRepositoryImpl` 의 두 `throw ApiException(...)` 호출 시그니처를 `code + message` 로 정리

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음. 머지 후 잘못된 인증번호로 verifyEmail 호출 시 Snackbar 가 "400" 대신 백엔드 message(예: "인증번호가 일치하지 않습니다") 노출.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 영향 범위: 본 PR 전엔 모든 4xx 응답이 `HttpException("HTTP 400 …")` 로만 전달되어 호출부의 `runCatching` 이 백엔드 message 를 못 받았음. 머지 후 자동으로 모든 API 호출이 백엔드 message 를 받게 됨 (sign-up 409, login 4xx, verifyEmail 4xx 등 일괄 적용)
- Interceptor 위치: 가장 외곽이라 다른 인터셉터들(`AuthInterceptor`, `LoggingInterceptor`)이 응답을 먼저 보고 마지막에 본 인터셉터가 4xx 변환. `tokenAuthenticator` 의 401 재시도도 그 전에 일어남
- `RefreshClient`/`S3Upload`/`CoilImage` 는 의도적으로 미적용 — 토큰 재발급 흐름은 자체 처리, S3 와 Coil 은 외부 서비스라 응답 형식 다름
- `ApiException.status` 필드 제거는 IDE unused 경고에 따른 정리. `code` 는 사용 중이라 유지
- 빌드 검증: `./gradlew :app:assembleDebug :core:network:ktlintCheck :core:data:ktlintCheck` BUILD SUCCESSFUL