### PR TITLE
refactor(onboarding): Login* 한국어 메시지 strings.xml 추출 (#170 부분)

### DIFF
--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginEntry.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginEntry.kt
@@ -10,12 +10,14 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
 import androidx.credentials.CredentialManager
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.ObserveAsEvents
 import com.afternote.core.ui.findActivity
 import com.afternote.feature.onboarding.presentation.BuildConfig
+import com.afternote.feature.onboarding.presentation.R
 import com.afternote.feature.onboarding.presentation.login.social.UserCancelledAuthException
 import com.afternote.feature.onboarding.presentation.login.social.requestGoogleIdToken
 import com.afternote.feature.onboarding.presentation.login.social.requestKakaoAccessToken
@@ -44,6 +46,11 @@ fun LoginEntry(
     val context = LocalContext.current
     val credentialManager = remember(context) { CredentialManager.create(context) }
 
+    val loginFailedMessage = stringResource(R.string.login_failed)
+    val kakaoFailedMessage = stringResource(R.string.login_kakao_failed)
+    val googleFailedMessage = stringResource(R.string.login_google_failed)
+    val screenUnavailableMessage = stringResource(R.string.login_screen_unavailable)
+
     val showErrorSnackbar: (String) -> Unit = { message ->
         coroutineScope.launch {
             snackbarHostState.showSnackbar(
@@ -61,7 +68,7 @@ fun LoginEntry(
     ObserveAsEvents(viewModel.eventFlow) { event ->
         when (event) {
             is LoginEvent.LoginSuccess -> onLoginSuccess()
-            is LoginEvent.ShowError -> showErrorSnackbar(event.message)
+            is LoginEvent.ShowError -> showErrorSnackbar(event.message ?: loginFailedMessage)
         }
     }
 
@@ -80,11 +87,11 @@ fun LoginEntry(
                                 viewModel.loginWithKakao(oauthToken)
                             }.onFailure { exception ->
                                 if (exception is UserCancelledAuthException) return@onFailure
-                                showErrorSnackbar(exception.message ?: "카카오 로그인에 실패했습니다.")
+                                showErrorSnackbar(exception.message ?: kakaoFailedMessage)
                             }
                     }
                 } else {
-                    showErrorSnackbar("로그인 화면을 띄울 수 없습니다.")
+                    showErrorSnackbar(screenUnavailableMessage)
                 }
             }
         },
@@ -99,7 +106,7 @@ fun LoginEntry(
                         viewModel.loginWithGoogle(idToken)
                     }.onFailure { exception ->
                         if (exception is UserCancelledAuthException) return@onFailure
-                        showErrorSnackbar(exception.message ?: "구글 로그인에 실패했습니다.")
+                        showErrorSnackbar(exception.message ?: googleFailedMessage)
                     }
                 }
             }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginEvent.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginEvent.kt
@@ -9,6 +9,6 @@ sealed interface LoginEvent {
     data object LoginSuccess : LoginEvent
 
     data class ShowError(
-        val message: String,
+        val message: String?,
     ) : LoginEvent
 }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginScreen.kt
@@ -261,7 +261,7 @@ private fun SocialLoginGroup(
             ) {
                 Image(
                     painter = painterResource(com.afternote.core.ui.R.drawable.core_ui_img_google_logo),
-                    contentDescription = "구글 로그인",
+                    contentDescription = stringResource(R.string.content_description_google_login),
                     modifier = Modifier.size(20.dp),
                 )
             }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginViewModel.kt
@@ -59,7 +59,7 @@ class LoginViewModel
                         eventChannel.send(LoginEvent.LoginSuccess)
                     }.onFailure { exception ->
                         eventChannel.send(
-                            LoginEvent.ShowError(exception.message ?: "로그인 실패"),
+                            LoginEvent.ShowError(exception.message),
                         )
                     }
             }

--- a/feature/onboarding/presentation/src/main/res/values/strings.xml
+++ b/feature/onboarding/presentation/src/main/res/values/strings.xml
@@ -18,6 +18,11 @@
     <string name="login_google">Google 계정으로 로그인</string>
     <string name="login_find_account">아이디/비밀번호 찾기</string>
     <string name="login_find_account_message">아이디/비밀번호 찾기의 경우,\n고객센터로 문의 바랍니다.</string>
+    <string name="login_failed">로그인 실패</string>
+    <string name="login_kakao_failed">카카오 로그인에 실패했습니다.</string>
+    <string name="login_google_failed">구글 로그인에 실패했습니다.</string>
+    <string name="login_screen_unavailable">로그인 화면을 띄울 수 없습니다.</string>
+    <string name="content_description_google_login">구글 로그인</string>
 
     <string name="onboarding_step_description">회원가입 진행도 4단계 중 %1$d단계</string>
 


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

refs chore: 한국어 하드코딩 메시지 strings.xml 일괄 추출 (i18n) #170 (Login 영역만, SignUp/Memorial 은 후속 PR)

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

#170 의 Login 영역 (develop 베이스) 만 처리. SignUp (PR #144 stack), Memorial domain (PR #127 stack) 은 후속 분리.

**신규 strings.xml 키 5개**
- `login_failed` — "로그인 실패"
- `login_kakao_failed` — "카카오 로그인에 실패했습니다."
- `login_google_failed` — "구글 로그인에 실패했습니다."
- `login_screen_unavailable` — "로그인 화면을 띄울 수 없습니다."
- `content_description_google_login` — "구글 로그인"

**수정**
- `LoginEvent.kt` — `ShowError(message: String?)` nullable 변경 (ViewModel 이 raw exception.message 전달, UI 가 fallback stringResource 적용)
- `LoginViewModel.kt` — `"로그인 실패"` hardcode 제거 → `exception.message` 그대로 전달
- `LoginEntry.kt` — Composable scope 에서 stringResource 4개 capture → 람다 / ObserveAsEvents 안에서 fallback 으로 사용
- `LoginScreen.kt:264` — `contentDescription = "구글 로그인"` → `stringResource(R.string.content_description_google_login)`

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 메시지 내용 동일, strings.xml 로 위치 이동.

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

**범위 분리**
- 본 PR: Login 영역 (develop 베이스). 다른 PR 과 충돌 없음
- 후속 PR (분리 예정):
  - `SignUpViewModel.kt` 6곳 한국어 메시지 — PR [#144](https://github.com/Afternote/Afternote-FE/pull/144) stack
  - `MemorialVideoSaveException` / `MemorialPhotoSaveException` (domain 레이어 한국어 메시지) — PR [#127](https://github.com/Afternote/Afternote-FE/pull/127) stack
  - `ReceiverHomeViewModel.kt` 2곳 — PR [#127](https://github.com/Afternote/Afternote-FE/pull/127) stack
  - `TermsDetailScreen.kt` 섹션 타이틀 6개 — 디자인 확정 후 별도

**설계 결정**
- `ShowError(message: String?)` nullable — ViewModel 책임은 raw 예외 메시지 전달, UI 책임은 i18n 폴백. ViewModel 에 Context 주입 회피 (메모리 leak 우려)
- Composable scope 에서 `stringResource()` 미리 capture → ObserveAsEvents / coroutine 람다 안에서 (non-Composable scope) 사용

**검증**
- `:feature:onboarding:presentation:compileDebugKotlin` + `ktlintCheck` BUILD SUCCESSFUL