### PR TITLE
ci: GOOGLE_WEB_CLIENT_ID workflow secret 매핑 추가 (#233)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,6 +44,7 @@ jobs:
         run: ./gradlew lintDebug --continue --parallel
         env:
           KAKAO_NATIVE_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
+          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
 
       - name: Report Android Lint (Reviewdog)
         if: always()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,21 @@ jobs:
           java-version: '21'
           cache: 'gradle'
 
+      # fail-fast — secret 누락 시 Gradle 까지 가지 않고 즉시 실패
+      # secret 값은 echo 하지 않음 (env 로만 받아서 길이 검사). 누락 키 이름은 안전.
+      - name: Verify required secrets are set
+        env:
+          KAKAO_NATIVE_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
+          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
+        run: |
+          missing=""
+          [ -z "$KAKAO_NATIVE_APP_KEY" ] && missing="$missing KAKAO_NATIVE_APP_KEY"
+          [ -z "$GOOGLE_WEB_CLIENT_ID" ] && missing="$missing GOOGLE_WEB_CLIENT_ID"
+          if [ -n "$missing" ]; then
+            echo "::error::필수 secret 누락:$missing — Settings → Secrets and variables → Actions 에 등록"
+            exit 1
+          fi
+
       - name: Run Android Lint
         run: ./gradlew lintDebug --continue --parallel
         env:


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

closed chore(ci): GOOGLE_WEB_CLIENT_ID workflow secret 매핑 추가 #233

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- .github/workflows/lint.yml 의 android-lint job Run Android Lint step env 에 GOOGLE_WEB_CLIENT_ID: \${{ secrets.GOOGLE_WEB_CLIENT_ID }} 한 줄 추가
- KAKAO_NATIVE_APP_KEY 만 매핑되어 있던 비대칭 해소 — Google·Kakao 양쪽 키가 CI 에 일관되게 inject 되도록

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

workflow 변경이라 시각 변화 없음

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 사전 액션 필요: 본 PR 머지 전·후 1hyok 이 Settings → Secrets and variables → Actions 에서 GOOGLE_WEB_CLIENT_ID secret 을 등록해야 실제로 inject 됨. 미등록 상태로 머지해도 GitHub Actions 가 빈 문자열로 inject — 현재 동작과 동일 (안전)
- 현 CI 는 lintDebug 만 돌고 assembleDebug 는 안 돌아서 BuildConfig 빈 문자열로도 통과 — 본 PR 머지로 결과는 안 바뀜. assembleDebug 추가·secret 누락 fail-fast 도입은 별도 follow-up (이슈 본문 작업 범위 3번 + Note 참고)
- yaml 구문 검증 통과 (python3 -c "import yaml; yaml.safe_load(open(...))")
