### PR TITLE
fix(core): AuthRepository.logout() 토큰 정리 + Result 이중 wrap 해소

### DIFF
--- a/core/data/src/main/java/com/afternote/core/data/repoimpl/auth/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/afternote/core/data/repoimpl/auth/AuthRepositoryImpl.kt
@@ -100,11 +100,16 @@ class AuthRepositoryImpl
                 tokenBundleResult
             }
 
+        /**
+         * 서버 로그아웃은 best-effort (네트워크 실패해도 사용자는 로그아웃 상태로 가야 함).
+         * 로컬 토큰은 서버 호출 결과와 무관하게 항상 정리한다.
+         */
         override suspend fun logout(): Result<Unit> =
             runCatching {
-                val refreshToken =
-                    getRefreshToken().getOrNull()
-                        ?: error("리프레시 토큰이 존재하지 않습니다.")
-                authApiService.logout(LogoutRequest(refreshToken))
+                val refreshToken = getRefreshToken().getOrNull()
+                if (refreshToken != null) {
+                    runCatching { authApiService.logout(LogoutRequest(refreshToken)) }
+                }
+                tokenDataSource.clearTokens()
             }
     }

--- a/feature/setting/presentation/src/main/kotlin/com/afternote/feature/setting/presentation/viewmodel/SettingViewModel.kt
+++ b/feature/setting/presentation/src/main/kotlin/com/afternote/feature/setting/presentation/viewmodel/SettingViewModel.kt
@@ -26,8 +26,8 @@ sealed interface SettingUiState {
 /**
  * 설정 화면용 ViewModel.
  *
- * 서버 logout 호출은 best-effort, 로컬 토큰 [AuthRepository.clearSession]은 실패 여부와 무관하게 실행한다.
- * 서버 logout이 실패(토큰 없음, 네트워크 에러 등)하더라도 로컬 세션은 반드시 삭제한다.
+ * 로그아웃 시 [AuthRepository.logout] 한 번 호출로 끝낸다. 내부적으로 서버 호출은 best-effort,
+ * 로컬 토큰은 결과 무관하게 정리하도록 위임돼 있다. 호출처는 토큰 정리 여부를 신경 쓸 필요 없음.
  */
 @HiltViewModel
 class SettingViewModel
@@ -64,8 +64,8 @@ class SettingViewModel
 
         fun logout() {
             viewModelScope.launch {
-                runCatching { authRepository.logout() }
-                authRepository.clearSession()
+                // logout() 내부에서 서버 호출(best-effort) + 로컬 토큰 정리까지 처리한다.
+                authRepository.logout()
                 userRepository.clearCachedProfile()
                 _logoutCompleted.value = true
             }


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed fix(core): AuthRepository.logout() 토큰 정리 누락 + Result 이중 wrap #163

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `core/data/.../repoimpl/auth/AuthRepositoryImpl.kt` 의 `logout()` 안에 `tokenDataSource.clearTokens()` 호출 포함
- `refreshToken` null 케이스에서도 로컬 토큰 정리 보장 (이전엔 `error()` throw 로 토큰 정리 못 함). null 이면 서버 호출 skip, 로컬 토큰만 정리
- 서버 호출 자체는 `runCatching` 으로 감싸 best-effort 처리 (네트워크 실패해도 사용자는 로그아웃 상태로)
- `feature/setting/presentation/.../SettingViewModel.kt` 의 호출처:
  - `runCatching { authRepository.logout() }` 의 이중 wrap 제거 (logout 자체가 Result 반환)
  - 별도 `authRepository.clearSession()` 호출 제거 (logout 안에 흡수)
  - KDoc 도 새 동작에 맞게 정정
- `clearSession()` API 는 그대로 유지 — `TokenAuthenticator` 가 401 자동 로그아웃 흐름에서 직접 사용

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음. 설정 화면에서 "로그아웃" 클릭 시 동작 동일하지만 내부 로직 정리.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 정책 결정: 서버 로그아웃이 실패해도 로컬 토큰은 정리한다 (사용자 입장에선 "로그아웃 됐다" 가 보장돼야 함). 토큰을 살려두면 좀비 세션 위험
- `clearSession()` 자체를 제거하지 않은 이유: `TokenAuthenticator` 가 401 refresh 실패 시 강제 로그아웃 흐름에서 직접 호출 (logout API 와는 분리된 경로). API 보존 필요
- 빌드 검증: `./gradlew :core:data:assembleDebug :feature:setting:presentation:assembleDebug :core:data:ktlintCheck :feature:setting:presentation:ktlintCheck` BUILD SUCCESSFUL