### PR TITLE
feat(afternote): 발신자 상세 PENDING 분리 + submit 에러 메시지 정밀화 (#225)

### DIFF
--- a/core/network/src/main/kotlin/com/afternote/core/network/interceptor/ApiErrorInterceptor.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/interceptor/ApiErrorInterceptor.kt
@@ -40,9 +40,10 @@ class ApiErrorInterceptor
                     ?.content
                     ?.takeUnless { it.isBlank() }
             // 디버깅용 message — serverMessage 우선, 없으면 HTTP reason, 그래도 없으면 generic fallback.
-            val message = serverMessage
-                ?: response.message.takeUnless { it.isBlank() }
-                ?: "요청에 실패했습니다."
+            val message =
+                serverMessage
+                    ?: response.message.takeUnless { it.isBlank() }
+                    ?: "요청에 실패했습니다."
 
             throw ApiException(code = code, serverMessage = serverMessage, message = message)
         }

--- a/core/network/src/main/kotlin/com/afternote/core/network/interceptor/ApiErrorInterceptor.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/interceptor/ApiErrorInterceptor.kt
@@ -32,15 +32,18 @@ class ApiErrorInterceptor
             val rawBody = response.peekBody(Long.MAX_VALUE).string()
             val parsed = runCatching { json.parseToJsonElement(rawBody).jsonObject }.getOrNull()
             val code = parsed?.get("code")?.jsonPrimitive?.intOrNull ?: response.code
-            val message =
+            // 서버가 실제로 내려준 message — null/blank 면 null 보존 (클라 fallback 과 구분).
+            val serverMessage =
                 parsed
                     ?.get("message")
                     ?.jsonPrimitive
                     ?.content
                     ?.takeUnless { it.isBlank() }
-                    ?: response.message.takeUnless { it.isBlank() }
-                    ?: "요청에 실패했습니다."
+            // 디버깅용 message — serverMessage 우선, 없으면 HTTP reason, 그래도 없으면 generic fallback.
+            val message = serverMessage
+                ?: response.message.takeUnless { it.isBlank() }
+                ?: "요청에 실패했습니다."
 
-            throw ApiException(code = code, message = message)
+            throw ApiException(code = code, serverMessage = serverMessage, message = message)
         }
     }

