### PR TITLE
chore(core-ui): 하드코드 Color.White 를 AfternoteDesign.colors.white 토큰으로 교체

### DIFF
--- a/core/ui/src/main/kotlin/com/afternote/core/ui/ViewModeSwitcher.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/ViewModeSwitcher.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.dropShadow
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -78,7 +77,7 @@ fun ViewModeSwitcher(
                     ).dropShadow(
                         shape = CircleShape,
                         shadow = toggleShadow_2,
-                    ).background(Color.White, CircleShape),
+                    ).background(AfternoteDesign.colors.white, CircleShape),
         )
 
         Row(modifier = Modifier.fillMaxSize()) {

--- a/core/ui/src/main/kotlin/com/afternote/core/ui/button/FAB/AfternoteFloatingActionButton.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/button/FAB/AfternoteFloatingActionButton.kt
@@ -6,7 +6,6 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -30,7 +29,7 @@ fun AfternoteFloatingActionButton(
         modifier = modifier,
         shape = CircleShape,
         containerColor = AfternoteDesign.colors.gray9,
-        contentColor = Color.White,
+        contentColor = AfternoteDesign.colors.white,
     ) {
         Icon(
             painter = painterResource(id = R.drawable.core_ui_circle_button_plus),

--- a/core/ui/src/main/kotlin/com/afternote/core/ui/button/FAB/PenFloatingActionButton.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/button/FAB/PenFloatingActionButton.kt
@@ -6,7 +6,6 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -25,7 +24,7 @@ fun PenFloatingActionButton(
         modifier = modifier,
         shape = CircleShape,
         containerColor = AfternoteDesign.colors.gray9,
-        contentColor = Color.White,
+        contentColor = AfternoteDesign.colors.white,
     ) {
         Icon(
             painter = painterResource(id = R.drawable.core_ui_ic_plus_button_fab_pen),


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed chore: 단순 매핑 가능한 색상 하드코드 → AfternoteDesign.colors 토큰 적용 #172

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `core/ui/.../ViewModeSwitcher.kt:81` — `.background(Color.White, CircleShape)` → `.background(AfternoteDesign.colors.white, CircleShape)`
- `core/ui/.../button/FAB/AfternoteFloatingActionButton.kt:33` — `contentColor = Color.White` → `contentColor = AfternoteDesign.colors.white`
- `core/ui/.../button/FAB/PenFloatingActionButton.kt:28` — 동일
- 세 파일 모두 `androidx.compose.ui.graphics.Color` 가 `Color.White` 외 사용처 없어 unused import 도 같이 제거

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 라이트 모드에서 `Color.White` 와 `AfternoteDesign.colors.white` 가 동일한 흰색. 다크 모드 토큰 반전 시 자동 대응되는 효과.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 컨벤션 룰 [Use theme colors]: 하드코드 `Color` 대신 `AfternoteDesign.colors` 토큰 사용
- 본 이슈는 토큰이 이미 존재하는 (`white`) 케이스만 다룸. 신규 토큰 필요 케이스 (shimmer, hero gradient, error, kakao, google 등) 는 디자인 의사결정 필요라 이슈 본문대로 별도 분리 예정
- 빌드 검증: `./gradlew :core:ui:compileDebugKotlin :core:ui:ktlintCheck` BUILD SUCCESSFUL