### PR TITLE
fix(afternote): 에디터 카테고리 전환 시 actions 잔류 수정

### DIFF
--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/state/AfternoteEditorState.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/state/AfternoteEditorState.kt
@@ -124,6 +124,8 @@ class AfternoteEditorState(
                     } else {
                         AfternoteServiceCatalog.defaultSocialService
                     },
+                socialProcessingMethods = emptyList(),
+                galleryProcessingMethods = emptyList(),
             )
         }
     }


### PR DESCRIPTION
## 📌Issues
_Closes #213_

## 📎Work Description
_AfternoteEditorState.selectCategory() 가 카테고리 전환 시 socialProcessingMethods·galleryProcessingMethods 양쪽 자리를 emptyList() 로 초기화하도록 수정._
_이전: 카테고리 전환 후에도 이전 카테고리 actions 가 form 에 잔류 → 저장 시 두 자리가 합쳐져 서버 전송 (예: SOCIAL "A","B" 입력 후 GALLERY 로 전환·"C","D" 입력 → actions:["A","B","C","D"])._

## 📷Screenshot
_(N/A — 내부 상태 수정)_

## 💬To Reviewers
_• 이슈 본문 옵션 A 채택. AfternoteEditorFormMapper 의 actions 합산 로직은 그대로 유지._
_• 수정 모드 race 점검: LaunchedEffect(route.initialCategory, route.itemId) 가 composition 즉시 selectCategoryByNavKey 호출 → PMs 비움. PrefillLoaded 이벤트는 ViewModel 비동기 fetch 응답 후 emit → applyFormPrefill 이 PMs 채움. 순서 보장됨._
_• Follow-up (자리/콜백 단일화) 는 이슈 본문 Follow-up 섹션 참고. 별도 PR._