--- a/core/network/src/main/kotlin/com/afternote/core/network/model/BaseResponse.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/model/BaseResponse.kt
@@ -18,9 +18,17 @@ data class BaseResponse<T>(
 
 fun <T : Any> BaseResponse<T>.requireData(): T {
     if (status != 200) {
-        throw ApiException(code = code, message = message ?: "알 수 없는 서버 에러가 발생했습니다.")
+        throw ApiException(
+            code = code,
+            serverMessage = message,
+            message = message ?: "알 수 없는 서버 에러가 발생했습니다.",
+        )
     }
-    return data ?: throw ApiException(code = code, message = "성공했으나 데이터가 비어있습니다.")
+    return data ?: throw ApiException(
+        code = code,
+        serverMessage = null,
+        message = "성공했으나 데이터가 비어있습니다.",
+    )
 }
 
 /**
@@ -29,14 +37,25 @@ fun <T : Any> BaseResponse<T>.requireData(): T {
  * [IOException] 의 서브클래스로 둔 이유 — OkHttp Interceptor (예: `ApiErrorInterceptor`)
  * 가 4xx/5xx 응답을 가로채 throw 할 때 OkHttp 가 그대로 전파할 수 있어야 하기 때문.
  * `Exception` 으로 두면 OkHttp 가 `IOException` 으로 래핑해 백엔드 message 가 손실된다.
+ *
+ * @property serverMessage 서버가 실제로 내려준 사용자 친화 message. **null 이면 서버가 message 미제공**
+ *   (4xx body 없거나 message blank). 호출처는 이 값이 null/non-null 인지로 "서버 message 있음/없음"
+ *   을 판단 — `message` 는 클라 fallback 이 섞여 사용자에게 노출하면 안 됨.
+ * @property message IOException 호환용 디버깅 메시지 (serverMessage 있으면 그것, 없으면 클라 fallback).
+ *   사용자 직접 노출 X — Logcat·Crashlytics 용.
  */
 class ApiException(
     val code: Int,
+    val serverMessage: String?,
     override val message: String,
 ) : IOException(message)
 
 fun BaseResponse<*>.requireStatus() {
     if (status != 200) {
-        throw ApiException(code = code, message = message ?: "요청에 실패했습니다.")
+        throw ApiException(
+            code = code,
+            serverMessage = message,
+            message = message ?: "요청에 실패했습니다.",
+        )
     }
 }

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImpl.kt
@@ -49,8 +49,14 @@ class ReceiverAuthRepositoryImpl
                 // ApiErrorInterceptor 가 4xx/5xx 응답을 ApiException 으로 변환 (백엔드 message 포함).
                 // presentation 이 core:network 의 ApiException 을 직접 알면 layer 위반이므로
                 // 도메인 예외 ReceiverDeliverySubmitException 으로 변환해 노출한다.
+                //
+                // ApiException.serverMessage = 서버가 실제 보낸 message (null 가능),
+                // ApiException.message = 클라 fallback 섞여 있어 사용자 노출 부적합 — serverMessage 만 전달.
                 throw if (throwable is ApiException) {
-                    ReceiverDeliverySubmitException(throwable.message)
+                    ReceiverDeliverySubmitException(
+                        serverMessage = throwable.serverMessage,
+                        httpCode = throwable.code,
+                    )
                 } else {
                     throwable
                 }

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImpl.kt
@@ -1,11 +1,13 @@
 package com.afternote.feature.afternote.data.repositoryimpl.receiver
 
+import com.afternote.core.network.model.ApiException
 import com.afternote.core.network.model.requireData
 import com.afternote.feature.afternote.data.dto.DeliveryVerificationRequest
 import com.afternote.feature.afternote.data.dto.ReceiverAuthPresignedUrlRequest
 import com.afternote.feature.afternote.data.dto.ReceiverAuthVerifyRequest
 import com.afternote.feature.afternote.data.dto.toDomain
 import com.afternote.feature.afternote.data.service.ReceiverAuthApiService
+import com.afternote.feature.afternote.domain.error.ReceiverDeliverySubmitException
 import com.afternote.feature.afternote.domain.model.receiver.DeliveryVerification
 import com.afternote.feature.afternote.domain.model.receiver.ReceiverAuthPresignedUrl
 import com.afternote.feature.afternote.domain.model.receiver.ReceiverIdentity
@@ -43,6 +45,15 @@ class ReceiverAuthRepositoryImpl
                         ),
                     ).requireData()
                     .toDomain()
+            }.recoverCatching { throwable ->
+                // ApiErrorInterceptor 가 4xx/5xx 응답을 ApiException 으로 변환 (백엔드 message 포함).
+                // presentation 이 core:network 의 ApiException 을 직접 알면 layer 위반이므로
+                // 도메인 예외 ReceiverDeliverySubmitException 으로 변환해 노출한다.
+                throw if (throwable is ApiException) {
+                    ReceiverDeliverySubmitException(throwable.message)
+                } else {
+                    throwable
+                }
             }
 
         override suspend fun getDeliveryVerificationStatus(): Result<DeliveryVerification> =

--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/error/ReceiverDeliverySubmitException.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/error/ReceiverDeliverySubmitException.kt
@@ -6,9 +6,14 @@ package com.afternote.feature.afternote.domain.error
  * HTTP 상태·Retrofit·BaseResponse 같은 인프라 디테일은 Data 계층에서 해석한 뒤
  * 이 타입으로 통일한다. 도메인·Presentation 은 [serverMessage] 만 받아 사용자에게 노출.
  *
