### PR TITLE
fix(core): UserRepositoryImpl 의 PII Log.d 제거 — 운영 빌드 logcat 의 개인정보 노출 차단

### DIFF
--- a/core/data/src/main/java/com/afternote/core/data/repoimpl/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/afternote/core/data/repoimpl/UserRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.afternote.core.data.repoimpl
 
-import android.util.Log
 import com.afternote.core.data.mapper.user.UserMapper
 import com.afternote.core.datastore.UserProfileDataSource
 import com.afternote.core.domain.repository.UserRepository
@@ -30,18 +29,8 @@ class UserRepositoryImpl
     ) : UserRepository {
         override suspend fun getMyProfile(): Result<UserProfileModel> =
             runCatching {
-                Log.d(TAG, "getMyProfile: request")
                 val response = api.getMyProfile()
-                val data = response.requireData()
-                Log.d(
-                    TAG,
-                    "getMyProfile: API data name='${data.name}' email='${data.email}' phone='${data.phone}'",
-                )
-                val profile = UserMapper.toUserProfile(data)
-                Log.d(
-                    TAG,
-                    "getMyProfile: mapped profile name='${profile.name}' email='${profile.email}'",
-                )
+                val profile = UserMapper.toUserProfile(response.requireData())
                 profileCache.saveUserName(profile.name)
                 profile
             }
@@ -58,7 +47,6 @@ class UserRepositoryImpl
             profileImageUrl: String?,
         ): Result<UserProfileModel> =
             runCatching {
-                Log.d(TAG, "updateMyProfile: name=$name, phone=$phone")
                 val response =
                     api.updateMyProfile(
                         body =
@@ -68,7 +56,6 @@ class UserRepositoryImpl
                                 profileImageUrl = profileImageUrl,
                             ),
                     )
-                Log.d(TAG, "updateMyProfile: response=$response")
                 val profile = UserMapper.toUserProfile(response.requireData())
                 profileCache.saveUserName(profile.name)
                 profile
@@ -76,18 +63,14 @@ class UserRepositoryImpl
 
         override suspend fun withdrawAccount(): Result<Unit> =
             runCatching {
-                Log.d(TAG, "withdrawAccount: request")
                 val response = api.withdrawAccount()
                 response.requireStatus()
                 profileCache.clear()
-                Log.d(TAG, "withdrawAccount: success")
             }
 
         override suspend fun getMyPushSettings(): Result<PushSettings> =
             runCatching {
-                Log.d(TAG, "getMyPushSettings: request")
                 val response = api.getMyPushSettings()
-                Log.d(TAG, "getMyPushSettings: response=$response")
                 UserMapper.toPushSettings(response.requireData())
             }
 
@@ -97,10 +80,6 @@ class UserRepositoryImpl
             afterNote: Boolean?,
         ): Result<PushSettings> =
             runCatching {
-                Log.d(
-                    TAG,
-                    "updateMyPushSettings: timeLetter=$timeLetter, mindRecord=$mindRecord, afterNote=$afterNote",
-                )
                 val response =
                     api.updateMyPushSettings(
                         body =
@@ -110,15 +89,12 @@ class UserRepositoryImpl
                                 afterNote = afterNote,
                             ),
                     )
-                Log.d(TAG, "updateMyPushSettings: response=$response")
                 UserMapper.toPushSettings(response.requireData())
             }
 
         override suspend fun getReceivers(): Result<List<ReceiverListItem>> =
             runCatching {
-                Log.d(TAG, "getReceivers: request")
                 val response = api.getReceivers()
-                Log.d(TAG, "getReceivers: response=$response")
                 val list = response.requireData()
                 list.map(UserMapper::toReceiverListItem)
             }
