### PR TITLE
chore: 점검 발견 소규모 정리 (가시성·패키지 경로·dead 주석·중복)

### DIFF
--- a/core/data/src/main/java/com/afternote/core/data/repoimpl/account/AccountRepositoryImpl.kt
+++ b/core/data/src/main/java/com/afternote/core/data/repoimpl/account/AccountRepositoryImpl.kt
@@ -18,7 +18,7 @@ import javax.inject.Inject
 class AccountRepositoryImpl
     @Inject
     constructor(
-        val accountApiService: AccountApiService,
+        private val accountApiService: AccountApiService,
     ) : AccountRepository {
         override suspend fun sendEmailCode(email: String): Result<Unit> =
             runCatching {

--- a/core/datastore/src/main/java/com/afternote/core/datastore/TokenDataSource.kt
+++ b/core/datastore/src/main/java/com/afternote/core/datastore/TokenDataSource.kt
@@ -63,12 +63,7 @@ class TokenDataSource
         suspend fun updateTokens(
             accessToken: String,
             refreshToken: String,
-        ) {
-            dataStore.edit { prefs ->
-                prefs[Keys.ACCESS_TOKEN] = accessToken
-                prefs[Keys.REFRESH_TOKEN] = refreshToken
-            }
-        }
+        ) = saveTokens(accessToken, refreshToken)
 
         suspend fun getAccessToken(): String? = preferencesFlow.first()[Keys.ACCESS_TOKEN]
 

--- a/core/ui/src/main/kotlin/com/afternote/core/ui/bottombar/BottomNavTab.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/bottombar/BottomNavTab.kt
@@ -30,8 +30,4 @@ enum class BottomNavTab(
         R.drawable.core_ui_ic_note,
         Route.Afternote,
     ),
-
-//    companion object {
-//        fun find(route: Route) = entries.find { it.route == route }
-//    }
 }

--- a/core/ui/src/main/kotlin/com/afternote/core/ui/theme/AfternoteTypography.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/theme/AfternoteTypography.kt
@@ -24,11 +24,6 @@ private val inter =
         Font(R.font.inter_variable, FontWeight.Medium),
     )
 
-// private val fedraMonoLight =
-//    FontFamily(
-//        Font(R.font.fedra_mono_light, FontWeight.Light),
-//    )
-
 data class AfternoteTypography(
     val h1: TextStyle =
         TextStyle(
@@ -149,12 +144,4 @@ data class AfternoteTypography(
             lineHeight = 21.sp,
             letterSpacing = (-0.006).em,
         ),
-//    val fedraMono: TextStyle =
-//        TextStyle(
-//            fontFamily = fedraMonoLight,
-//            fontWeight = FontWeight.Light,
-//            fontSize = 11.sp,
-//            lineHeight = 16.5.sp,
-//            letterSpacing = 0.61.sp,
-//        ),
 )

--- a/core/ui/src/main/kotlin/com/afternote/core/ui/theme/Color.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/theme/Color.kt
@@ -261,17 +261,4 @@ class AfternoteColors(
     }
 }
 
-// 이전 레포
-// val Purple80 = Color(0xFFD0BCFF)
-// val PurpleGrey80 = Color(0xFFCCC2DC)
-// val Pink80 = Color(0xFFEFB8C8)
-//
-// val Purple40 = Color(0xFF6650a4)
-// val PurpleGrey40 = Color(0xFF625b71)
-// val Pink40 = Color(0xFF7D5260)
-// val TextPrimary = Color(0xFF2D2722) // 다이얼로그 텍스트 등 주요 텍스트 색상
-//
-// val LightBlue = Color(0xFFE3F2FD) // 아이콘 배경용
-// val ShadowBlack = Color.Black.copy(alpha = 0.05f) // 그림자용
-
 val Red = Color(0xFFFF0C0C) // 에러 메시지용 빨간색

--- a/core/ui/src/main/kotlin/com/afternote/core/ui/theme/Theme.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/theme/Theme.kt
@@ -8,23 +8,6 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 
-// 기존 버전
-
-// private val AfternoteLightColors =
-//    lightColorScheme(
-//        background = AfternoteDesign.colors.gray2,
-//    )
-//
-// fun ProvideAfternoteTheme(content: @Composable () -> Unit) {
-//    MaterialTheme(
-//        colorScheme = AfternoteLightColors,
-//        typography = afternoteTypography,
-//        content = content,
-//    )
-// }
-
-// 수정된 버전
-
 // (static)compositionLocalOf는 부모에서 자식 컴포저블로 데이터를 전달할 때 파라미터로 일일이 넘기지(Prop Drilling) 않고 데이터를 사용할 수 있게 함
 // LocalColors.current의 형태로 현재 전달된 데이터를 꺼내 쓸 수 있음
 // staticCompositionLocalOf는 데이터 값이 변경되면 데이터 제공자와 그 모든 자식 컴포저블을 리컴포지션
