### PR TITLE
feat(home): ReceiverHomeViewModel awaitAll 부분 폴백 정책 (#175 부분)

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeViewModel.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeViewModel.kt
@@ -8,11 +8,11 @@ import com.afternote.afternote_fe.screen.receiver.model.ReceiverDownloadState
 import com.afternote.afternote_fe.screen.receiver.model.ReceiverHomeUiState
 import com.afternote.afternote_fe.screen.receiver.model.SenderMessage
 import com.afternote.feature.afternote.domain.model.receiver.AfterNoteListItemDto
+import com.afternote.feature.afternote.domain.model.receiver.AfterNotesListResult
 import com.afternote.feature.afternote.domain.repository.receiver.ReceiverRepository
 import com.afternote.feature.afternote.presentation.shared.util.getAfternoteDisplayRes
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -56,16 +56,29 @@ class ReceiverHomeViewModel
                 val mindRecords = async { receiverRepository.loadMindRecordsCount() }
                 val timeLetters = async { receiverRepository.loadTimeLettersCount() }
                 val message = async { receiverRepository.loadSenderMessage() }
-                awaitAll(afternotes, mindRecords, timeLetters, message)
+                val afternotesRes = afternotes.await()
+                val mindRecordsRes = mindRecords.await()
+                val timeLettersRes = timeLetters.await()
+                val messageRes = message.await()
+
+                // 모든 호출이 실패한 경우만 Error. 일부 실패는 fallback 으로 진행.
+                if (afternotesRes.isFailure &&
+                    mindRecordsRes.isFailure &&
+                    timeLettersRes.isFailure &&
+                    messageRes.isFailure
+                ) {
+                    _uiState.value =
+                        ReceiverHomeUiState.Error(
+                            afternotesRes.exceptionOrNull() ?: RuntimeException("All home requests failed"),
+                        )
+                    return@launch
+                }
 
                 val afternotesResult =
-                    afternotes.await().getOrElse {
-                        _uiState.value = ReceiverHomeUiState.Error(it)
-                        return@launch
-                    }
-                val mindRecordsCount = mindRecords.await().getOrNull()?.totalCount ?: 0
-                val timeLettersCount = timeLetters.await().getOrNull()?.totalCount ?: 0
-                val senderMessageBody = message.await().getOrNull()?.takeIf { it.isNotBlank() }
+                    afternotesRes.getOrNull() ?: AfterNotesListResult(items = emptyList(), totalCount = 0)
+                val mindRecordsCount = mindRecordsRes.getOrNull()?.totalCount ?: 0
+                val timeLettersCount = timeLettersRes.getOrNull()?.totalCount ?: 0
+                val senderMessageBody = messageRes.getOrNull()?.takeIf { it.isNotBlank() }
 
                 _uiState.value =
                     ReceiverHomeUiState.Success(


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

refs feat(home): ReceiverHomeUiState.Loading placeholder + ReceiverHomeViewModel.awaitAll 폴백 정책 정리 #175 (폴백만, Loading placeholder 보류)

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

수신자 홈의 awaitAll 폴백 정책 변경 + 잉여 코드 정리.

**수정 1개**
- `app/.../screen/receiver/ReceiverHomeViewModel.kt`
  - `loadHome()` 폴백 정책 변경:
    - Before: `afternotes` 첫 실패 시 전체 Error
    - After: 4개 호출 결과 모두 받아서 **모두 실패한 경우만 Error**, 그 외엔 각 호출 결과 `getOrNull()` + fallback (`afternotesResult = AfterNotesListResult(emptyList(), 0)`)
  - 잉여 `awaitAll(afternotes, mindRecords, timeLetters, message)` 한 줄 제거 + `import kotlinx.coroutines.awaitAll` 제거. 각 `.await()` 자체가 자연 barrier 역할 — 첫 `.await()` 가 가장 느린 호출을 기다리고, 나머지는 이미 완료된 결과 즉시 반환

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 (Loading 분기 자체는 동일). 폴백 정책 변경으로:
- 일부 호출 실패 시 → 빈 데이터로 fallback 후 정상 Success 화면 (Error 화면 안 뜸)
- 4개 모두 실패 시에만 Error 화면

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

**Stack 정보**
- base = `feat/126` (PR [#127](https://github.com/Afternote/Afternote-FE/pull/127)). PR #127 가 `app/.../ReceiverHomeViewModel.kt` 를 변경하므로 그 위에 stack
- PR #127 머지 시 본 PR base 를 `develop` 으로 rebase 필요

**범위 한정**
- Loading placeholder 디자인은 미정 (skeleton vs cachedUserName 즉시 표시 vs 빈 화면) — 본 PR 에서는 손대지 않음. 폴백 정책 변경으로 Loading 진입 빈도 감소 (일부 호출 실패도 Success 로 처리됨)
- HomeTab 의 `GetHomeSummaryUseCase` 부분 폴백 패턴과 일관

**검증**
- `:app:compileDebugKotlin` + `ktlintCheck` BUILD SUCCESSFUL