### PR TITLE
refactor(afternote): Detail 이 Editor 모델 직접 참조 제거 — shared/model 로 매핑 추출 (#176)

### DIFF
--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/detail/AfternoteDetailSuccessMapper.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/detail/AfternoteDetailSuccessMapper.kt
@@ -4,27 +4,12 @@ import com.afternote.core.model.AlbumCover
 import com.afternote.feature.afternote.domain.AfternoteServiceType
 import com.afternote.feature.afternote.domain.model.author.Detail
 import com.afternote.feature.afternote.presentation.author.detail.socialnetwork.SocialNetworkDetailContent
-import com.afternote.feature.afternote.presentation.author.editor.model.InformationProcessingMethod
-import com.afternote.feature.afternote.presentation.author.editor.processing.model.AccountProcessingMethod
 import com.afternote.feature.afternote.presentation.shared.model.ReceiverUiModel
+import com.afternote.feature.afternote.presentation.shared.model.mapProcessMethodLabel
 
 /** 상세 화면에 쓰는 "최종 작성일": 갱신일이 있으면 그것, 공백이면 생성일. */
 private val Detail.finalWriteDate: String
     get() = timestamps.updatedAt.ifBlank { timestamps.createdAt }
-
-/**
- * 서버가 내려주는 `processMethod` enum 문자열을 사용자 표시 라벨로 변환한다.
- * 매핑되지 않은 값은 raw 문자열을 그대로 반환해 호환성을 유지한다.
- */
-private fun mapProcessMethodLabel(serverValue: String): String =
-    when (serverValue) {
-        "MEMORIAL" -> AccountProcessingMethod.MEMORIAL_ACCOUNT.title
-        "TRANSFER" -> AccountProcessingMethod.TRANSFER_TO_RECEIVER.title
-        "PERMANENT_DELETE" -> AccountProcessingMethod.PERMANENT_DELETE.title
-        "TRANSFER_TO_AFTERNOTE_EDIT_RECEIVER" -> InformationProcessingMethod.TRANSFER_TO_AFTERNOTE_EDIT_RECEIVER.title
-        "TRANSFER_TO_ADDITIONAL_AFTERNOTE_EDIT_RECEIVER" -> InformationProcessingMethod.TRANSFER_TO_ADDITIONAL_AFTERNOTE_EDIT_RECEIVER.title
-        else -> serverValue
-    }
 
 internal fun Detail.toReceiverUiModels(): List<ReceiverUiModel> =
     receivers.mapIndexed { index, r ->

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/detail/ReceivedAfternoteDetailSuccessMapper.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/detail/ReceivedAfternoteDetailSuccessMapper.kt
@@ -2,24 +2,7 @@ package com.afternote.feature.afternote.presentation.receiver.detail
 
 import com.afternote.feature.afternote.domain.AfternoteServiceType
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedAfternoteDetail
-import com.afternote.feature.afternote.presentation.author.editor.model.InformationProcessingMethod
-import com.afternote.feature.afternote.presentation.author.editor.processing.model.AccountProcessingMethod
-
-/**
- * 서버 `processMethod` enum 문자열 → 사용자 표시 라벨.
- *
- * 발신자 상세 매퍼([com.afternote.feature.afternote.presentation.author.detail.AfternoteDetailSuccessMapper])
- * 와 동일한 규칙. 향후 공용 매퍼로 추출 검토.
- */
-private fun mapProcessMethodLabel(serverValue: String): String =
-    when (serverValue) {
-        "MEMORIAL" -> AccountProcessingMethod.MEMORIAL_ACCOUNT.title
-        "TRANSFER" -> AccountProcessingMethod.TRANSFER_TO_RECEIVER.title
-        "PERMANENT_DELETE" -> AccountProcessingMethod.PERMANENT_DELETE.title
-        "TRANSFER_TO_AFTERNOTE_EDIT_RECEIVER" -> InformationProcessingMethod.TRANSFER_TO_AFTERNOTE_EDIT_RECEIVER.title
-        "TRANSFER_TO_ADDITIONAL_AFTERNOTE_EDIT_RECEIVER" -> InformationProcessingMethod.TRANSFER_TO_ADDITIONAL_AFTERNOTE_EDIT_RECEIVER.title
-        else -> serverValue
-    }
+import com.afternote.feature.afternote.presentation.shared.model.mapProcessMethodLabel
 
 internal fun ReceivedAfternoteDetail.toReceivedDetailContentUiModel(): ReceivedDetailContentUiModel =
     when (type) {

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/shared/model/ProcessMethodLabel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/shared/model/ProcessMethodLabel.kt
@@ -1,0 +1,23 @@
+package com.afternote.feature.afternote.presentation.shared.model
+
+/**
+ * 서버 `processMethod` enum 문자열 → 사용자 표시 라벨.
+ *
+ * 발신자/수신자 Detail 매퍼 공용. 메모리 룰 [Detail screen UI models] 적용 —
+ * Detail 은 Editor 측 enum (`InformationProcessingMethod`, `AccountProcessingMethod`) 을
+ * 직접 import 하지 않고 본 공용 매퍼만 호출한다.
+ *
+ * 라벨 문자열은 Editor enum 의 `.title` 과 동일하게 유지되어야 한다 (단일 source of truth 정리는
+ * `#190` processMethod 통합 작업에서 진행 예정).
+ *
+ * 매핑되지 않은 값은 raw 문자열을 그대로 반환해 호환성을 유지한다.
+ */
+fun mapProcessMethodLabel(serverValue: String): String =
+    when (serverValue) {
+        "MEMORIAL" -> "추모 계정으로 전환"
+        "TRANSFER" -> "수신자에게 정보 전달"
+        "PERMANENT_DELETE" -> "계정 영구 삭제"
+        "TRANSFER_TO_AFTERNOTE_EDIT_RECEIVER" -> "수신자에게 정보 전달"
+        "TRANSFER_TO_ADDITIONAL_AFTERNOTE_EDIT_RECEIVER" -> "추가 수신자에게 정보 전달"
+        else -> serverValue
+    }


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed refactor(afternote): Detail 이 Editor 모델 직접 import — shared/model 로 공용 라벨/enum 추출 #176

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

메모리 룰 [Detail screen UI models] 적용 — Detail 화면은 Editor 모델을 직접 참조 금지. shared/model 에 공용 매퍼 추출.

**신규 파일 1개**
- `feature/afternote/presentation/.../shared/model/ProcessMethodLabel.kt` — 공용 top-level 함수 `mapProcessMethodLabel(serverValue: String): String`. 서버 `processMethod` enum 문자열을 사용자 표시 라벨로 변환. 라벨 문자열은 Editor enum 의 `.title` 과 동일하게 hardcoded

**수정 2개**
- `feature/afternote/presentation/.../author/detail/AfternoteDetailSuccessMapper.kt`
  - import 제거: `editor.model.InformationProcessingMethod`, `editor.processing.model.AccountProcessingMethod`
  - private `mapProcessMethodLabel` 함수 제거 → 공용 함수 import
- `feature/afternote/presentation/.../receiver/detail/ReceivedAfternoteDetailSuccessMapper.kt` — 동일

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 매핑 결과 문자열 동일.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

**Stack 정보**
- 본 PR 의 base 는 `feat/126` (PR [#127](https://github.com/Afternote/Afternote-FE/pull/127)). PR #127 가 receiver detail mapper (`ReceivedAfternoteDetailSuccessMapper.kt`) 를 변경하므로 그 변경 위에서 stack 진행
- PR #127 머지 시 본 PR base 를 `develop` 으로 변경 (rebase 필요)

**설계 결정**
- 매핑 결과 라벨은 한국어 hardcoded — mapper 가 non-Composable 이라 `stringResource` 못 씀. i18n 추출은 #170 작업
- 단일 source of truth (Editor enum 폐기 + shared enum 통합) 는 작업 큼 + 다수 사용처 영향 → #190 작업으로 분리

**임시 정리 성격**
- `processMethod` 필드 자체가 #190 (`processMethod` → `actions` 통합) 작업에서 폐기 예정 → 본 PR 의 `mapProcessMethodLabel` 함수 + `ProcessMethodLabel.kt` 파일도 **#190 머지 시 dead 가 되어 같이 제거**
- 그 사이 (#190 머지까지) Detail 이 Editor 에 결합된 상태로 두지 않기 위한 단기 정리

**검증**
- `:feature:afternote:presentation:compileDebugKotlin` + `ktlintCheck` BUILD SUCCESSFUL