- * @property serverMessage 백엔드가 내려준 사용자 친화 message
- *   (예: 409 `"이미 대기 중인 인증 요청이 존재합니다."`).
+ * @property serverMessage 백엔드가 실제로 내려준 사용자 친화 message
+ *   (예: 409 `"이미 대기 중인 인증 요청이 존재합니다."`). **null 이면 서버가 message 미제공** —
+ *   호출처는 도메인 fallback (정적 R.string) 으로 폴백. 클라가 만든 generic 문구
+ *   ("알 수 없는 서버 에러" 등) 는 여기 들어오지 않음.
+ * @property httpCode HTTP status code (예: 409). 향후 "특정 code 일 때만 분기" 요구 시 사용.
+ *   message 문자열 매칭 회귀 회피.
  */
 class ReceiverDeliverySubmitException(
-    val serverMessage: String,
-) : Exception(serverMessage)
+    val serverMessage: String?,
+    val httpCode: Int? = null,
+) : Exception(serverMessage ?: "submit failed (httpCode=$httpCode)")

--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/error/ReceiverDeliverySubmitException.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/error/ReceiverDeliverySubmitException.kt
@@ -1,0 +1,14 @@
+package com.afternote.feature.afternote.domain.error
+
+/**
+ * 수신자 열람 신청(`submitDeliveryVerification`) API 가 거절한 실패.
+ *
+ * HTTP 상태·Retrofit·BaseResponse 같은 인프라 디테일은 Data 계층에서 해석한 뒤
+ * 이 타입으로 통일한다. 도메인·Presentation 은 [serverMessage] 만 받아 사용자에게 노출.
+ *
+ * @property serverMessage 백엔드가 내려준 사용자 친화 message
+ *   (예: 409 `"이미 대기 중인 인증 요청이 존재합니다."`).
+ */
+class ReceiverDeliverySubmitException(
+    val serverMessage: String,
+) : Exception(serverMessage)

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadScreen.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadScreen.kt
@@ -118,12 +118,13 @@ fun DocumentUploadScreen(
     }
 
     // sealed ErrorPayload 분기 — 타입 자체가 "Res / Text 중 하나" 강제, 우선순위 로직 불필요.
