### PR TITLE
fix(onboarding): OnboardingProfileScreen 의 IME Done 가드 누락 보완 (#174)

### DIFF
--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/OnboardingProfileScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/OnboardingProfileScreen.kt
@@ -108,21 +108,22 @@ fun OnboardingProfileScreen(
                     displayImageUri = displayImageUri?.toString(),
                 )
 
+                val isNameProvided =
+                    nameState.text
+                        .toString()
+                        .trim()
+                        .isNotEmpty()
+
                 AfternoteTextField(
                     state = nameState,
                     placeholder = stringResource(R.string.profile_name_placeholder),
                     imeAction = ImeAction.Done,
                     onImeAction = {
                         focusManager.clearFocus()
-                        onCompleteClick()
+                        if (isNameProvided) onCompleteClick()
                     },
                 )
 
-                val isNameProvided =
-                    nameState.text
-                        .toString()
-                        .trim()
-                        .isNotEmpty()
                 AfternoteButton(
                     text = stringResource(R.string.profile_complete),
                     onClick = {


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed fix(onboarding): OnboardingProfileScreen 의 IME Done 가드 누락 #174

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

`feature/onboarding/presentation/.../OnboardingProfileScreen.kt` 의 이름 입력 필드 `onImeAction` 람다에 `isNameProvided` 가드 추가. PR [#144](https://github.com/Afternote/Afternote-FE/pull/144) 의 SignUp Step 1~3 IME 가드 패턴 (`if (isNextEnabled) onNextClick()`) 과 일관성 정리.

**Before**
```kotlin
onImeAction = {
    focusManager.clearFocus()
    onCompleteClick()   // 이름 빈 값 가드 없이 무조건 호출
}
```

**After**
```kotlin
val isNameProvided = nameState.text.toString().trim().isNotEmpty()  // TextField 위로 이동
...
onImeAction = {
    focusManager.clearFocus()
    if (isNameProvided) onCompleteClick()
}
```

`isNameProvided` 산출을 `AfternoteTextField` 호출 위로 이동해서 람다에서 접근 가능하게 변경. `AfternoteButton` 의 `type` 토글에서도 같은 변수 재활용.

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

- Before: 이름 빈 상태에서 IME Done 누르면 ViewModel 내부 가드가 차단 후 Snackbar 노출 → 버튼 disable 됐는데 에러 메시지 뜨는 어색한 UX
- After: 빈 이름에서 IME Done 누르면 아무 일 안 일어남 (Step 1~3 패턴과 동일)

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

**Stack 정보**
- 본 PR base 는 `fix/141` (PR [#144](https://github.com/Afternote/Afternote-FE/pull/144)). PR #144 가 `OnboardingProfileScreen.kt` 를 변경하므로 그 위에 stack
- PR #144 머지 시 본 PR base 를 `develop` 으로 rebase 필요

**범위 한정**
- 이슈 본문의 IME 가드만 처리. `AfternoteButton.onClick` 도 이론상 같은 어색한 UX 가능성이 있지만 버튼 disable 시각화로 사용자 행동 차단되는 패턴 — 이슈 범위 외라 손대지 않음

**검증**
- `:feature:onboarding:presentation:compileDebugKotlin` + `ktlintCheck` BUILD SUCCESSFUL (7s)