### PR TITLE
fix(home): 수신자 홈 Hero 카드 senderName 매핑 + loadSenderMessage 도메인 모델 확장 (#164)

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeScreen.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeScreen.kt
@@ -104,17 +104,20 @@ private fun SuccessContent(
                 .padding(horizontal = 20.dp, vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(20.dp),
     ) {
-        Text(
-            text = stringResource(R.string.receiver_home_sender_record_title, state.senderName),
-            style = AfternoteDesign.typography.h2,
-            color = AfternoteDesign.colors.gray9,
-        )
-        state.senderMessage?.let { message ->
-            SenderMessageHeroCard(
-                senderName = state.senderName,
-                date = message.date,
-                message = message.body,
+        // senderName 가 blank 면 헤더·Hero 카드 모두 안 그림 — "故 님이 남기신 기록" 같은 깨진 문구 회피.
+        if (state.senderName.isNotBlank()) {
+            Text(
+                text = stringResource(R.string.receiver_home_sender_record_title, state.senderName),
+                style = AfternoteDesign.typography.h2,
+                color = AfternoteDesign.colors.gray9,
             )
+            state.senderMessage?.let { message ->
+                SenderMessageHeroCard(
+                    senderName = state.senderName,
+                    date = message.date,
+                    message = message.body,
+                )
+            }
         }
         MindRecordSection(
             summary = state.mindRecord,

--- a/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeViewModel.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeViewModel.kt
@@ -78,11 +78,13 @@ class ReceiverHomeViewModel
                     afternotesRes.getOrNull() ?: AfterNotesListResult(items = emptyList(), totalCount = 0)
                 val mindRecordsCount = mindRecordsRes.getOrNull()?.totalCount ?: 0
                 val timeLettersCount = timeLettersRes.getOrNull()?.totalCount ?: 0
-                val senderMessageBody = messageRes.getOrNull()?.takeIf { it.isNotBlank() }
+                val senderMessageInfo = messageRes.getOrNull()
+                val senderMessageBody = senderMessageInfo?.message?.takeIf { it.isNotBlank() }
 
                 _uiState.value =
                     ReceiverHomeUiState.Success(
-                        senderName = "",
+                        senderName = senderMessageInfo?.senderName.orEmpty(),
+                        // TODO: 백엔드 응답에 date 필드 추가되면 채울 것. 현재 receiver-auth/message 응답은 senderName/message 만.
                         senderMessage = senderMessageBody?.let { SenderMessage(date = "", body = it) },
                         mindRecord =
                             MindRecordSummary(

--- a/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeViewModel.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeViewModel.kt
@@ -79,11 +79,14 @@ class ReceiverHomeViewModel
                 val mindRecordsCount = mindRecordsRes.getOrNull()?.totalCount ?: 0
                 val timeLettersCount = timeLettersRes.getOrNull()?.totalCount ?: 0
                 val senderMessageInfo = messageRes.getOrNull()
+                // senderName / senderMessage 둘 다 blank 가드 — sender 가 이름·메시지 미입력 케이스 대응.
+                // ".orEmpty()" 만으로는 공백("  ") 통과해 "故 님이 남기신 기록" / "님의 한 마디" UI 깨짐.
+                val senderName = senderMessageInfo?.senderName?.takeIf { it.isNotBlank() }.orEmpty()
                 val senderMessageBody = senderMessageInfo?.message?.takeIf { it.isNotBlank() }
 
                 _uiState.value =
                     ReceiverHomeUiState.Success(
-                        senderName = senderMessageInfo?.senderName.orEmpty(),
+                        senderName = senderName,
                         // TODO: 백엔드 응답에 date 필드 추가되면 채울 것. 현재 receiver-auth/message 응답은 senderName/message 만.
                         senderMessage = senderMessageBody?.let { SenderMessage(date = "", body = it) },
                         mindRecord =

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverRepositoryImpl.kt
@@ -4,15 +4,18 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import com.afternote.core.network.model.requireData
+import com.afternote.feature.afternote.data.dto.toDomain
 import com.afternote.feature.afternote.data.local.ReceiverAuthCodeDataSource
 import com.afternote.feature.afternote.data.mapper.response.toDomain
 import com.afternote.feature.afternote.data.paging.ReceiverAfternotePagingSource
 import com.afternote.feature.afternote.data.service.ReceiverAfternoteApiService
+import com.afternote.feature.afternote.data.service.ReceiverAuthApiService
 import com.afternote.feature.afternote.domain.model.receiver.AfterNoteListItemDto
 import com.afternote.feature.afternote.domain.model.receiver.AfterNotesListResult
 import com.afternote.feature.afternote.domain.model.receiver.LoadCountResult
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedAfternoteDetail
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedExportBundle
+import com.afternote.feature.afternote.domain.model.receiver.SenderMessageInfo
 import com.afternote.feature.afternote.domain.repository.receiver.ReceiverRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -31,6 +34,7 @@ class ReceiverRepositoryImpl
     constructor(
         private val authCodeDataSource: ReceiverAuthCodeDataSource,
         private val api: ReceiverAfternoteApiService,
+        private val authApi: ReceiverAuthApiService,
     ) : ReceiverRepository {
         override val authCodeFlow: Flow<String?> = authCodeDataSource.savedCodeFlow
 
@@ -74,5 +78,8 @@ class ReceiverRepositoryImpl
 
         override suspend fun loadTimeLettersCount(): Result<LoadCountResult> = Result.success(LoadCountResult(0))
 
-        override suspend fun loadSenderMessage(): Result<String?> = Result.success(null)
+        override suspend fun loadSenderMessage(): Result<SenderMessageInfo?> =
+            runCatching {
+                authApi.getSenderMessage().requireData().toDomain()
+            }
     }

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverRepositoryImpl.kt
@@ -4,18 +4,17 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import com.afternote.core.network.model.requireData
-import com.afternote.feature.afternote.data.dto.toDomain
 import com.afternote.feature.afternote.data.local.ReceiverAuthCodeDataSource
 import com.afternote.feature.afternote.data.mapper.response.toDomain
 import com.afternote.feature.afternote.data.paging.ReceiverAfternotePagingSource
 import com.afternote.feature.afternote.data.service.ReceiverAfternoteApiService
-import com.afternote.feature.afternote.data.service.ReceiverAuthApiService
 import com.afternote.feature.afternote.domain.model.receiver.AfterNoteListItemDto
 import com.afternote.feature.afternote.domain.model.receiver.AfterNotesListResult
 import com.afternote.feature.afternote.domain.model.receiver.LoadCountResult
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedAfternoteDetail
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedExportBundle
 import com.afternote.feature.afternote.domain.model.receiver.SenderMessageInfo
+import com.afternote.feature.afternote.domain.repository.receiver.ReceiverAuthRepository
 import com.afternote.feature.afternote.domain.repository.receiver.ReceiverRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -34,7 +33,7 @@ class ReceiverRepositoryImpl
     constructor(
         private val authCodeDataSource: ReceiverAuthCodeDataSource,
         private val api: ReceiverAfternoteApiService,
-        private val authApi: ReceiverAuthApiService,
+        private val receiverAuthRepository: ReceiverAuthRepository,
     ) : ReceiverRepository {
         override val authCodeFlow: Flow<String?> = authCodeDataSource.savedCodeFlow
 
@@ -78,8 +77,7 @@ class ReceiverRepositoryImpl
 
         override suspend fun loadTimeLettersCount(): Result<LoadCountResult> = Result.success(LoadCountResult(0))
 
-        override suspend fun loadSenderMessage(): Result<SenderMessageInfo?> =
-            runCatching {
-                authApi.getSenderMessage().requireData().toDomain()
-            }
+        // sender 메시지 조회는 receiver-auth 영역 → ReceiverAuthRepository 가 책임.
+        // 본 Repository 는 위임만 — 같은 API 호출이 두 곳에 중복되지 않게 (Multiple levels of repositories).
+        override suspend fun loadSenderMessage(): Result<SenderMessageInfo?> = receiverAuthRepository.getSenderMessage().map { it }
     }

--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/repository/receiver/ReceiverRepository.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/repository/receiver/ReceiverRepository.kt
@@ -6,6 +6,7 @@ import com.afternote.feature.afternote.domain.model.receiver.AfterNotesListResul
 import com.afternote.feature.afternote.domain.model.receiver.LoadCountResult
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedAfternoteDetail
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedExportBundle
+import com.afternote.feature.afternote.domain.model.receiver.SenderMessageInfo
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -45,5 +46,5 @@ interface ReceiverRepository {
 
     suspend fun loadTimeLettersCount(): Result<LoadCountResult>
 
-    suspend fun loadSenderMessage(): Result<String?>
+    suspend fun loadSenderMessage(): Result<SenderMessageInfo?>
 }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

closed fix(home): ReceiverHomeViewModel 의 senderName/senderMessage.date 가 항상 빈 문자열 #164
refs #209 (date 필드 백엔드 응답 의존 — 본 PR 범위 밖)

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- 수신자 홈 Hero 카드의 senderName 이 항상 빈 문자열로 노출되던 버그 fix
- 근본 원인: ReceiverRepositoryImpl.loadSenderMessage() 가 stub (Result.success(null)) 상태였고, 시그니처 Result<String?> 라 senderName 을 흘릴 자리도 없었음. #187 에서 ReceiverAuthApiService.getSenderMessage() + SenderMessageInfo 도메인 모델·매퍼만 깔린 상태
- ReceiverRepository.loadSenderMessage() 시그니처 Result<String?> → Result<SenderMessageInfo?> — senderName · message 모두 흘림
- ReceiverRepositoryImpl 에 ReceiverAuthApiService 주입 + authApi.getSenderMessage().requireData().toDomain() 실제 구현
- ReceiverHomeViewModel 에서 senderName = senderMessageInfo?.senderName.orEmpty() 매핑

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

실기 테스트 후 첨부

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 복구 PR 사유: 원본 PR #210 이 #208 머지 시점에 base 브랜치(fix/201) 가 --delete-branch 옵션으로 삭제되면서 GitHub 정책상 자동 close 됨. base 가 develop 으로 retarget 되지 않아 fix/164 의 단독 commit 이 develop 에 못 들어간 상태. 본 PR 은 그 변경분(c79240be 1 commit) 만 develop 으로 머지하는 복구용
- date 필드 미처리: SenderMessage.date 는 여전히 "" 빈 문자열로 들어감. backend GET /api/v1/receiver-auth/message 응답에 시간 필드(createdAt / sentAt 등) 가 없어서 매핑할 소스가 없음. Swagger OpenAPI 스펙으로 재확인했고 #209 로 백엔드 추가 요청 트래킹 중. 백엔드 추가되면 클라이언트 매핑 3줄(DTO + SenderMessageInfo + ViewModel) 만 추가하면 됨
- 작업 범위 외 stub: ReceiverRepositoryImpl.getReceivedAfterNotes() 도 stub 상태 (AfterNotesListResult(emptyList(), 0)) 지만, #164 직접 원인(senderName 빈 문자열)의 fix 범위 밖이라 별도 후속. Hero 카드 노출과는 무관