-    val errorMessage = uiState.error?.let { err ->
-        when (err) {
-            is ErrorPayload.Res -> stringResource(err.id)
-            is ErrorPayload.Text -> err.message
+    val errorMessage =
+        uiState.error?.let { err ->
+            when (err) {
+                is ErrorPayload.Res -> stringResource(err.id)
+                is ErrorPayload.Text -> err.message
+            }
         }
-    }
     LaunchedEffect(errorMessage) {
         if (errorMessage != null) {
             snackbarHostState.showSnackbar(errorMessage)

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadScreen.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadScreen.kt
@@ -117,7 +117,13 @@ fun DocumentUploadScreen(
         }
     }
 
-    val errorMessage = uiState.errorMessage ?: uiState.errorMessageRes?.let { stringResource(it) }
+    // sealed ErrorPayload 분기 — 타입 자체가 "Res / Text 중 하나" 강제, 우선순위 로직 불필요.
+    val errorMessage = uiState.error?.let { err ->
+        when (err) {
+            is ErrorPayload.Res -> stringResource(err.id)
+            is ErrorPayload.Text -> err.message
+        }
+    }
     LaunchedEffect(errorMessage) {
         if (errorMessage != null) {
             snackbarHostState.showSnackbar(errorMessage)

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadScreen.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadScreen.kt
@@ -117,7 +117,7 @@ fun DocumentUploadScreen(
         }
     }
 
-    val errorMessage = uiState.errorMessageRes?.let { stringResource(it) }
+    val errorMessage = uiState.errorMessage ?: uiState.errorMessageRes?.let { stringResource(it) }
     LaunchedEffect(errorMessage) {
         if (errorMessage != null) {
             snackbarHostState.showSnackbar(errorMessage)

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadUiState.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadUiState.kt
@@ -1,6 +1,21 @@
 package com.afternote.feature.afternote.presentation.receiver.deliveryverification
 
+import androidx.annotation.StringRes
 import androidx.compose.runtime.Immutable
+
+/**
+ * UI 에 노출할 에러 — sealed 로 "i18n string resource" vs "서버 동적 message" 상호 배타 보장.
+ *
+ * 두 경우를 각각 별도 nullable 필드로 두면 컨벤션 의존 (둘 다 set 되는 버그 가능). sealed 로 묶으면
+ * 타입 자체가 "하나만 가능" 강제.
+ */
+sealed interface ErrorPayload {
+    /** 클라이언트가 미리 정의한 generic 문구 (i18n 가능). 서버 message 미제공 시 fallback. */
+    data class Res(@StringRes val id: Int) : ErrorPayload
+
+    /** 백엔드가 런타임에 내려준 사용자 친화 message (예: 409 "이미 대기 중인 인증 요청이 존재합니다."). */
+    data class Text(val message: String) : ErrorPayload
+}
 
 /**
  * 증빙 서류 업로드(6·7·8) UI 상태.
@@ -13,24 +28,8 @@ data class DocumentUploadUiState(
     val deathCertificate: DocumentSlotState = DocumentSlotState(),
     val familyRelationCertificate: DocumentSlotState = DocumentSlotState(),
     val isSubmitting: Boolean = false,
-    /**
-     * 클라이언트가 미리 정의한 generic 문구 (`strings.xml` 의 string resource id).
-     * i18n 가능. 서버 message 가 없을 때 fallback.
-     *
-     * [errorMessage] 와 *상호 배타* — 둘 다 set 하지 않는다 (타입으로 강제 X, 컨벤션).
-     * 화면 측 우선순위는 [errorMessage] 가 우선, 없으면 본 필드 사용.
-     */
-    val errorMessageRes: Int? = null,
-    /**
-     * 백엔드가 런타임에 내려준 사용자 친화 message 를 그대로 노출할 때 사용
-     * (예: 409 "이미 대기 중인 인증 요청이 존재합니다."). i18n 불가 — 서버가 한국어로 보낸 가정.
-     *
-     * [errorMessageRes] 와 *상호 배타*. 화면 측은 본 필드를 우선 노출.
-     *
-     * (후속 정리 후보: 두 필드를 `ErrorPayload` sealed 로 합치면 상호 배타 강제 가능 — 다른 VM
-     * 의 동일 패턴까지 일괄 정리될 때 도입 검토.)
-     */
-    val errorMessage: String? = null,
+    /** 표시할 에러 — null 이면 에러 없음. [ErrorPayload.Res] 또는 [ErrorPayload.Text] 둘 중 하나. */
+    val error: ErrorPayload? = null,
 ) {
     val canSubmit: Boolean
         get() =

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadUiState.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadUiState.kt
@@ -11,10 +11,14 @@ import androidx.compose.runtime.Immutable
  */
 sealed interface ErrorPayload {
     /** 클라이언트가 미리 정의한 generic 문구 (i18n 가능). 서버 message 미제공 시 fallback. */
-    data class Res(@StringRes val id: Int) : ErrorPayload
+    data class Res(
+        @StringRes val id: Int,
+    ) : ErrorPayload
 
     /** 백엔드가 런타임에 내려준 사용자 친화 message (예: 409 "이미 대기 중인 인증 요청이 존재합니다."). */
-    data class Text(val message: String) : ErrorPayload
+    data class Text(
+        val message: String,
+    ) : ErrorPayload
 }
 
 /**

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadUiState.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadUiState.kt
@@ -13,7 +13,24 @@ data class DocumentUploadUiState(
     val deathCertificate: DocumentSlotState = DocumentSlotState(),
     val familyRelationCertificate: DocumentSlotState = DocumentSlotState(),
     val isSubmitting: Boolean = false,
+    /**
+     * 클라이언트가 미리 정의한 generic 문구 (`strings.xml` 의 string resource id).
+     * i18n 가능. 서버 message 가 없을 때 fallback.
+     *
+     * [errorMessage] 와 *상호 배타* — 둘 다 set 하지 않는다 (타입으로 강제 X, 컨벤션).
+     * 화면 측 우선순위는 [errorMessage] 가 우선, 없으면 본 필드 사용.
+     */
     val errorMessageRes: Int? = null,
+    /**
+     * 백엔드가 런타임에 내려준 사용자 친화 message 를 그대로 노출할 때 사용
+     * (예: 409 "이미 대기 중인 인증 요청이 존재합니다."). i18n 불가 — 서버가 한국어로 보낸 가정.
+     *
+     * [errorMessageRes] 와 *상호 배타*. 화면 측은 본 필드를 우선 노출.
+     *
+     * (후속 정리 후보: 두 필드를 `ErrorPayload` sealed 로 합치면 상호 배타 강제 가능 — 다른 VM
+     * 의 동일 패턴까지 일괄 정리될 때 도입 검토.)
+     */
+    val errorMessage: String? = null,
 ) {
     val canSubmit: Boolean
         get() =

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadViewModel.kt
@@ -96,11 +96,12 @@ class DocumentUploadViewModel
                         _uiState.update {
                             it.copy(
                                 isSubmitting = false,
-                                error = if (serverMessage != null) {
-                                    ErrorPayload.Text(serverMessage)
-                                } else {
-                                    ErrorPayload.Res(R.string.receiver_verify_submit_failed)
-                                },
+                                error =
+                                    if (serverMessage != null) {
+                                        ErrorPayload.Text(serverMessage)
+                                    } else {
+                                        ErrorPayload.Res(R.string.receiver_verify_submit_failed)
+                                    },
                             )
                         }
                     }

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadViewModel.kt
@@ -2,6 +2,7 @@ package com.afternote.feature.afternote.presentation.receiver.deliveryverificati
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.feature.afternote.domain.error.ReceiverDeliverySubmitException
 import com.afternote.feature.afternote.domain.repository.receiver.ReceiverAuthRepository
 import com.afternote.feature.afternote.domain.repository.receiver.ReceiverDeliveryDocumentUploadRepository
 import com.afternote.feature.afternote.presentation.R
@@ -73,18 +74,32 @@ class DocumentUploadViewModel
                 }
                 return
             }
-            _uiState.update { it.copy(isSubmitting = true, errorMessageRes = null) }
+            _uiState.update {
+                it.copy(isSubmitting = true, errorMessageRes = null, errorMessage = null)
+            }
             viewModelScope.launch {
                 receiverAuthRepository
                     .submitDeliveryVerification(deathUrl, famRelUrl)
                     .onSuccess {
                         _uiState.update { it.copy(isSubmitting = false) }
                         _events.send(DocumentUploadEvent.Submitted)
-                    }.onFailure {
+                    }.onFailure { throwable ->
+                        // 두 갈래로 분기한다:
+                        //  (1) data 레이어가 ApiException 을 ReceiverDeliverySubmitException 으로 매핑해 내려준 경우
+                        //      → 백엔드가 보낸 사용자 친화 message(예: 409 "이미 대기 중인 인증 요청이 존재합니다.")
+                        //        가 serverMessage 에 담겨 있으므로 그대로 노출.
+                        //  (2) 그 외 throwable (UnknownHostException, SerializationException 등 도메인 매핑 안 된 인프라 예외)
+                        //      → 기술적 메시지라 사용자 노출 부적합. generic 한국어 문구로 fallback.
+                        //
+                        // `as?` = safe cast: 타입 일치 시 캐스팅 값, 불일치 시 null. (1)이면 값, (2)이면 null.
+                        // 이어지는 `?.serverMessage?.takeIf { ... }` 는 null-safe 체인 + 빈 문자열도 null 로 폴백.
+                        val serverMessage =
+                            (throwable as? ReceiverDeliverySubmitException)?.serverMessage?.takeIf { it.isNotBlank() }
                         _uiState.update {
                             it.copy(
                                 isSubmitting = false,
-                                errorMessageRes = R.string.receiver_verify_submit_failed,
+                                errorMessage = serverMessage,
+                                errorMessageRes = R.string.receiver_verify_submit_failed.takeIf { serverMessage == null },
                             )
                         }
                     }
@@ -92,7 +107,7 @@ class DocumentUploadViewModel
         }
 
         fun consumeError() {
-            _uiState.update { it.copy(errorMessageRes = null) }
+            _uiState.update { it.copy(errorMessageRes = null, errorMessage = null) }
         }
 
         private inline fun updateSlot(

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadViewModel.kt
@@ -58,7 +58,7 @@ class DocumentUploadViewModel
                     }.onFailure {
                         updateSlot(slot) { DocumentSlotState() }
                         _uiState.update {
-                            it.copy(errorMessageRes = R.string.receiver_verify_document_upload_failed)
+                            it.copy(error = ErrorPayload.Res(R.string.receiver_verify_document_upload_failed))
                         }
                     }
             }
@@ -70,12 +70,12 @@ class DocumentUploadViewModel
             val famRelUrl = state.familyRelationCertificate.fileUrl
             if (deathUrl == null || famRelUrl == null || state.isSubmitting) {
                 _uiState.update {
-                    it.copy(errorMessageRes = R.string.receiver_verify_documents_required)
+                    it.copy(error = ErrorPayload.Res(R.string.receiver_verify_documents_required))
                 }
                 return
             }
             _uiState.update {
-                it.copy(isSubmitting = true, errorMessageRes = null, errorMessage = null)
+                it.copy(isSubmitting = true, error = null)
             }
             viewModelScope.launch {
                 receiverAuthRepository
@@ -87,19 +87,20 @@ class DocumentUploadViewModel
                         // 두 갈래로 분기한다:
                         //  (1) data 레이어가 ApiException 을 ReceiverDeliverySubmitException 으로 매핑해 내려준 경우
                         //      → 백엔드가 보낸 사용자 친화 message(예: 409 "이미 대기 중인 인증 요청이 존재합니다.")
-                        //        가 serverMessage 에 담겨 있으므로 그대로 노출.
-                        //  (2) 그 외 throwable (UnknownHostException, SerializationException 등 도메인 매핑 안 된 인프라 예외)
-                        //      → 기술적 메시지라 사용자 노출 부적합. generic 한국어 문구로 fallback.
-                        //
-                        // `as?` = safe cast: 타입 일치 시 캐스팅 값, 불일치 시 null. (1)이면 값, (2)이면 null.
-                        // 이어지는 `?.serverMessage?.takeIf { ... }` 는 null-safe 체인 + 빈 문자열도 null 로 폴백.
+                        //        가 serverMessage 에 담겨 있으면 그대로 노출. **null 이면 서버가 message 미제공** —
+                        //        클라 fallback 으로 폴백 (이전엔 클라 fallback 이 ApiException.message 에 섞여
+                        //        사용자에게 "서버 메시지" 인 척 노출되던 버그를 ApiException.serverMessage 분리로 해결).
+                        //  (2) 그 외 throwable (UnknownHostException 등 도메인 매핑 안 된 인프라 예외) → 같은 fallback.
                         val serverMessage =
                             (throwable as? ReceiverDeliverySubmitException)?.serverMessage?.takeIf { it.isNotBlank() }
                         _uiState.update {
                             it.copy(
                                 isSubmitting = false,
-                                errorMessage = serverMessage,
-                                errorMessageRes = R.string.receiver_verify_submit_failed.takeIf { serverMessage == null },
+                                error = if (serverMessage != null) {
+                                    ErrorPayload.Text(serverMessage)
+                                } else {
+                                    ErrorPayload.Res(R.string.receiver_verify_submit_failed)
+                                },
                             )
                         }
                     }
@@ -107,7 +108,7 @@ class DocumentUploadViewModel
         }
 
         fun consumeError() {
-            _uiState.update { it.copy(errorMessageRes = null, errorMessage = null) }
+            _uiState.update { it.copy(error = null) }
         }
 
         private inline fun updateSlot(

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/senderdetail/SenderDetailScreen.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/senderdetail/SenderDetailScreen.kt
@@ -281,13 +281,21 @@ private fun VerificationActionButton(
 ) {
     when (state) {
         SenderVerificationState.NotRequested,
-        SenderVerificationState.Pending,
         SenderVerificationState.Rejected,
         -> {
             AfternoteButton(
                 text = stringResource(R.string.receiver_sender_detail_request_verification),
                 onClick = onRequestVerification,
                 type = AfternoteButtonType.Default,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+
+        SenderVerificationState.Pending -> {
+            AfternoteButton(
+                text = stringResource(R.string.receiver_sender_detail_pending_button),
+                onClick = {},
+                type = AfternoteButtonType.Un,
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/feature/afternote/presentation/src/main/res/values/strings.xml
+++ b/feature/afternote/presentation/src/main/res/values/strings.xml
@@ -142,6 +142,7 @@
     <string name="receiver_sender_detail_no_request_record">신청 기록이 없습니다</string>
     <string name="receiver_sender_detail_no_approval_record">승인 기록이 없습니다</string>
     <string name="receiver_sender_detail_request_verification">열람 신청하기</string>
+    <string name="receiver_sender_detail_pending_button">심사 진행 중</string>
     <string name="receiver_sender_detail_open_records">기록 열람하기</string>
     <string name="receiver_sender_detail_status_load_failed">열람 신청 상태를 불러오지 못했습니다.</string>
     <string name="receiver_sender_detail_not_found">발신자를 찾을 수 없습니다.</string>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #225

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `SenderDetailScreen` 의 `VerificationActionButton` 의 `Pending` 분기를 `NotRequested` / `Rejected` 와 분리 → `AfternoteButtonType.Un` 비활성 버튼 "심사 진행 중" 으로 표시. PENDING 상태 사용자가 진입 즉시 자기 상태 인지 → 본인 확인 → 마스터 키 → 서류 업로드 7+ 화면 거치는 낭비 제거.
- `strings.xml` 에 `receiver_sender_detail_pending_button` 신규 (가칭 "심사 진행 중").
- `feature/afternote/domain/error/ReceiverDeliverySubmitException` 신설 — `serverMessage` 만 보유하는 도메인 예외.
- `ReceiverAuthRepositoryImpl.submitDeliveryVerification` 에 `recoverCatching` 추가 — `ApiException` (네트워크 인프라 예외) → `ReceiverDeliverySubmitException` (도메인 예외) 매핑. presentation 이 `core:network` 직접 의존 안 하도록 layer 책임 분리.
- `DocumentUploadUiState` 에 `errorMessage: String?` 필드 신설 — 백엔드가 내려준 사용자 친화 message (예: 409 "이미 대기 중인 인증 요청이 존재합니다.") 를 그대로 노출하기 위함. 기존 `errorMessageRes: Int?` 와 *상호 배타*.
- `DocumentUploadViewModel.submit()` onFailure 가 `ReceiverDeliverySubmitException.serverMessage` 를 우선 사용, 없으면 generic resId fallback.
- `DocumentUploadScreen` 의 LaunchedEffect 우선순위: `uiState.errorMessage ?: stringResource(errorMessageRes)`.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- **PENDING 버튼 텍스트 "심사 진행 중" 은 가칭** — 디자이너 확정 후 `strings.xml` 의 `receiver_sender_detail_pending_button` 값만 갱신 예정. 시안 11 의 PENDING 시각은 명시 안 되어 있어 본 PR 은 *비활성 + 텍스트 노출* 만 보장.
- **`errorMessage(String?) + errorMessageRes(Int?)` 두 필드 패턴 — 통합 후보**: 본인 영역에 동일 패턴 3 UiState 반복 (`DocumentUploadUiState`, `IdentityVerificationUiState`, `MasterKeyUiState`). `sealed ErrorPayload(Server(String) / Resource(@StringRes Int))` 로 합치면 *상호 배타* 가 타입으로 강제 + 우선순위 로직 한 곳. 본 PR 머지 직전 일괄 이슈화 예정.
- **도메인 예외 매핑 패턴 = 다른 ReceiverAuth 메서드에도 동일 적용 후보**: `verify`, `getPresignedUrl` 등도 현재 `Result<T>.onFailure { Throwable }` 의 generic 처리. 본 PR 의 `submitDeliveryVerification` 패턴을 다른 메서드에도 확대하면 *통합 에러 핸들러* 효과. 본 이슈 본문에 언급된 "통합 에러 핸들러 도입 고려" 후속 작업.