### PR TITLE
fix(onboarding): TermsDetailScreen 의 인트로 Text 중복 렌더링 제거

### DIFF
--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/terms/TermsDetailScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/terms/TermsDetailScreen.kt
@@ -42,11 +42,6 @@ fun TermsDetailScreen(
             ) {
                 Spacer(modifier = Modifier.height(8.dp))
 
-                Text(
-                    text = stringResource(R.string.terms_detail_intro),
-                    style = AfternoteDesign.typography.bodySmallR,
-                    color = AfternoteDesign.colors.gray9,
-                )
                 // 인트로 텍스트
                 Text(
                     text = stringResource(R.string.terms_detail_intro),


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed fix(onboarding): TermsDetailScreen 의 terms_detail_intro Text 가 중복 렌더링 #165

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `feature/onboarding/presentation/.../terms/TermsDetailScreen.kt` 의 동일한 `stringResource(R.string.terms_detail_intro)` Text 블록 두 개 중 하나를 제거
- `// 인트로 텍스트` 주석이 붙은 블록만 남기고 그 위 블록 삭제

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

약관 상세 화면 진입 시 인트로 문장이 한 번만 표시됨 (기존엔 두 번 반복).

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- PR [#156](https://github.com/Afternote/Afternote-FE/pull/156) (약관 상세 보기 화면 연결) 머지 후 사용자에게 노출되는 화면이라 같은 시점에 fix 권장
- 빌드 검증: `./gradlew :feature:onboarding:presentation:assembleDebug :feature:onboarding:presentation:lintDebug :feature:onboarding:presentation:ktlintCheck` BUILD SUCCESSFUL