@@ -130,7 +106,6 @@ class UserRepositoryImpl
             email: String?,
         ): Result<Long> =
             runCatching {
-                Log.d(TAG, "registerReceiver: name=$name, relation=$relation")
                 val response =
                     api.registerReceiver(
                         RegisterReceiverRequestDto(
@@ -140,7 +115,6 @@ class UserRepositoryImpl
                             email = email,
                         ),
                     )
-                Log.d(TAG, "registerReceiver: response=$response")
                 if (response.status != 201) {
                     throw ApiException(
                         status = response.status,
@@ -154,9 +128,7 @@ class UserRepositoryImpl
 
         override suspend fun getReceiverDetail(receiverId: Long): Result<ReceiverDetail> =
             runCatching {
-                Log.d(TAG, "getReceiverDetail: receiverId=$receiverId")
                 val response = api.getReceiverDetail(receiverId = receiverId)
-                Log.d(TAG, "getReceiverDetail: response=$response")
                 UserMapper.toReceiverDetail(response.requireData())
             }
 
@@ -168,7 +140,6 @@ class UserRepositoryImpl
             email: String?,
         ): Result<Unit> =
             runCatching {
-                Log.d(TAG, "updateReceiver: receiverId=$receiverId, name=$name")
                 val response =
                     api.updateReceiver(
                         receiverId = receiverId,
@@ -180,7 +151,6 @@ class UserRepositoryImpl
                                 email = email,
                             ),
                     )
-                Log.d(TAG, "updateReceiver: response=$response")
                 if (response.status !in 200..299) {
                     throw ApiException(
                         status = response.status,
@@ -196,14 +166,12 @@ class UserRepositoryImpl
             size: Int,
         ): Result<ReceiverDailyQuestionsResult> =
             runCatching {
-                Log.d(TAG, "getReceiverDailyQuestions: receiverId=$receiverId, page=$page, size=$size")
                 val response =
                     api.getReceiverDailyQuestions(
                         receiverId = receiverId,
                         page = page,
                         size = size,
                     )
-                Log.d(TAG, "getReceiverDailyQuestions: response=$response")
                 val body = response.requireData()
                 val items = body.items.map(UserMapper::toDailyQuestionAnswerItem)
                 UserMapper.toReceiverDailyQuestionsResult(items = items, hasNext = body.hasNext)
@@ -215,14 +183,12 @@ class UserRepositoryImpl
             size: Int,
         ): Result<ReceiverMindRecordsResult> =
             runCatching {
-                Log.d(TAG, "getReceiverMindRecords: receiverId=$receiverId, page=$page, size=$size")
                 val response =
                     api.getReceiverMindRecords(
                         receiverId = receiverId,
                         page = page,
                         size = size,
                     )
-                Log.d(TAG, "getReceiverMindRecords: response=$response")
                 val body = response.requireData()
                 val items = (body.items).map(UserMapper::toReceiverMindRecordItem)
                 UserMapper.toReceiverMindRecordsResult(items = items, hasNext = body.hasNext)
@@ -230,9 +196,7 @@ class UserRepositoryImpl
 
         override suspend fun getDeliveryCondition(): Result<DeliveryCondition> =
             runCatching {
-                Log.d(TAG, "getDeliveryCondition: request")
                 val response = api.getDeliveryCondition()
-                Log.d(TAG, "getDeliveryCondition: response=$response")
                 UserMapper.toDeliveryCondition(response.requireData())
             }
 
@@ -243,7 +207,6 @@ class UserRepositoryImpl
             leaveMessage: String?,
         ): Result<DeliveryCondition> =
             runCatching {
-                Log.d(TAG, "updateDeliveryCondition: conditionType=$conditionType")
                 val body =
                     UserMapper.toDeliveryConditionRequestDto(
                         conditionType = conditionType,
@@ -252,11 +215,6 @@ class UserRepositoryImpl
                         leaveMessage = leaveMessage,
                     )
                 val response = api.updateDeliveryCondition(body)
-                Log.d(TAG, "updateDeliveryCondition: response=$response")
                 UserMapper.toDeliveryCondition(response.requireData())
             }
-
-        companion object {
-            private const val TAG = "UserRepositoryImpl"
-        }
     }


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed fix(core): UserRepositoryImpl 가 운영 빌드에서 PII(이름/이메일/전화) 를 Log.d 로 노출 #162

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `core/data/.../repoimpl/UserRepositoryImpl.kt` 의 모든 `Log.d(TAG, ...)` 호출 30+곳 제거
- `import android.util.Log` 제거
- `companion object { private const val TAG = "UserRepositoryImpl" }` 통째로 제거
- 비즈니스 로직(api 호출, mapper, profileCache, requireData/requireStatus, ApiException throw) 은 모두 그대로 유지

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음. 운영 빌드 logcat 에서 사용자 이름/이메일/전화/수신자 정보가 더 이상 노출되지 않음.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 제거 이유: `BuildConfig.DEBUG` 가드 없이 사용자 PII (이름/이메일/전화/수신자/푸시 설정) 가 운영 빌드 logcat 에 평문으로 남던 상태. root 단말 / `adb logcat` / OEM 진단 앱 / crash analytics 등을 통한 외부 노출 위험 + 개인정보보호법·GDPR 컴플라이언스 리스크
- `OkHttp HttpLoggingInterceptor` 가 이미 `BuildConfig.DEBUG` 가드 + `redactHeader("Authorization")` 로 디버그 빌드에서만 API 요청/응답을 로깅하므로, 디버깅에 필요한 정보는 거기서 충분히 보존
- 다른 repoimpl(`AuthRepositoryImpl`, `AccountRepositoryImpl` 등) 도 같은 패턴이 있다면 별도 후속 PR 로 일괄 정리 권장
- 빌드 검증: `./gradlew :core:data:assembleDebug :core:data:lintDebug :core:data:ktlintCheck` BUILD SUCCESSFUL