### PR TITLE
refactor(afternote): 단순 Card 컨테이너 → Row/Box + clip/background 체이닝

### DIFF
--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/list/AfternoteListItem.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/list/AfternoteListItem.kt
@@ -12,8 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -31,64 +29,58 @@ fun AfternoteListItem(
     item: AppNoteItem,
     modifier: Modifier = Modifier,
 ) {
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = AfternoteDesign.colors.white),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp), // Flat design
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(AfternoteDesign.colors.white)
+                .defaultMinSize(minHeight = 80.dp)
+                .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(
+        Box(
             modifier =
                 Modifier
-                    .fillMaxWidth()
-                    .defaultMinSize(minHeight = 80.dp)
-                    .padding(horizontal = 16.dp),
-            verticalAlignment = Alignment.CenterVertically,
+                    .size(48.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(item.iconBgColor),
+            contentAlignment = Alignment.Center,
         ) {
-            // 아이콘 박스
-            Box(
-                modifier =
-                    Modifier
-                        .size(48.dp)
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(item.iconBgColor),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = item.icon,
-                    contentDescription = null,
-                    tint = item.iconColor,
-                    modifier = Modifier.size(28.dp),
-                )
-            }
-
-            Spacer(modifier = Modifier.width(16.dp))
-
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                Text(
-                    text = item.name,
-                    style =
-                        AfternoteDesign.typography.textField.copy(
-                            fontWeight = FontWeight.Medium,
-                        ),
-                )
-
-                Text(
-                    text = item.date,
-                    style =
-                        AfternoteDesign.typography.footnoteCaption.copy(
-                            color = AfternoteDesign.colors.gray5,
-                        ),
-                )
-            }
-
-            RightArrowIcon(
-                modifier = Modifier.size(24.dp),
-                tint = AfternoteDesign.colors.gray9,
+            Icon(
+                imageVector = item.icon,
+                contentDescription = null,
+                tint = item.iconColor,
+                modifier = Modifier.size(28.dp),
             )
         }
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = item.name,
+                style =
+                    AfternoteDesign.typography.textField.copy(
+                        fontWeight = FontWeight.Medium,
+                    ),
+            )
+
+            Text(
+                text = item.date,
+                style =
+                    AfternoteDesign.typography.footnoteCaption.copy(
+                        color = AfternoteDesign.colors.gray5,
+                    ),
+            )
+        }
+
+        RightArrowIcon(
+            modifier = Modifier.size(24.dp),
+            tint = AfternoteDesign.colors.gray9,
+        )
     }
 }

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/summary/ContentSection.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/summary/ContentSection.kt
@@ -1,6 +1,7 @@
 package com.afternote.feature.afternote.presentation.receiver.summary
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -11,12 +12,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -40,68 +40,66 @@ fun ContentSection(
             color = AfternoteDesign.colors.gray9,
         )
 
-        Card(
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(16.dp),
-            colors = CardDefaults.cardColors(containerColor = AfternoteDesign.colors.white),
-            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp), // Flat style as per image
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(AfternoteDesign.colors.white),
         ) {
-            Box(modifier = Modifier.fillMaxWidth()) {
-                // Background decoration (Simulating the 3D icons in the image)
-                Box(
+            Box(
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomEnd),
+            ) {
+                Image(
+                    painter = imageResource,
+                    contentDescription = null,
                     modifier =
                         Modifier
-                            .align(Alignment.BottomEnd),
-                ) {
-                    Image(
-                        painter = imageResource,
-                        contentDescription = null,
-                        modifier =
-                            Modifier
-                                .size(170.dp),
-                    )
-                }
+                            .size(170.dp),
+                )
+            }
 
-                Column(modifier = Modifier.padding(20.dp)) {
+            Column(modifier = Modifier.padding(20.dp)) {
+                Text(
+                    text = desc,
+                    style =
+                        AfternoteDesign.typography.textField.copy(
+                            fontWeight = FontWeight.Medium,
+                            color = AfternoteDesign.colors.gray9,
+                        ),
+                )
+                Text(
+                    text = subDesc,
+                    style = AfternoteDesign.typography.captionLargeR,
+                    color = AfternoteDesign.colors.gray9,
+                    modifier = Modifier.padding(top = 4.dp, bottom = 16.dp),
+                )
+
+                Button(
+                    onClick = onButtonClick,
+                    colors = ButtonDefaults.buttonColors(containerColor = AfternoteDesign.colors.gray9),
+                    shape = RoundedCornerShape(50),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    modifier = Modifier.defaultMinSize(minHeight = 36.dp),
+                ) {
                     Text(
-                        text = desc,
+                        text = btnText,
                         style =
-                            AfternoteDesign.typography.textField.copy(
+                            AfternoteDesign.typography.captionLargeR.copy(
                                 fontWeight = FontWeight.Medium,
                                 color = AfternoteDesign.colors.gray9,
                             ),
                     )
-                    Text(
-                        text = subDesc,
-                        style = AfternoteDesign.typography.captionLargeR,
-                        color = AfternoteDesign.colors.gray9,
-                        modifier = Modifier.padding(top = 4.dp, bottom = 16.dp),
+
+                    RightArrowIcon(
+                        modifier =
+                            Modifier
+                                .padding(start = 4.dp)
+                                .size(12.dp),
+                        tint = AfternoteDesign.colors.gray9,
                     )
-
-                    Button(
-                        onClick = onButtonClick,
-                        colors = ButtonDefaults.buttonColors(containerColor = AfternoteDesign.colors.gray9),
-                        shape = RoundedCornerShape(50),
-                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-                        modifier = Modifier.defaultMinSize(minHeight = 36.dp),
-                    ) {
-                        Text(
-                            text = btnText,
-                            style =
-                                AfternoteDesign.typography.captionLargeR.copy(
-                                    fontWeight = FontWeight.Medium,
-                                    color = AfternoteDesign.colors.gray9,
-                                ),
-                        )
-
-                        RightArrowIcon(
-                            modifier =
-                                Modifier
-                                    .padding(start = 4.dp)
-                                    .size(12.dp),
-                            tint = AfternoteDesign.colors.gray9,
-                        )
-                    }
                 }
             }
         }


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed refactor: Material3 Card 단순 컨테이너 사용 → Column + clip/background 체이닝 교체 #173

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `feature/afternote/presentation/.../receiver/list/AfternoteListItem.kt` — elevation 0 으로 단순 컨테이너 역할만 하던 `Card` 제거. 자식이 `Row` 하나라 wrapper 없이 `Row` 에 `clip(RoundedCornerShape(16.dp))` + `background(AfternoteDesign.colors.white)` 직접 체이닝
- `feature/afternote/presentation/.../receiver/summary/ContentSection.kt` — 동일 패턴 적용. 추가로 `Card → 내부 Box(fillMaxWidth)` 중첩이 의미 없어 외부 `Box` 한 단계로 통합
- 부수: 의미 없는 sketch 주석 (`// 아이콘 박스`, `// Background decoration ...`) 제거

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — `Card(elevation = 0)` 와 `layout + clip/background` 는 시각적으로 동일.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 컨벤션 룰: 단순 둥근 배경 컨테이너는 `Card` 대신 layout 에 `clip/background` 체이닝
- 이슈 예시는 `Column` wrapper 였으나, 단일 자식이 `Row`/`Box` 인 케이스라 wrapper 추가 없이 해당 layout 에 직접 체이닝하는 게 더 간결하다고 판단
- 빌드 검증: `./gradlew :feature:afternote:presentation:compileDebugKotlin :feature:afternote:presentation:ktlintCheck` BUILD SUCCESSFUL