### PR TITLE
fix(core): PresignedUrlResponseDto 에 fileKey 필드 추가 — Swagger spec 동기화

### DIFF
--- a/core/network/src/main/kotlin/com/afternote/core/network/dto/PresignedUrlDto.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/dto/PresignedUrlDto.kt
@@ -11,6 +11,7 @@ data class PresignedUrlRequestDto(
 @Serializable
 data class PresignedUrlResponseDto(
     val presignedUrl: String,
+    val fileKey: String,
     val fileUrl: String,
     val contentType: String,
 )


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed fix(core): PresignedUrlResponseDto 에 fileKey 필드 누락 — S3 업로드 후 파일 식별 불가 #191

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `core/network/dto/PresignedUrlDto.kt` — `PresignedUrlResponseDto` 에 `val fileKey: String` 한 줄 추가
- 필드 순서는 Swagger spec 의 `presignedUrl`, `fileKey`, `fileUrl`, `contentType` 를 따름

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 데이터 모델 동기화.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 호출처 (`PhotoUploadRepositoryImpl`, `MemorialVideoUploadRepositoryImpl`, `MemorialThumbnailUploadRepositoryImpl`) 는 모두 현재 `presigned.fileUrl` 만 활용 — 본 PR 에서는 손대지 않음
- `fileKey` 가 backend 에 전달되어야 하는 흐름 (예: 명시적 파일 식별) 이 필요하면 별도 PR 에서 호출처도 수정
- 인접 PR [#192](https://github.com/Afternote/Afternote-FE/pull/192) (`receiver-auth` API 5건 데이터 레이어) 의 `ReceiverAuthPresignedUrlResponse` 는 처음부터 `fileKey` 포함해서 정의 — 동일한 spec 준수
- 백엔드 의존 아님 — Swagger spec 에 이미 명세됨
- 검증: `:core:network:compileDebugKotlin` + `:core:network:ktlintCheck` + 의존 모듈 (`core/data`, `feature/afternote/data`) compile BUILD SUCCESSFUL