### PR TITLE
fix(core): DailyNotification work 예약 정책 UPDATE → KEEP — 콜드스타트마다 next trigger 갱신되던 문제

### DIFF
--- a/core/common/src/main/kotlin/com/afternote/core/common/notification/NotificationScheduler.kt
+++ b/core/common/src/main/kotlin/com/afternote/core/common/notification/NotificationScheduler.kt
@@ -46,10 +46,12 @@ object NotificationScheduler {
                 .setConstraints(Constraints.Builder().setRequiresBatteryNotLow(true).build())
                 .build()
 
-        // 시간 변경 등으로 기존 예약을 덮어써야 하므로 UPDATE 정책 사용 (KEEP 아님).
+        // 앱 콜드스타트마다 호출되므로 KEEP 으로 두지 않으면 매번 next trigger 가 새 initialDelay 로 갱신돼
+        // 사용자가 알림 시각 전에 앱을 켜면 알림이 영원히 미뤄질 수 있다.
+        // 시간 변경 등 명시적 재예약이 필요할 때는 별도 API(예: reschedule) 로 CANCEL_AND_REENQUEUE 적용.
         workManager.enqueueUniquePeriodicWork(
             DailyNotificationWorker.UNIQUE_WORK_NAME,
-            ExistingPeriodicWorkPolicy.UPDATE,
+            ExistingPeriodicWorkPolicy.KEEP,
             dailyWorkRequest,
         )
     }


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed fix(core): DailyNotificationInitializer 가 매 콜드스타트마다 알림 시각 재계산 — 알림이 영원히 미뤄질 수 있음 #161

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `core/common/.../notification/NotificationScheduler.kt` 의 `enqueueUniquePeriodicWork` 정책을 `ExistingPeriodicWorkPolicy.UPDATE` → `KEEP` 으로 변경
- 매 콜드스타트마다 `DailyNotificationInitializer.create()` 가 호출되는데, UPDATE 정책이면 기존 work 가 cancel + 재enqueue 되어 `initialDelay` 가 그 시점 기준으로 다시 계산. 사용자가 알림 시각 직전(예: 8:59) 에 자주 앱을 켜면 잦은 cancel/reenqueue 로 trigger 가 손실되거나 미뤄질 위험
- KEEP 정책에서는 첫 schedule 한 번만 적용되고 그 후 콜드스타트는 무시. 24시간 주기 PeriodicWork 가 안정적으로 동작
- 주석도 정정해서 KEEP 채택 이유 + 미래 시간 변경 기능 추가 시 별도 API (CANCEL_AND_REENQUEUE) 로 처리하라는 흐름 메모

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음. WorkManager 동작 정책 변경. 검증은 `WorkManager.getWorkInfosForUniqueWork(...)` 로 next trigger time 이 콜드스타트 후에도 변하지 않는지 확인.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 현재 코드엔 알림 시각 변경 기능이 없음 (`DailyNotificationInitializer` 의 `// TODO: 설정(DataStore 등)에서 시·분 읽기`). 항상 9시 0분 호출이라 UPDATE 가 필요한 시나리오 자체가 없음 → KEEP 으로 충분
- 미래에 알림 시각 변경 UI 가 생기면 별도 함수(예: `NotificationScheduler.reschedule(hour, minute)`) 가 `ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE` 로 명시적 재예약하도록 분리 권장 — 주석에 메모해둠
- 빌드 검증: `./gradlew :core:common:assembleDebug :core:common:lintDebug :core:common:ktlintCheck` BUILD SUCCESSFUL