### PR TITLE
feat(afternote): receiver-auth API 5건 데이터 레이어 추가 (#187 인프라 단계)

### DIFF
--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/di/AfternoteServiceModule.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/di/AfternoteServiceModule.kt
@@ -3,6 +3,7 @@ package com.afternote.feature.afternote.data.di
 import com.afternote.feature.afternote.data.service.AfternoteApiService
 import com.afternote.feature.afternote.data.service.MusicApiService
 import com.afternote.feature.afternote.data.service.ReceiverAfternoteApiService
+import com.afternote.feature.afternote.data.service.ReceiverAuthApiService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -25,4 +26,8 @@ object AfternoteServiceModule {
     @Singleton
     fun provideReceiverAfternoteApiService(retrofit: Retrofit): ReceiverAfternoteApiService =
         retrofit.create(ReceiverAfternoteApiService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideReceiverAuthApiService(retrofit: Retrofit): ReceiverAuthApiService = retrofit.create(ReceiverAuthApiService::class.java)
 }

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/di/ReceiverAuthRepositoryModule.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/di/ReceiverAuthRepositoryModule.kt
@@ -1,0 +1,17 @@
+package com.afternote.feature.afternote.data.di
+
+import com.afternote.feature.afternote.data.repositoryimpl.receiver.ReceiverAuthRepositoryImpl
+import com.afternote.feature.afternote.domain.repository.receiver.ReceiverAuthRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ReceiverAuthRepositoryModule {
+    @Binds
+    @Singleton
+    abstract fun bindReceiverAuthRepository(impl: ReceiverAuthRepositoryImpl): ReceiverAuthRepository
+}

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/ReceiverAuthDto.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/ReceiverAuthDto.kt
@@ -1,0 +1,89 @@
+package com.afternote.feature.afternote.data.dto
+
+import com.afternote.feature.afternote.domain.model.receiver.DeliveryVerification
+import com.afternote.feature.afternote.domain.model.receiver.DeliveryVerificationStatus
+import com.afternote.feature.afternote.domain.model.receiver.ReceiverAuthPresignedUrl
+import com.afternote.feature.afternote.domain.model.receiver.ReceiverIdentity
+import com.afternote.feature.afternote.domain.model.receiver.SenderMessageInfo
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ReceiverAuthVerifyRequest(
+    @SerialName("authCode") val authCode: String,
+)
+
+@Serializable
+data class ReceiverAuthVerifyResponse(
+    @SerialName("receiverId") val receiverId: Long,
+    @SerialName("receiverName") val receiverName: String,
+    @SerialName("senderName") val senderName: String,
+    @SerialName("relation") val relation: String,
+)
+
+@Serializable
+data class ReceiverAuthPresignedUrlRequest(
+    @SerialName("extension") val extension: String,
+)
+
+@Serializable
+data class ReceiverAuthPresignedUrlResponse(
+    @SerialName("presignedUrl") val presignedUrl: String,
+    @SerialName("fileKey") val fileKey: String,
+    @SerialName("fileUrl") val fileUrl: String,
+    @SerialName("contentType") val contentType: String,
+)
+
+@Serializable
+data class DeliveryVerificationRequest(
+    @SerialName("deathCertificateUrl") val deathCertificateUrl: String,
+    @SerialName("familyRelationCertificateUrl") val familyRelationCertificateUrl: String,
+)
+
+@Serializable
+data class DeliveryVerificationResponse(
+    @SerialName("id") val id: Long,
+    @SerialName("status") val status: String,
+    @SerialName("deathCertificateUrl") val deathCertificateUrl: String? = null,
+    @SerialName("familyRelationCertificateUrl") val familyRelationCertificateUrl: String? = null,
+    @SerialName("adminNote") val adminNote: String? = null,
+    @SerialName("createdAt") val createdAt: String,
+)
+
+@Serializable
+data class ReceiverMessageResponse(
+    @SerialName("senderName") val senderName: String,
+    @SerialName("message") val message: String,
+)
+
+fun ReceiverAuthVerifyResponse.toDomain(): ReceiverIdentity =
+    ReceiverIdentity(
+        receiverId = receiverId,
+        receiverName = receiverName,
+        senderName = senderName,
+        relation = relation,
+    )
+
+fun ReceiverAuthPresignedUrlResponse.toDomain(): ReceiverAuthPresignedUrl =
+    ReceiverAuthPresignedUrl(
+        presignedUrl = presignedUrl,
+        fileKey = fileKey,
+        fileUrl = fileUrl,
+        contentType = contentType,
+    )
+
+fun DeliveryVerificationResponse.toDomain(): DeliveryVerification =
+    DeliveryVerification(
+        id = id,
+        status = DeliveryVerificationStatus.fromRaw(status),
+        deathCertificateUrl = deathCertificateUrl,
+        familyRelationCertificateUrl = familyRelationCertificateUrl,
+        adminNote = adminNote,
+        createdAt = createdAt,
+    )
+
+fun ReceiverMessageResponse.toDomain(): SenderMessageInfo =
+    SenderMessageInfo(
+        senderName = senderName,
+        message = message,
+    )

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImpl.kt
@@ -1,0 +1,57 @@
+package com.afternote.feature.afternote.data.repositoryimpl.receiver
+
+import com.afternote.core.network.model.requireData
+import com.afternote.feature.afternote.data.dto.DeliveryVerificationRequest
+import com.afternote.feature.afternote.data.dto.ReceiverAuthPresignedUrlRequest
+import com.afternote.feature.afternote.data.dto.ReceiverAuthVerifyRequest
+import com.afternote.feature.afternote.data.dto.toDomain
+import com.afternote.feature.afternote.data.service.ReceiverAuthApiService
+import com.afternote.feature.afternote.domain.model.receiver.DeliveryVerification
+import com.afternote.feature.afternote.domain.model.receiver.ReceiverAuthPresignedUrl
+import com.afternote.feature.afternote.domain.model.receiver.ReceiverIdentity
+import com.afternote.feature.afternote.domain.model.receiver.SenderMessageInfo
+import com.afternote.feature.afternote.domain.repository.receiver.ReceiverAuthRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReceiverAuthRepositoryImpl
+    @Inject
+    constructor(
+        private val api: ReceiverAuthApiService,
+    ) : ReceiverAuthRepository {
+        override suspend fun verify(authCode: String): Result<ReceiverIdentity> =
+            runCatching {
+                api.verify(ReceiverAuthVerifyRequest(authCode)).requireData().toDomain()
+            }
+
+        override suspend fun getPresignedUrl(extension: String): Result<ReceiverAuthPresignedUrl> =
+            runCatching {
+                api.getPresignedUrl(ReceiverAuthPresignedUrlRequest(extension)).requireData().toDomain()
+            }
+
+        override suspend fun submitDeliveryVerification(
+            deathCertificateUrl: String,
+            familyRelationCertificateUrl: String,
+        ): Result<DeliveryVerification> =
+            runCatching {
+                api
+                    .submitDeliveryVerification(
+                        DeliveryVerificationRequest(
+                            deathCertificateUrl = deathCertificateUrl,
+                            familyRelationCertificateUrl = familyRelationCertificateUrl,
+                        ),
+                    ).requireData()
+                    .toDomain()
+            }
+
+        override suspend fun getDeliveryVerificationStatus(): Result<DeliveryVerification> =
+            runCatching {
+                api.getDeliveryVerificationStatus().requireData().toDomain()
+            }
+
+        override suspend fun getSenderMessage(): Result<SenderMessageInfo> =
+            runCatching {
+                api.getSenderMessage().requireData().toDomain()
+            }
+    }

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/service/ReceiverAuthApiService.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/service/ReceiverAuthApiService.kt
@@ -1,0 +1,43 @@
+package com.afternote.feature.afternote.data.service
+
+import com.afternote.core.network.model.BaseResponse
+import com.afternote.feature.afternote.data.dto.DeliveryVerificationRequest
+import com.afternote.feature.afternote.data.dto.DeliveryVerificationResponse
+import com.afternote.feature.afternote.data.dto.ReceiverAuthPresignedUrlRequest
+import com.afternote.feature.afternote.data.dto.ReceiverAuthPresignedUrlResponse
+import com.afternote.feature.afternote.data.dto.ReceiverAuthVerifyRequest
+import com.afternote.feature.afternote.data.dto.ReceiverAuthVerifyResponse
+import com.afternote.feature.afternote.data.dto.ReceiverMessageResponse
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+/**
+ * 수신자 인증 흐름 전용 API.
+ *
+ * `verify` 외 모든 endpoint 는 `X-Auth-Code` 헤더가 필요하며
+ * [com.afternote.feature.afternote.data.network.ReceiverAuthInterceptor] 가
+ * 저장된 인증 코드를 자동 부착한다.
+ */
+interface ReceiverAuthApiService {
+    @POST("receiver-auth/verify")
+    suspend fun verify(
+        @Body body: ReceiverAuthVerifyRequest,
+    ): BaseResponse<ReceiverAuthVerifyResponse>
+
+    @POST("receiver-auth/presigned-url")
+    suspend fun getPresignedUrl(
+        @Body body: ReceiverAuthPresignedUrlRequest,
+    ): BaseResponse<ReceiverAuthPresignedUrlResponse>
+
+    @POST("receiver-auth/delivery-verification")
+    suspend fun submitDeliveryVerification(
+        @Body body: DeliveryVerificationRequest,
+    ): BaseResponse<DeliveryVerificationResponse>
+
+    @GET("receiver-auth/delivery-verification/status")
+    suspend fun getDeliveryVerificationStatus(): BaseResponse<DeliveryVerificationResponse>
+
+    @GET("receiver-auth/message")
+    suspend fun getSenderMessage(): BaseResponse<ReceiverMessageResponse>
+}

--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/model/receiver/ReceiverAuthModels.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/model/receiver/ReceiverAuthModels.kt
@@ -1,0 +1,41 @@
+package com.afternote.feature.afternote.domain.model.receiver
+
+data class ReceiverIdentity(
+    val receiverId: Long,
+    val receiverName: String,
+    val senderName: String,
+    val relation: String,
+)
+
+data class ReceiverAuthPresignedUrl(
+    val presignedUrl: String,
+    val fileKey: String,
+    val fileUrl: String,
+    val contentType: String,
+)
+
+data class DeliveryVerification(
+    val id: Long,
+    val status: DeliveryVerificationStatus,
+    val deathCertificateUrl: String?,
+    val familyRelationCertificateUrl: String?,
+    val adminNote: String?,
+    val createdAt: String,
+)
+
+enum class DeliveryVerificationStatus {
+    PENDING,
+    APPROVED,
+    REJECTED,
+    UNKNOWN,
+    ;
+
+    companion object {
+        fun fromRaw(value: String): DeliveryVerificationStatus = entries.firstOrNull { it.name.equals(value, ignoreCase = true) } ?: UNKNOWN
+    }
+}
+
+data class SenderMessageInfo(
+    val senderName: String,
+    val message: String,
+)

--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/repository/receiver/ReceiverAuthRepository.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/repository/receiver/ReceiverAuthRepository.kt
@@ -1,0 +1,31 @@
+package com.afternote.feature.afternote.domain.repository.receiver
+
+import com.afternote.feature.afternote.domain.model.receiver.DeliveryVerification
+import com.afternote.feature.afternote.domain.model.receiver.ReceiverAuthPresignedUrl
+import com.afternote.feature.afternote.domain.model.receiver.ReceiverIdentity
+import com.afternote.feature.afternote.domain.model.receiver.SenderMessageInfo
+
+/**
+ * 수신자 인증 흐름 전용 Repository (`receiver-auth/...` 경로).
+ *
+ * 기존 [ReceiverRepository] 는 인증된 수신자가 사용하는 일반 조회 (after-notes 등) 책임.
+ * 본 Repository 는 인증 자체 + 서류 제출/검증 + sender 메시지 조회를 담당한다.
+ *
+ * 인증 코드 저장은 [ReceiverRepository.saveAuthCode] 를 사용하며,
+ * 저장된 코드는 [com.afternote.feature.afternote.data.network.ReceiverAuthInterceptor] 가
+ * `X-Auth-Code` 헤더로 자동 부착한다.
+ */
+interface ReceiverAuthRepository {
+    suspend fun verify(authCode: String): Result<ReceiverIdentity>
+
+    suspend fun getPresignedUrl(extension: String): Result<ReceiverAuthPresignedUrl>
+
+    suspend fun submitDeliveryVerification(
+        deathCertificateUrl: String,
+        familyRelationCertificateUrl: String,
+    ): Result<DeliveryVerification>
+
+    suspend fun getDeliveryVerificationStatus(): Result<DeliveryVerification>
+
+    suspend fun getSenderMessage(): Result<SenderMessageInfo>
+}


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

refs fix(afternote): receiver-auth 인증/서류/메시지 API 5건 미연동 — 수신자 흐름 핵심 결손 #187 (인프라 단계 부분 처리, 화면 wire-up 후속 PR)

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

#187 인프라 단계 — 데이터 레이어 (ApiService + DTO + 도메인 모델 + Repository) 만 추가. 화면 wire-up 은 후속 PR.

**신규 파일 6개**
- `feature/afternote/data/service/ReceiverAuthApiService.kt` — 5 endpoint (`verify`, `getPresignedUrl`, `submitDeliveryVerification`, `getDeliveryVerificationStatus`, `getSenderMessage`)
- `feature/afternote/data/dto/ReceiverAuthDto.kt` — 7 DTO (request·response) + 4 `toDomain()` extension (단순 매핑이라 별도 mapper 파일 미신설)
- `feature/afternote/domain/model/receiver/ReceiverAuthModels.kt` — 도메인 모델 4개 (`ReceiverIdentity`, `ReceiverAuthPresignedUrl`, `DeliveryVerification`, `SenderMessageInfo`) + `DeliveryVerificationStatus` enum (`fromRaw` 로 unknown 처리)
- `feature/afternote/domain/repository/receiver/ReceiverAuthRepository.kt` — interface
- `feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImpl.kt` — `runCatching { api.X().requireData().toDomain() }` 패턴
- `feature/afternote/data/di/ReceiverAuthRepositoryModule.kt` — Hilt `@Binds`

**수정 1개**
- `feature/afternote/data/di/AfternoteServiceModule.kt` — `provideReceiverAuthApiService` 추가

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 데이터 레이어 인프라.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

**설계 결정**
- 기존 `ReceiverRepository` 와 분리해 새 `ReceiverAuthRepository` 신설 — `ReceiverRepository.kt`/`ReceiverRepositoryImpl.kt` (PR [#127](https://github.com/Afternote/Afternote-FE/pull/127) 변경 파일) 무접촉으로 충돌 회피
- 도메인 모델 `SenderMessageInfo` 명명 — `app/.../ReceiverHomeUiState.kt` 의 기존 `SenderMessage` 와 혼동 회피 (향후 `loadSenderMessage()` stub 제거하며 정리될 부분)
- 인증 코드 저장은 기존 `ReceiverRepository.saveAuthCode` 활용 (분리 안 함). `ReceiverAuthInterceptor` 가 `/receiver-auth/` 경로에 `X-Auth-Code` 헤더 자동 부착하는 기존 인프라 그대로 활용
- UseCase 미신설 — 화면 wire-up 시 결정 (Repository 직접 호출 vs UseCase 경유)

**별개 발견 → 별도 이슈로 분리**
- `core/network/dto/PresignedUrlDto.kt` 의 `PresignedUrlResponseDto` 가 Swagger spec 의 `fileKey` 필드 누락. `receiver-auth/presigned-url` 응답도 같은 4개 필드라 본 PR 의 `ReceiverAuthPresignedUrlResponse` 는 처음부터 fileKey 포함. → #191 에서 트래킹

**후속 작업** (별도 PR, PR [#127](https://github.com/Afternote/Afternote-FE/pull/127) 머지 후)
- `verify` 진입 (인증코드 입력 화면) → 성공 시 `ReceiverRepository.saveAuthCode` 저장 → 이후 호출은 인터셉터 자동 처리
- 서류 업로드 화면 (`/receiver-auth/presigned-url` + S3 PUT + `/receiver-auth/delivery-verification`)
- 검증 상태 폴링 화면 (`/receiver-auth/delivery-verification/status`)
- sender 메시지 표시 — #164 의 `senderMessage` 빈 문자열 해결과 직접 연결 (`app/.../ReceiverHomeViewModel.loadSenderMessage()` stub 제거 + 본 PR 의 `ReceiverAuthRepository.getSenderMessage()` 활용)

**검증**
- `:feature:afternote:data:compileDebugKotlin` + `:feature:afternote:domain:compileDebugKotlin` + 양쪽 `ktlintCheck` BUILD SUCCESSFUL