### PR TITLE
fix(home): 수신자 홈 Hero 카드 senderName 매핑 + loadSenderMessage 도메인 모델 확장

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeViewModel.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeViewModel.kt
@@ -78,11 +78,13 @@ class ReceiverHomeViewModel
                     afternotesRes.getOrNull() ?: AfterNotesListResult(items = emptyList(), totalCount = 0)
                 val mindRecordsCount = mindRecordsRes.getOrNull()?.totalCount ?: 0
                 val timeLettersCount = timeLettersRes.getOrNull()?.totalCount ?: 0
-                val senderMessageBody = messageRes.getOrNull()?.takeIf { it.isNotBlank() }
+                val senderMessageInfo = messageRes.getOrNull()
+                val senderMessageBody = senderMessageInfo?.message?.takeIf { it.isNotBlank() }
 
                 _uiState.value =
                     ReceiverHomeUiState.Success(
-                        senderName = "",
+                        senderName = senderMessageInfo?.senderName.orEmpty(),
+                        // TODO: 백엔드 응답에 date 필드 추가되면 채울 것. 현재 receiver-auth/message 응답은 senderName/message 만.
                         senderMessage = senderMessageBody?.let { SenderMessage(date = "", body = it) },
                         mindRecord =
                             MindRecordSummary(

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverRepositoryImpl.kt
@@ -4,15 +4,18 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import com.afternote.core.network.model.requireData
+import com.afternote.feature.afternote.data.dto.toDomain
 import com.afternote.feature.afternote.data.local.ReceiverAuthCodeDataSource
 import com.afternote.feature.afternote.data.mapper.response.toDomain
 import com.afternote.feature.afternote.data.paging.ReceiverAfternotePagingSource
 import com.afternote.feature.afternote.data.service.ReceiverAfternoteApiService
+import com.afternote.feature.afternote.data.service.ReceiverAuthApiService
 import com.afternote.feature.afternote.domain.model.receiver.AfterNoteListItemDto
 import com.afternote.feature.afternote.domain.model.receiver.AfterNotesListResult
 import com.afternote.feature.afternote.domain.model.receiver.LoadCountResult
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedAfternoteDetail
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedExportBundle
+import com.afternote.feature.afternote.domain.model.receiver.SenderMessageInfo
 import com.afternote.feature.afternote.domain.repository.receiver.ReceiverRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -31,6 +34,7 @@ class ReceiverRepositoryImpl
     constructor(
         private val authCodeDataSource: ReceiverAuthCodeDataSource,
         private val api: ReceiverAfternoteApiService,
+        private val authApi: ReceiverAuthApiService,
     ) : ReceiverRepository {
         override val authCodeFlow: Flow<String?> = authCodeDataSource.savedCodeFlow
 
@@ -74,5 +78,8 @@ class ReceiverRepositoryImpl
 
         override suspend fun loadTimeLettersCount(): Result<LoadCountResult> = Result.success(LoadCountResult(0))
 
-        override suspend fun loadSenderMessage(): Result<String?> = Result.success(null)
+        override suspend fun loadSenderMessage(): Result<SenderMessageInfo?> =
+            runCatching {
+                authApi.getSenderMessage().requireData().toDomain()
+            }
     }

--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/repository/receiver/ReceiverRepository.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/repository/receiver/ReceiverRepository.kt
@@ -6,6 +6,7 @@ import com.afternote.feature.afternote.domain.model.receiver.AfterNotesListResul
 import com.afternote.feature.afternote.domain.model.receiver.LoadCountResult
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedAfternoteDetail
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedExportBundle
+import com.afternote.feature.afternote.domain.model.receiver.SenderMessageInfo
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -45,5 +46,5 @@ interface ReceiverRepository {
 
     suspend fun loadTimeLettersCount(): Result<LoadCountResult>
 
-    suspend fun loadSenderMessage(): Result<String?>
+    suspend fun loadSenderMessage(): Result<SenderMessageInfo?>
 }


### PR DESCRIPTION
## 📌Issues

_Closes #164_
_refs #209 (date 필드 백엔드 응답 의존 — 본 PR 범위 밖)_

## 📎Work Description

_수신자 홈 Hero 카드의 `senderName` 이 항상 빈 문자열로 노출되던 버그 fix._

_근본 원인: `ReceiverRepositoryImpl.loadSenderMessage()` 가 stub (`Result.success(null)`) 으로 남아있었고, 시그니처가 `Result<String?>` 이라 senderName 을 흘릴 곳도 없었음. #187 에서 추가된 `ReceiverAuthApiService.getSenderMessage()` 와 `SenderMessageInfo` 도메인 모델 · 매퍼 인프라만 깔린 상태였음._

_변경:_
- _`ReceiverRepository.loadSenderMessage()` 시그니처 `Result<String?>` → `Result<SenderMessageInfo?>` — senderName · message 모두 흘림_
- _`ReceiverRepositoryImpl` 에 `ReceiverAuthApiService` 주입 + `authApi.getSenderMessage().requireData().toDomain()` 으로 실제 구현_
- _`ReceiverHomeViewModel` 에서 `senderName = senderMessageInfo?.senderName.orEmpty()` 매핑_

## 📷Screenshot

_(실기 테스트 후 첨부)_

## 💬To Reviewers

_본 PR 은 [#208](https://github.com/Afternote/Afternote-FE/pull/208) (fix/201) 위에 stack 되어 있습니다. base: `fix/201`. fix/201 머지 후 base 가 자동으로 develop 으로 회수됩니다._

_**date 필드 미처리**: `SenderMessage.date` 는 여전히 `""` 빈 문자열로 들어갑니다. backend `GET /api/v1/receiver-auth/message` 응답에 시간 필드(`createdAt` / `sentAt` 등) 가 없어서 매핑할 소스가 없음. Swagger OpenAPI 스펙으로 재확인했고 #209 로 백엔드 추가 요청 트래킹 중. 백엔드 추가되면 클라이언트 매핑 3 줄(`DTO + SenderMessageInfo + ViewModel`) 만 추가하면 됨._

_**작업 범위 외 stub**: `ReceiverRepositoryImpl.getReceivedAfterNotes()` 도 stub 상태 (`AfterNotesListResult(emptyList(), 0)`) 지만, #164 직접 원인(senderName 빈 문자열)의 fix 범위 밖이라 별도 후속. Hero 카드 노출과는 무관._