### PR TITLE
chore(onboarding): strings.xml 미사용 키 2개 제거 (#185)

### DIFF
--- a/feature/onboarding/presentation/src/main/res/values/strings.xml
+++ b/feature/onboarding/presentation/src/main/res/values/strings.xml
@@ -33,13 +33,11 @@
     <string name="signup_resident_number_label">주민등록번호</string>
     <string name="signup_resident_number_placeholder">주민등록번호</string>
     <string name="signup_resident_number_back_placeholder">0</string>
-    <string name="signup_resident_number_mask">\u0020●●●●●●</string>
     <string name="signup_password_input_label">비밀번호 입력</string>
     <string name="signup_password_confirm_placeholder">비밀번호 확인</string>
     <string name="signup_password_rule_combination">8 ~ 16자의 영문 대소문자, 숫자, 특수문자를 조합하여 설정해 주세요.</string>
     <string name="signup_password_rule_reuse">이전에 사용한 적 없는 비밀번호가 안전합니다.</string>
 
-    <string name="terms_top_bar_title">타임레터</string>
     <string name="terms_welcome">환영합니다!</string>
     <string name="terms_description">애프터노트와 함께\n당신의 마지막을 준비하세요.</string>
     <string name="terms_agree_all">약관에 전체동의</string>


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed chore: onboarding/res/strings.xml 미사용 키 제거 (#171 후속) #185

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

`feature/onboarding/presentation/src/main/res/values/strings.xml` 에서 외부 참조 0건 확인 후 미사용 키 2개 제거.

- `terms_top_bar_title` — 어디서도 사용되지 않음 + 내용도 `"타임레터"` 로 잘못
- `signup_resident_number_mask` — 어디서도 사용되지 않음

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — dead key 제거.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

**Stack 정보**
- 본 PR base 는 `fix/141` (PR [#144](https://github.com/Afternote/Afternote-FE/pull/144)). PR #144 가 같은 `strings.xml` 을 변경하므로 그 위에 stack
- PR #145 (`fix/143`) 는 `strings.xml` 미접촉이라 별도 stack 단계 추가 안 함
- PR #144 머지 시 본 PR base 를 `develop` 으로 rebase 필요

**Verify**
- `rg "terms_top_bar_title|signup_resident_number_mask" -g "!**/build/**"` → strings.xml 만, 호출처 0건
- `:feature:onboarding:presentation:compileDebugKotlin` + `ktlintCheck` BUILD SUCCESSFUL (3s)