@@ -54,8 +37,6 @@ fun AfternoteTheme(
     isDarkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit,
 ) {
-    // remember는 이미 저장된 값이 있으면 블록을 실행하지 않기 때문에 darkTheme이 적용되지 않는다
-//    val currentColor = remember { if (isDarkTheme) darkColors else colors }
     val currentColor = if (isDarkTheme) darkColors else colors
     // currentColors가 참조하는 원본의 변경에 따른 리컴포지션을 트리거하지 않고, 원본 내부를 update하지 않기 위해서 copy
     // copy를 리컴포지션마다 하지 않기 위해 remember

--- a/core/ui/src/main/kotlin/com/afternote/core/ui/topbar/DetailTopBar.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/topbar/DetailTopBar.kt
@@ -65,7 +65,6 @@ fun DetailTopBar(
         colors =
             TopAppBarDefaults.topAppBarColors(
                 containerColor = AfternoteDesign.colors.gray1,
-//                containerColor = Color.Red,
             ),
     )
 }

--- a/core/ui/src/main/kotlin/com/afternote/core/ui/topbar/TitleTopBar.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/topbar/TitleTopBar.kt
@@ -1,4 +1,4 @@
-package com.afternote.core.ui.scaffold.topbar
+package com.afternote.core.ui.topbar
 
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
@@ -47,7 +47,6 @@ fun TitleTopBar(
         colors =
             TopAppBarDefaults.topAppBarColors(
                 containerColor = AfternoteDesign.colors.gray1,
-//                containerColor = Color.Red,
             ),
     )
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/HomeScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/HomeScreen.kt
@@ -25,9 +25,9 @@ import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.R
 import com.afternote.core.ui.ViewModeSwitcher
 import com.afternote.core.ui.button.FAB.AfternoteFloatingActionButton
-import com.afternote.core.ui.scaffold.topbar.TitleTopBar
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.core.ui.topbar.TitleTopBar
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
 
 @Composable

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/social/KakaoLoginHelper.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/social/KakaoLoginHelper.kt
@@ -18,7 +18,6 @@ import kotlin.coroutines.resume
  * 디바이스에 카카오톡이 설치된 경우 앱 로그인을, 그 외에는 웹 계정 로그인을 수행하며,
  * 앱 로그인이 비정상 종료된 경우에는 웹 계정 로그인으로 폴백한다.
  * 콜백 기반 SDK API를 [suspendCancellableCoroutine]으로 감싸 코루틴 흐름으로 변환한다.
- * +TODO:검토
  */
 
 suspend fun requestKakaoAccessToken(activity: Activity): Result<String> =


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed chore: 점검에서 발견된 소규모 코드 위생 정리 (가시성·패키지 경로·중복·dead 주석) #177

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

**가시성**
- `core/data/.../repoimpl/account/AccountRepositoryImpl.kt:21` — 다른 repoimpl 관례에 맞춰 `val accountApiService` → `private val accountApiService`

**패키지 경로 일치**
- `core/ui/.../topbar/TitleTopBar.kt` — package 선언 `com.afternote.core.ui.scaffold.topbar` → `com.afternote.core.ui.topbar` (파일 위치 + `DetailTopBar` 와 일치)
- `feature/mindrecord/.../HomeScreen.kt` — 위 import 동기화 + ktlint import-ordering 보정

**Dead code 주석 제거**
- `core/ui/theme/Color.kt` — "이전 레포" Purple/Pink 색상 주석 블록 12줄
- `core/ui/theme/Theme.kt` — "기존 버전" `ProvideAfternoteTheme` 주석 블록 14줄 + `remember` dead 1줄 (의미 잃은 "수정된 버전" 라벨 같이 정리)
- `core/ui/theme/AfternoteTypography.kt` — `fedraMonoLight` FontFamily + `fedraMono` TextStyle 주석 블록
- `core/ui/topbar/DetailTopBar.kt`, `TitleTopBar.kt` — `// containerColor = Color.Red` 디버깅 잔재
- `core/ui/bottombar/BottomNavTab.kt` — 죽은 `find` companion object 주석 3줄

**TODO 마커**
- `feature/onboarding/.../KakaoLoginHelper.kt` — docstring 내 `+TODO:검토` 마커

**코드 중복**
- `core/datastore/TokenDataSource.kt` — `updateTokens` 본문이 `saveTokens` 와 토씨 하나 안 틀리고 동일 → `updateTokens` 가 `saveTokens` 위임으로 단축

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 모두 위생 작업.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 이슈 본문에 명시된 항목 위주로 처리. 일부 라인 번호 off-by-one 있어서 명세 위치보다 "주석 처리된 dead code 제거" 의도에 맞춰 정확한 dead 위치만 변경
- 이슈가 언급한 `AuthRepository.saveSession` / `updateTokens` 중복은 호출처 영향 분석이 필요해 이 PR 에서 제외 → 별도 후속 PR 로 처리 예정
- `Color.kt` / `Theme.kt` / `AfternoteTypography.kt` 의 dead 주석은 git history 에 그대로 보존. 필요 시 `git log -p` 로 복구 가능
- 검증: 영향 5개 모듈 (`core/data`, `core/datastore`, `core/ui`, `feature/mindrecord/presentation`, `feature/onboarding/presentation`) compile + ktlint BUILD SUCCESSFUL