### PR TITLE
feat(onboarding): 구글 로그인 NoCredentialException 시 친화적 안내 (#204)

### DIFF
--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginEntry.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginEntry.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.credentials.CredentialManager
+import androidx.credentials.exceptions.NoCredentialException
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.ObserveAsEvents
@@ -49,6 +50,7 @@ fun LoginEntry(
     val loginFailedMessage = stringResource(R.string.login_failed)
     val kakaoFailedMessage = stringResource(R.string.login_kakao_failed)
     val googleFailedMessage = stringResource(R.string.login_google_failed)
+    val googleNoCredentialsMessage = stringResource(R.string.login_google_no_credentials)
     val screenUnavailableMessage = stringResource(R.string.login_screen_unavailable)
 
     val showErrorSnackbar: (String) -> Unit = { message ->
@@ -105,8 +107,13 @@ fun LoginEntry(
                     ).onSuccess { idToken ->
                         viewModel.loginWithGoogle(idToken)
                     }.onFailure { exception ->
-                        if (exception is UserCancelledAuthException) return@onFailure
-                        showErrorSnackbar(exception.message ?: googleFailedMessage)
+                        val message =
+                            when (exception) {
+                                is UserCancelledAuthException -> return@onFailure
+                                is NoCredentialException -> googleNoCredentialsMessage
+                                else -> exception.message ?: googleFailedMessage
+                            }
+                        showErrorSnackbar(message)
                     }
                 }
             }

--- a/feature/onboarding/presentation/src/main/res/values/strings.xml
+++ b/feature/onboarding/presentation/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="login_failed">로그인 실패</string>
     <string name="login_kakao_failed">카카오 로그인에 실패했습니다.</string>
     <string name="login_google_failed">구글 로그인에 실패했습니다.</string>
+    <string name="login_google_no_credentials">기기에 Google 계정이 없어요.\n설정 &gt; 계정에서 Google 계정을 추가해 주세요.</string>
     <string name="login_screen_unavailable">로그인 화면을 띄울 수 없습니다.</string>
     <string name="content_description_google_login">구글 로그인</string>
 


### PR DESCRIPTION
📌𝘐𝘴𝘴𝘶𝘦𝘴

closed feat(onboarding): 구글 로그인 NoCredentialException 사용자 친화적 안내 #204

📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

구글 로그인 시 디바이스에 Google 계정이 없으면 시스템이 "No credentials available" 영어 toast 만 잠깐 띄우고 사라지던 문제를 친화적 Snackbar 로 안내.

**신규 strings.xml 키**
- `login_google_no_credentials` — "기기에 Google 계정이 없어요.\n설정 > 계정에서 Google 계정을 추가해 주세요."

**수정**
- `LoginEntry.kt`
  - `androidx.credentials.exceptions.NoCredentialException` import
  - `googleNoCredentialsMessage` stringResource capture
  - `onGoogleLoginClick` 의 `onFailure` 람다를 `when` 분기로 변경 — `NoCredentialException` 잡아 친화적 메시지 Snackbar 표시. 그 외 케이스는 기존 일반 실패 메시지 유지

📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

Before: 시스템 영어 toast "No credentials available" 잠깐 + 일반 실패 메시지 fallback
After: 한국어 친화적 안내 + 해결 방법(설정 > 계정에서 Google 계정 추가) 명시

💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

**Stack 정보**
- base = `fix/170-login` (PR [#203](https://github.com/Afternote/Afternote-FE/pull/203))
- PR #203 머지 시 본 PR base 를 `develop` 으로 rebase

**설계 결정**
- `GoogleLoginHelper.kt` 무변경 — `NoCredentialException` 은 `GetCredentialException` subclass 라 기존 catch 가 잡아 Result.failure 로 전달. UI 에서 type 분기하는 게 더 단순
- Dialog + "설정 열기" 액션 까지 X — 단순 Snackbar 로 시작. 디자인 결정 시 향후 보강 가능

**검증**
- `:feature:onboarding:presentation:compileDebugKotlin` + `ktlintCheck` BUILD SUCCESSFUL