### PR TITLE
feat(afternote): 카테고리별 actions prefill 템플릿 추가 (#189 — SOCIAL/GALLERY 부분)

### DIFF
--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/processing/AfternoteActionsTemplate.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/processing/AfternoteActionsTemplate.kt
@@ -1,0 +1,39 @@
+package com.afternote.feature.afternote.presentation.author.editor.processing
+
+import androidx.annotation.StringRes
+import com.afternote.feature.afternote.presentation.R
+import com.afternote.feature.afternote.presentation.author.editor.model.EditorCategory
+import com.afternote.feature.afternote.presentation.author.editor.processing.AfternoteActionsTemplate.defaultsFor
+
+/**
+ * 카테고리별 추천 처리 방법(actions) 템플릿. 에디터 진입 시 prefill 용도.
+ *
+ * 사용자는 항목을 자유롭게 수정·삭제·추가할 수 있고, 저장 시 현재 값이 그대로 서버 `actions` 로 전송된다.
+ * 서버는 예시 생성 로직이 없으므로 클라이언트가 책임진다.
+ *
+ * [defaultsFor] 는 `stringRes` ID 리스트를 반환하며, 호출처(@Composable)에서 `stringResource(id)` 로 i18n 해석한다.
+ */
+object AfternoteActionsTemplate {
+    @StringRes
+    fun defaultsFor(category: EditorCategory): List<Int> =
+        when (category) {
+            EditorCategory.SOCIAL -> {
+                listOf(
+                    R.string.afternote_editor_actions_social_remove_post,
+                    R.string.afternote_editor_actions_social_post_memorial,
+                    R.string.afternote_editor_actions_social_switch_memorial_account,
+                )
+            }
+
+            EditorCategory.GALLERY -> {
+                listOf(
+                    R.string.afternote_editor_actions_gallery_send_folder,
+                    R.string.afternote_editor_actions_gallery_delete_folder,
+                )
+            }
+
+            EditorCategory.MEMORIAL -> {
+                emptyList()
+            }
+        }
+}

--- a/feature/afternote/presentation/src/main/res/values/strings.xml
+++ b/feature/afternote/presentation/src/main/res/values/strings.xml
@@ -86,6 +86,12 @@
     <string name="afternote_editor_category_social">소셜네트워크</string>
     <string name="afternote_editor_category_gallery">갤러리 및 파일</string>
     <string name="afternote_editor_category_memorial">추모 가이드라인</string>
+    <!-- Afternote editor (author) — actions prefill 템플릿 (디자인 의도: 사용자가 카테고리 선택 시 예시 노출 후 자유 수정) -->
+    <string name="afternote_editor_actions_social_remove_post">게시물 내리기</string>
+    <string name="afternote_editor_actions_social_post_memorial">추모 게시물 올리기</string>
+    <string name="afternote_editor_actions_social_switch_memorial_account">추모 계정으로 전환하기</string>
+    <string name="afternote_editor_actions_gallery_send_folder">\'엽사\' 폴더 박선호에게 전송</string>
+    <string name="afternote_editor_actions_gallery_delete_folder">\'흑역사\' 폴더 삭제</string>
 
     <string name="afternote_editor_label_account_info">계정 정보</string>
     <string name="afternote_editor_label_account_process_method">계정 처리 방법</string>


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

refs feat(afternote): 처리 방법(actions) 예시를 프론트에서 카테고리별 생성 + 서버 전송 #189 (SOCIAL/GALLERY 부분 처리, BUSINESS/ESTATE 는 #195 후속)

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

#189 의 actions 템플릿만 정의. wire-up 은 후속 PR. 디자인 협조로 받은 카테고리별 예시 문구 반영.

**신규 파일 1개**
- `feature/afternote/presentation/.../editor/processing/AfternoteActionsTemplate.kt` — `EditorCategory` 별 `@StringRes List<Int>` prefill 템플릿
  - `SOCIAL` → 게시물 내리기 / 추모 게시물 올리기 / 추모 계정으로 전환하기
  - `GALLERY` → \'엽사\' 폴더 박선호에게 전송 / \'흑역사\' 폴더 삭제
  - `MEMORIAL` → 빈 리스트

**수정 1개**
- `feature/afternote/presentation/src/main/res/values/strings.xml` — 5개 키 추가 (SOCIAL 3 + GALLERY 2)

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 (호출처 wire-up 없음). 디자인 의도 시안:
- 소셜 네트워크 → 게시물 내리기 / 추모 게시물 올리기 / 추모 계정으로 전환하기
- 갤러리 및 파일 → \'엽사\' 폴더 박선호에게 전송 / \'흑역사\' 폴더 삭제

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

**범위 재정의**
- 처음 `EditorCategory` enum 에 `BUSINESS`/`ESTATE` 추가 시도 → `when` 사용처 4곳 (`AfternoteEditorFormMapper`, `AfternoteEditorContent`, `AfternoteEditorValidator`, `EditorComposeStrings`) 모두 분기 추가 필요 + `AfternoteEditorFormMapper` 는 PR [#127](https://github.com/Afternote/Afternote-FE/pull/127) 충돌 → 비용 과대
- 본 PR 은 actions 템플릿 신규 파일 + strings (SOCIAL/GALLERY) 만 추가. BUSINESS/ESTATE 카테고리 자체 추가는 #195 로 분리

**설계 결정**
- 매핑 키는 `AfternoteCategory` (필터용) 가 아닌 `EditorCategory` (작성용) — actions 는 작성 시 prefill 이라 자연스러움
- 반환 타입 `List<Int>` (`@StringRes`) — 호출처(@Composable) 에서 `stringResource()` 로 i18n 해석
- 위치 `editor/processing/` — `ProcessingMethodList` 등 기존 actions 입력 UI 와 같은 위치
- mock fixture (`AfternoteMockFixtures.kt`) 의 기존 문구와 일치 확인됨

**후속 작업** (별도 PR, PR [#127](https://github.com/Afternote/Afternote-FE/pull/127) 머지 후)
- `AfternoteEditorFormMapper` 에서 신규 작성 진입 시 `AfternoteActionsTemplate.defaultsFor(category)` 호출 → form prefill 또는 placeholder. 수정 진입 시 기존 actions 우선 (예시로 덮어쓰지 않기)
- BUSINESS/ESTATE 카테고리 추가 (#195) + BUSINESS actions 키 (자동 응답 설정 / 메일함 데이터 백업 / 중요 메일 전달) 도 본 PR 머지 후 #195 작업에서 추가

**검증**
- `:feature:afternote:presentation:compileDebugKotlin` + `ktlintCheck` BUILD SUCCESSFUL