### PR TITLE
feat(app): 발신자 홈 WeeklySummaryGrid 콜백 임시 wire-up + AfternoteSourceIcon.key 정리

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
@@ -184,11 +184,18 @@ fun rememberHomeTabActions(
                 appState.navController.navigate(Route.MindRecord)
             }
 
-            override fun onWeeklyImageClick() {}
+            // TODO: 카드별 destination 디자인 확정 후 분기. 우선 마음의 기록 탭으로 임시 연결.
+            override fun onWeeklyImageClick() {
+                appState.navigateToBottomBarRoute(Route.MindRecord)
+            }
 
-            override fun onWeeklyCountClick() {}
+            override fun onWeeklyCountClick() {
+                appState.navigateToBottomBarRoute(Route.MindRecord)
+            }
 
-            override fun onWeeklyRecentRecordClick() {}
+            override fun onWeeklyRecentRecordClick() {
+                appState.navigateToBottomBarRoute(Route.MindRecord)
+            }
 
             override fun onMemoriesSectionClick() {
                 appState.navController.navigate(Route.MemorySpace)

--- a/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeScreen.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeScreen.kt
@@ -228,10 +228,10 @@ private fun ReceiverHomeScreenPreview() {
                     afternoteTotalCount = 10,
                     afternoteIcons =
                         listOf(
-                            AfternoteSourceIcon("INSTAGRAM", AfternoteFeatureR.drawable.feature_afternote_img_insta_pattern),
-                            AfternoteSourceIcon("GALLERY", AfternoteFeatureR.drawable.feature_afternote_img_googlephoto_pattern),
-                            AfternoteSourceIcon("NAVER_MAIL", AfternoteFeatureR.drawable.feature_afternote_img_naver_mail_pattern),
-                            AfternoteSourceIcon("KAKAOTALK", AfternoteFeatureR.drawable.feature_afternote_img_kakaotalk_pattern),
+                            AfternoteSourceIcon(AfternoteFeatureR.drawable.feature_afternote_img_insta_pattern),
+                            AfternoteSourceIcon(AfternoteFeatureR.drawable.feature_afternote_img_googlephoto_pattern),
+                            AfternoteSourceIcon(AfternoteFeatureR.drawable.feature_afternote_img_naver_mail_pattern),
+                            AfternoteSourceIcon(AfternoteFeatureR.drawable.feature_afternote_img_kakaotalk_pattern),
                         ),
                 ),
             onEvent = {},

--- a/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeViewModel.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeViewModel.kt
@@ -136,7 +136,6 @@ private fun List<AfterNoteListItemDto>.toAfternoteIcons(): List<AfternoteSourceI
         .take(MAX_AFTERNOTE_ICONS)
         .map { typeKey ->
             AfternoteSourceIcon(
-                key = typeKey,
                 drawableResId = getAfternoteDisplayRes(typeKey).drawableResId,
             )
         }.toList()

--- a/app/src/main/java/com/afternote/afternote_fe/screen/receiver/component/AfternoteSection.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/receiver/component/AfternoteSection.kt
@@ -126,10 +126,10 @@ private fun AfternoteSectionPreview() {
             totalCount = 10,
             icons =
                 listOf(
-                    AfternoteSourceIcon("INSTAGRAM", AfternoteFeatureR.drawable.feature_afternote_img_insta_pattern),
-                    AfternoteSourceIcon("GALLERY", AfternoteFeatureR.drawable.feature_afternote_img_googlephoto_pattern),
-                    AfternoteSourceIcon("NAVER_MAIL", AfternoteFeatureR.drawable.feature_afternote_img_naver_mail_pattern),
-                    AfternoteSourceIcon("KAKAOTALK", AfternoteFeatureR.drawable.feature_afternote_img_kakaotalk_pattern),
+                    AfternoteSourceIcon(AfternoteFeatureR.drawable.feature_afternote_img_insta_pattern),
+                    AfternoteSourceIcon(AfternoteFeatureR.drawable.feature_afternote_img_googlephoto_pattern),
+                    AfternoteSourceIcon(AfternoteFeatureR.drawable.feature_afternote_img_naver_mail_pattern),
+                    AfternoteSourceIcon(AfternoteFeatureR.drawable.feature_afternote_img_kakaotalk_pattern),
                 ),
             onGoClick = {},
             modifier = Modifier.padding(20.dp),

--- a/app/src/main/java/com/afternote/afternote_fe/screen/receiver/model/ReceiverHomeUiState.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/receiver/model/ReceiverHomeUiState.kt
@@ -42,7 +42,6 @@ data class MindRecordSummary(
 
 @Immutable
 data class AfternoteSourceIcon(
-    val key: String,
     val drawableResId: Int,
 )
 


### PR DESCRIPTION
## 📌Issues

_Closes #201_

## 📎Work Description

_발신자 홈 탭 `WeeklySummaryGrid` 의 카드 3개(RECORDED MOMENT / THIS WEEK / 최근 깊은생각) 클릭 콜백을 `appState.navigateToBottomBarRoute(Route.MindRecord)` 로 임시 wire-up. 디자인상 각 카드의 destination 이 정의되지 않아 디자인 확정 후 분기 예정 (TODO 주석 표시)._

_dead 필드 `AfternoteSourceIcon.key` 제거 및 Preview · 매핑 사이트 정리. wrapper 자체는 `List<AfternoteSourceIcon>` 타입 의미 살아있어 유지._

_참고 1: 이슈 본문에 "수신자 홈" 이라 적혀있으나 실제 코드 위치는 **발신자(sender) 홈 탭**의 `WeeklySummaryGrid`._

_참고 2: 이슈 본문이 언급한 `HomeTabScreen.kt:94-100` 빈 구현은 `HomeTabActionsNoop` (Preview / 기본값) 객체라 wire-up 대상이 아니라서 유지._

_참고 3: 3개 카드가 표시하는 데이터(`recordedCount` / `recentRecordDate` / `recentRecordTitle`)는 현재 기본 인자(목)로 노출 중. mindrecord 도메인 레이어 의존이라 #22 (주간 리포트 도메인) · #21 (깊은 생각 도메인) 에 발신자 홈 wire-up 컨텍스트 코멘트 추가했음. 본 PR 범위 외._

## 📷Screenshot

_발신자 홈 탭에서 WeeklySummaryGrid 카드 3개 클릭 → 마음의 기록 탭 이동 실기 확인 완료_

## 💬To Reviewers

_3개 카드 모두 동일하게 `Route.MindRecord` 로 가는 **임시** wire-up. 카드별 destination 분기는 디자이너로부터 클릭 액션 정의 받은 후 별도 작업으로 진행._

_`AfternoteSourceIcon` wrapper 통째로 제거 (`List<@DrawableRes Int>` 로 단순화) 도 고려했으나, 타입 의미가 살아있다고 판단해 wrapper 유지 + key 필드만 제거하는 보수적 변경을 채택._