### PR TITLE
fix: 마음의 기록 QA — API 연동/시각 규칙/사용자 이름

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/usecase/GetHomeSummaryUseCase.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/usecase/GetHomeSummaryUseCase.kt
@@ -40,7 +40,12 @@ class GetHomeSummaryUseCase
                     val profile = profileDeferred.await()
                     val receivers = receiversDeferred.await()
                     val diaryCount = diaryDeferred.await().getOrNull()?.size ?: 0
-                    val deepThoughtCount = deepThoughtDeferred.await().getOrNull()?.items?.size ?: 0
+                    val deepThoughtCount =
+                        deepThoughtDeferred
+                            .await()
+                            .getOrNull()
+                            ?.items
+                            ?.size ?: 0
 
                     HomeSummary(
                         userName = profile.name,

--- a/app/src/main/java/com/afternote/afternote_fe/usecase/GetHomeSummaryUseCase.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/usecase/GetHomeSummaryUseCase.kt
@@ -40,7 +40,7 @@ class GetHomeSummaryUseCase
                     val profile = profileDeferred.await()
                     val receivers = receiversDeferred.await()
                     val diaryCount = diaryDeferred.await().getOrNull()?.size ?: 0
-                    val deepThoughtCount = deepThoughtDeferred.await().getOrNull()?.size ?: 0
+                    val deepThoughtCount = deepThoughtDeferred.await().getOrNull()?.items?.size ?: 0
 
                     HomeSummary(
                         userName = profile.name,

--- a/core/ui/src/main/kotlin/com/afternote/core/ui/UiText.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/UiText.kt
@@ -1,0 +1,57 @@
+package com.afternote.core.ui
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.res.stringResource
+
+/**
+ * Presentation 레이어가 ViewModel ↔ Composable 사이에서 "표시할 텍스트" 를 주고받기 위한 타입.
+ *
+ * ViewModel 은 Context/Resources 에 접근하지 않으므로, 리소스 ID 또는 외부에서 받은 동적 문자열을
+ * UiText 로 들고 있다가 Composable 측에서 [asString] 으로 변환한다.
+ */
+sealed interface UiText {
+    data class Resource(
+        @StringRes val resId: Int,
+        val args: List<Any> = emptyList(),
+    ) : UiText
+
+    data class Dynamic(
+        val value: String,
+    ) : UiText
+
+    /** 서버/예외가 메시지를 주면 그대로, 없으면 리소스 fallback. `e.message ?: getString(R.string.x)` 대응. */
+    data class DynamicOrResource(
+        val value: String?,
+        @StringRes val fallbackResId: Int,
+    ) : UiText
+
+    companion object {
+        fun resource(
+            @StringRes resId: Int,
+            vararg args: Any,
+        ): UiText = Resource(resId, args.toList())
+    }
+}
+
+@Composable
+@ReadOnlyComposable
+fun UiText.asString(): String =
+    when (this) {
+        is UiText.Resource -> {
+            if (args.isEmpty()) {
+                stringResource(resId)
+            } else {
+                stringResource(resId, *args.toTypedArray())
+            }
+        }
+
+        is UiText.Dynamic -> {
+            value
+        }
+
+        is UiText.DynamicOrResource -> {
+            value ?: stringResource(fallbackResId)
+        }
+    }

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/api/WeeklyReportApiService.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/api/WeeklyReportApiService.kt
@@ -1,0 +1,13 @@
+package com.afternote.feature.mindrecord.data.api
+
+import com.afternote.core.network.model.BaseResponse
+import com.afternote.feature.mindrecord.data.dto.WeeklyReportResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface WeeklyReportApiService {
+    @GET("mind-record")
+    suspend fun getWeeklyReport(
+        @Query("date") date: String,
+    ): BaseResponse<WeeklyReportResponse>
+}

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/di/MindRecordRepositoryModule.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/di/MindRecordRepositoryModule.kt
@@ -4,10 +4,12 @@ import com.afternote.feature.mindrecord.data.repositoryimpl.DailyQuestionReposit
 import com.afternote.feature.mindrecord.data.repositoryimpl.DeepThoughtRepositoryImpl
 import com.afternote.feature.mindrecord.data.repositoryimpl.DiaryRepositoryImpl
 import com.afternote.feature.mindrecord.data.repositoryimpl.MindRecordReceiverRepositoryImpl
+import com.afternote.feature.mindrecord.data.repositoryimpl.WeeklyReportRepositoryImpl
 import com.afternote.feature.mindrecord.domain.repository.DailyQuestionRepository
 import com.afternote.feature.mindrecord.domain.repository.DeepThoughtRepository
 import com.afternote.feature.mindrecord.domain.repository.DiaryRepository
 import com.afternote.feature.mindrecord.domain.repository.MindRecordReceiverRepository
+import com.afternote.feature.mindrecord.domain.repository.WeeklyReportRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -32,4 +34,8 @@ interface MindRecordRepositoryModule {
     @Binds
     @Singleton
     fun bindMindRecordReceiverRepository(impl: MindRecordReceiverRepositoryImpl): MindRecordReceiverRepository
+
+    @Binds
+    @Singleton
+    fun bindWeeklyReportRepository(impl: WeeklyReportRepositoryImpl): WeeklyReportRepository
 }

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/di/MindRecordServiceModule.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/di/MindRecordServiceModule.kt
@@ -4,6 +4,7 @@ import com.afternote.feature.mindrecord.data.api.DailyQuestionApiService
 import com.afternote.feature.mindrecord.data.api.DeepThoughtApiService
 import com.afternote.feature.mindrecord.data.api.DiaryApiService
 import com.afternote.feature.mindrecord.data.api.MindRecordReceiverApiService
+import com.afternote.feature.mindrecord.data.api.WeeklyReportApiService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -30,4 +31,8 @@ object MindRecordServiceModule {
     @Singleton
     fun provideMindRecordReceiverApiService(retrofit: Retrofit): MindRecordReceiverApiService =
         retrofit.create(MindRecordReceiverApiService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideWeeklyReportApiService(retrofit: Retrofit): WeeklyReportApiService = retrofit.create(WeeklyReportApiService::class.java)
 }

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DeepThoughtDto.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DeepThoughtDto.kt
@@ -29,17 +29,23 @@ data class DeepThoughtListItem(
     @SerialName("title") val title: String,
     @SerialName("content") val content: String,
     @SerialName("category") val category: String,
-    @SerialName("is_draft") val isDraft: Boolean,
-    @SerialName("tag") val tag: List<String> = emptyList(),
+    @SerialName("isDraft") val isDraft: Boolean,
+    @SerialName("tags") val tags: List<String> = emptyList(),
     @SerialName("imageUrl") val imageUrl: String? = null,
+    @SerialName("createdAt") val createdAt: String = "",
+    @SerialName("updatedAt") val updatedAt: String? = null,
 )
 
-// `/deep-thought` 응답의 `data` 는 배열이 아니라 객체 — `deepThoughts` 외에도
-// `tagCounts` 가 함께 내려오지만 현재는 목록만 사용.
-// (Json 글로벌 설정에 `ignoreUnknownKeys = true` 적용됨)
+@Serializable
+data class DeepThoughtTagCountDto(
+    @SerialName("tag") val tag: String,
+    @SerialName("count") val count: Int,
+)
+
 @Serializable
 data class DeepThoughtListResponse(
     @SerialName("deepThoughts") val deepThoughts: List<DeepThoughtListItem> = emptyList(),
+    @SerialName("tagCounts") val tagCounts: List<DeepThoughtTagCountDto> = emptyList(),
 )
 
 @Serializable

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/WeeklyReportDto.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/WeeklyReportDto.kt
@@ -1,0 +1,37 @@
+package com.afternote.feature.mindrecord.data.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WeeklyReportResponse(
+    @SerialName("dailyQuestionAmount") val dailyQuestionAmount: Int = 0,
+    @SerialName("diaryAmount") val diaryAmount: Int = 0,
+    @SerialName("deepThoughtAmount") val deepThoughtAmount: Int = 0,
+    @SerialName("summaryText") val summaryText: String = "",
+    @SerialName("week") val week: List<WeeklyReportDayDto> = emptyList(),
+    // 서버 JSON 키가 kebab-case (`daily-question`).
+    @SerialName("daily-question") val dailyQuestions: List<WeeklyReportDailyQuestionDto> = emptyList(),
+    @SerialName("emotions") val emotions: List<WeeklyReportEmotionDto> = emptyList(),
+)
+
+@Serializable
+data class WeeklyReportDayDto(
+    @SerialName("diaryId") val diaryId: Long = 0L,
+    @SerialName("day") val day: Int = 0,
+    @SerialName("isDiary") val isDiary: Boolean = false,
+    @SerialName("emotion") val emotion: TodayMood? = null,
+)
+
+@Serializable
+data class WeeklyReportDailyQuestionDto(
+    @SerialName("title") val title: String = "",
+    @SerialName("content") val content: String = "",
+    @SerialName("date") val date: String = "",
+)
+
+@Serializable
+data class WeeklyReportEmotionDto(
+    @SerialName("keyword") val keyword: String = "",
+    @SerialName("percentage") val percentage: Int = 0,
+)

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DeepThoughtMapper.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DeepThoughtMapper.kt
@@ -6,6 +6,8 @@ import com.afternote.feature.mindrecord.data.dto.DeepThoughtCategoryMutationResp
 import com.afternote.feature.mindrecord.data.dto.DeepThoughtCategoryUpdateRequest
 import com.afternote.feature.mindrecord.data.dto.DeepThoughtCreateRequest
 import com.afternote.feature.mindrecord.data.dto.DeepThoughtListItem
+import com.afternote.feature.mindrecord.data.dto.DeepThoughtListResponse
+import com.afternote.feature.mindrecord.data.dto.DeepThoughtTagCountDto
 import com.afternote.feature.mindrecord.data.dto.DeepThoughtUpdateRequest
 import com.afternote.feature.mindrecord.data.dto.RandomDeepThoughtResponse
 import com.afternote.feature.mindrecord.domain.model.DeepThought
@@ -13,6 +15,8 @@ import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategory
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategoryCreatePayload
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategoryUpdatePayload
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCreatePayload
+import com.afternote.feature.mindrecord.domain.model.DeepThoughtList
+import com.afternote.feature.mindrecord.domain.model.DeepThoughtTagCount
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtUpdatePayload
 import com.afternote.feature.mindrecord.domain.model.RandomDeepThought
 
@@ -23,8 +27,22 @@ fun DeepThoughtListItem.toDomain(): DeepThought =
         content = content,
         category = category,
         isDraft = isDraft,
-        tags = tag,
+        tags = tags,
         imageUrl = imageUrl,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+    )
+
+fun DeepThoughtTagCountDto.toDomain(): DeepThoughtTagCount =
+    DeepThoughtTagCount(
+        tag = tag,
+        count = count,
+    )
+
+fun DeepThoughtListResponse.toDomain(): DeepThoughtList =
+    DeepThoughtList(
+        items = deepThoughts.map { it.toDomain() },
+        tagCounts = tagCounts.map { it.toDomain() },
     )
 
 fun RandomDeepThoughtResponse.toDomain(): RandomDeepThought =

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/WeeklyReportMapper.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/WeeklyReportMapper.kt
@@ -1,0 +1,42 @@
+package com.afternote.feature.mindrecord.data.mapper
+
+import com.afternote.feature.mindrecord.data.dto.WeeklyReportDailyQuestionDto
+import com.afternote.feature.mindrecord.data.dto.WeeklyReportDayDto
+import com.afternote.feature.mindrecord.data.dto.WeeklyReportEmotionDto
+import com.afternote.feature.mindrecord.data.dto.WeeklyReportResponse
+import com.afternote.feature.mindrecord.domain.model.WeeklyReport
+import com.afternote.feature.mindrecord.domain.model.WeeklyReportDailyQuestion
+import com.afternote.feature.mindrecord.domain.model.WeeklyReportDay
+import com.afternote.feature.mindrecord.domain.model.WeeklyReportEmotion
+
+fun WeeklyReportResponse.toDomain(): WeeklyReport =
+    WeeklyReport(
+        dailyQuestionAmount = dailyQuestionAmount,
+        diaryAmount = diaryAmount,
+        deepThoughtAmount = deepThoughtAmount,
+        summaryText = summaryText,
+        week = week.map { it.toDomain() },
+        dailyQuestions = dailyQuestions.map { it.toDomain() },
+        emotions = emotions.map { it.toDomain() },
+    )
+
+fun WeeklyReportDayDto.toDomain(): WeeklyReportDay =
+    WeeklyReportDay(
+        diaryId = diaryId,
+        day = day,
+        isDiary = isDiary,
+        emotion = emotion?.toDomain(),
+    )
+
+fun WeeklyReportDailyQuestionDto.toDomain(): WeeklyReportDailyQuestion =
+    WeeklyReportDailyQuestion(
+        title = title,
+        content = content,
+        date = date,
+    )
+
+fun WeeklyReportEmotionDto.toDomain(): WeeklyReportEmotion =
+    WeeklyReportEmotion(
+        keyword = keyword,
+        percentage = percentage,
+    )

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/repositoryimpl/DeepThoughtRepositoryImpl.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/repositoryimpl/DeepThoughtRepositoryImpl.kt
@@ -5,11 +5,11 @@ import com.afternote.core.network.model.requireStatus
 import com.afternote.feature.mindrecord.data.api.DeepThoughtApiService
 import com.afternote.feature.mindrecord.data.mapper.toDomain
 import com.afternote.feature.mindrecord.data.mapper.toRequest
-import com.afternote.feature.mindrecord.domain.model.DeepThought
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategory
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategoryCreatePayload
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategoryUpdatePayload
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCreatePayload
+import com.afternote.feature.mindrecord.domain.model.DeepThoughtList
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtUpdatePayload
 import com.afternote.feature.mindrecord.domain.model.RandomDeepThought
 import com.afternote.feature.mindrecord.domain.repository.DeepThoughtRepository
@@ -24,13 +24,12 @@ class DeepThoughtRepositoryImpl
             date: String?,
             tag: String?,
             category: String?,
-        ): Result<List<DeepThought>> =
+        ): Result<DeepThoughtList> =
             runCatching {
                 api
                     .getDeepThoughts(date = date, tag = tag, category = category)
                     .requireData()
-                    .deepThoughts
-                    .map { it.toDomain() }
+                    .toDomain()
             }
 
         override suspend fun getRandom(): Result<RandomDeepThought> =

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/repositoryimpl/WeeklyReportRepositoryImpl.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/repositoryimpl/WeeklyReportRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.afternote.feature.mindrecord.data.repositoryimpl
+
+import com.afternote.core.network.model.requireData
+import com.afternote.feature.mindrecord.data.api.WeeklyReportApiService
+import com.afternote.feature.mindrecord.data.mapper.toDomain
+import com.afternote.feature.mindrecord.domain.model.WeeklyReport
+import com.afternote.feature.mindrecord.domain.repository.WeeklyReportRepository
+import javax.inject.Inject
+
+class WeeklyReportRepositoryImpl
+    @Inject
+    constructor(
+        private val api: WeeklyReportApiService,
+    ) : WeeklyReportRepository {
+        override suspend fun getWeeklyReport(date: String): Result<WeeklyReport> =
+            runCatching {
+                api.getWeeklyReport(date = date).requireData().toDomain()
+            }
+    }

--- a/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/DeepThoughtCategoryName.kt
+++ b/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/DeepThoughtCategoryName.kt
@@ -8,7 +8,7 @@ value class DeepThoughtCategoryName private constructor(
         fun from(raw: String): Result<DeepThoughtCategoryName> {
             val trimmed = raw.trim()
             return if (trimmed.isEmpty()) {
-                Result.failure(IllegalArgumentException("카테고리 이름이 비어 있습니다."))
+                Result.failure(MindRecordError.EmptyCategoryName)
             } else {
                 Result.success(DeepThoughtCategoryName(trimmed))
             }

--- a/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/DeepThoughtModels.kt
+++ b/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/DeepThoughtModels.kt
@@ -6,8 +6,20 @@ data class DeepThought(
     val content: String,
     val category: String,
     val isDraft: Boolean,
+    val createdAt: String,
     val tags: List<String> = emptyList(),
     val imageUrl: String? = null,
+    val updatedAt: String? = null,
+)
+
+data class DeepThoughtTagCount(
+    val tag: String,
+    val count: Int,
+)
+
+data class DeepThoughtList(
+    val items: List<DeepThought>,
+    val tagCounts: List<DeepThoughtTagCount>,
 )
 
 data class RandomDeepThought(

--- a/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/MindRecordError.kt
+++ b/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/MindRecordError.kt
@@ -1,0 +1,10 @@
+package com.afternote.feature.mindrecord.domain.model
+
+/**
+ * 도메인 레이어가 던지는 알려진 에러. 메시지 문자열을 도메인에 두지 않기 위해 typed
+ * 형태로 정의하고, presentation 레이어가 R.string 으로 매핑한다.
+ */
+sealed class MindRecordError : Exception() {
+    /** 카테고리 이름이 trim 후 비어 있을 때. */
+    object EmptyCategoryName : MindRecordError()
+}

--- a/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/WeeklyReportModels.kt
+++ b/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/WeeklyReportModels.kt
@@ -1,0 +1,29 @@
+package com.afternote.feature.mindrecord.domain.model
+
+data class WeeklyReport(
+    val dailyQuestionAmount: Int,
+    val diaryAmount: Int,
+    val deepThoughtAmount: Int,
+    val summaryText: String,
+    val week: List<WeeklyReportDay>,
+    val dailyQuestions: List<WeeklyReportDailyQuestion>,
+    val emotions: List<WeeklyReportEmotion>,
+)
+
+data class WeeklyReportDay(
+    val diaryId: Long,
+    val day: Int,
+    val isDiary: Boolean,
+    val emotion: TodayMood?,
+)
+
+data class WeeklyReportDailyQuestion(
+    val title: String,
+    val content: String,
+    val date: String,
+)
+
+data class WeeklyReportEmotion(
+    val keyword: String,
+    val percentage: Int,
+)

--- a/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/repository/DeepThoughtRepository.kt
+++ b/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/repository/DeepThoughtRepository.kt
@@ -1,10 +1,10 @@
 package com.afternote.feature.mindrecord.domain.repository
 
-import com.afternote.feature.mindrecord.domain.model.DeepThought
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategory
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategoryCreatePayload
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategoryUpdatePayload
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCreatePayload
+import com.afternote.feature.mindrecord.domain.model.DeepThoughtList
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtUpdatePayload
 import com.afternote.feature.mindrecord.domain.model.RandomDeepThought
 
@@ -13,7 +13,7 @@ interface DeepThoughtRepository {
         date: String? = null,
         tag: String? = null,
         category: String? = null,
-    ): Result<List<DeepThought>>
+    ): Result<DeepThoughtList>
 
     suspend fun getRandom(): Result<RandomDeepThought>
 

--- a/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/repository/WeeklyReportRepository.kt
+++ b/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/repository/WeeklyReportRepository.kt
@@ -1,0 +1,10 @@
+package com.afternote.feature.mindrecord.domain.repository
+
+import com.afternote.feature.mindrecord.domain.model.WeeklyReport
+
+interface WeeklyReportRepository {
+    /**
+     * @param date 조회하려는 주의 **월요일** 날짜 (`yyyy-MM-dd`).
+     */
+    suspend fun getWeeklyReport(date: String): Result<WeeklyReport>
+}

--- a/feature/mindrecord/presentation/build.gradle.kts
+++ b/feature/mindrecord/presentation/build.gradle.kts
@@ -12,6 +12,7 @@ android {
 dependencies {
     implementation(projects.feature.mindrecord.domain)
     implementation(projects.core.common)
+    implementation(projects.core.domain)
     implementation(projects.core.ui)
     implementation(projects.core.model)
     implementation(libs.coil.compose)

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/BottomSheetCalendar.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/BottomSheetCalendar.kt
@@ -1,6 +1,8 @@
 package com.afternote.feature.mindrecord.presentation.component
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.afternote.feature.mindrecord.presentation.R
 import java.time.LocalDate
 import com.afternote.core.ui.calendar.BottomSheetCalendar as CoreBottomSheetCalendar
 
@@ -13,7 +15,7 @@ fun BottomSheetCalendar(
     CoreBottomSheetCalendar(
         onDismiss = onDismiss,
         onDateSelect = onDateSelect,
-        title = "발송 날짜",
+        title = stringResource(R.string.mindrecord_calendar_send_date_title),
         initialDate = initialDate,
     )
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/CategoryActionSheets.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/CategoryActionSheets.kt
@@ -19,8 +19,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
+import com.afternote.feature.mindrecord.presentation.R
 
 @Composable
 fun CategoryNameDialog(
@@ -51,7 +53,7 @@ fun CategoryNameDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("취소") }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.mindrecord_action_cancel)) }
         },
     )
 }
@@ -78,7 +80,7 @@ fun CategoryActionSheet(
                 modifier = Modifier.padding(vertical = 8.dp),
             )
             Text(
-                text = "이름 수정",
+                text = stringResource(R.string.mindrecord_action_rename),
                 style = AfternoteDesign.typography.bodyBase,
                 color = AfternoteDesign.colors.gray9,
                 modifier =
@@ -88,7 +90,7 @@ fun CategoryActionSheet(
                         .padding(vertical = 14.dp),
             )
             Text(
-                text = "삭제",
+                text = stringResource(R.string.mindrecord_action_delete),
                 style = AfternoteDesign.typography.bodyBase,
                 color = Color(0xFFE5484D),
                 modifier =

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/CategorySettingBottomSheet.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/CategorySettingBottomSheet.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -30,6 +31,7 @@ import com.afternote.core.ui.R
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.model.CategoryUiModel
+import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -92,7 +94,7 @@ fun CategorySettingContent(
             // 뒤로가기
             Icon(
                 painter = painterResource(R.drawable.core_ui_arrow_left),
-                contentDescription = "뒤로가기",
+                contentDescription = stringResource(MindRecordR.string.mindrecord_back_cd),
                 modifier =
                     Modifier
                         .align(Alignment.CenterStart)
@@ -101,7 +103,7 @@ fun CategorySettingContent(
                 tint = AfternoteDesign.colors.gray9,
             )
             Text(
-                text = "카테고리 설정하기",
+                text = stringResource(MindRecordR.string.mindrecord_category_setting_title),
                 style = AfternoteDesign.typography.h3,
                 color = AfternoteDesign.colors.gray9,
                 textAlign = TextAlign.Center,
@@ -127,7 +129,7 @@ fun CategorySettingContent(
             )
             Spacer(modifier = Modifier.width(12.dp))
             Text(
-                text = "새 카테고리 만들기",
+                text = stringResource(MindRecordR.string.mindrecord_category_new_title),
                 style = AfternoteDesign.typography.bodyBase,
                 color = AfternoteDesign.colors.gray9,
             )
@@ -179,7 +181,7 @@ fun CategoryItem(
         // 더보기 메뉴
         Icon(
             painter = painterResource(R.drawable.core_ui_vertical), // ⋮ 아이콘
-            contentDescription = "더보기",
+            contentDescription = stringResource(MindRecordR.string.mindrecord_more_cd),
             tint = AfternoteDesign.colors.gray5,
             modifier =
                 Modifier

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyCalendar.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyCalendar.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -26,6 +27,7 @@ import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.model.DayState
 import com.afternote.feature.mindrecord.presentation.model.DayUiModel
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
+import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 import java.util.Calendar
 
 @Composable
@@ -36,8 +38,10 @@ fun DailyCalendar(
     onPrevMonth: () -> Unit,
     onNextMonth: () -> Unit,
     modifier: Modifier = Modifier,
+    answeredDays: Set<Int> = emptySet(),
+    emotionByDay: Map<Int, String> = emptyMap(),
 ) {
-    val days = buildDays(year, month)
+    val days = buildDays(year, month, answeredDays, emotionByDay)
 
     Column(modifier = modifier) {
         Row(
@@ -50,7 +54,7 @@ fun DailyCalendar(
                 modifier = Modifier.clickable { onPrevMonth() },
             )
             Text(
-                text = "${year}년 ${month}월",
+                text = stringResource(MindRecordR.string.mindrecord_calendar_year_month, year, month),
                 color = AfternoteDesign.colors.gray9,
                 style = AfternoteDesign.typography.h3,
             )
@@ -62,7 +66,7 @@ fun DailyCalendar(
         }
         Spacer(modifier = Modifier.height(4.dp))
         Text(
-            text = "18개의 답변 완료",
+            text = stringResource(MindRecordR.string.mindrecord_calendar_answered_count, answeredDays.size),
             style = AfternoteDesign.typography.captionLargeR,
             color = AfternoteDesign.colors.black.copy(alpha = 0.35f),
         )
@@ -76,7 +80,16 @@ fun DailyCalendar(
             modifier = Modifier.fillMaxWidth(),
         ) {
             Column {
-                val dayLabels = listOf("일", "월", "화", "수", "목", "금", "토")
+                val dayLabels =
+                    listOf(
+                        stringResource(MindRecordR.string.mindrecord_calendar_day_label_sun),
+                        stringResource(MindRecordR.string.mindrecord_calendar_day_label_mon),
+                        stringResource(MindRecordR.string.mindrecord_calendar_day_label_tue),
+                        stringResource(MindRecordR.string.mindrecord_calendar_day_label_wed),
+                        stringResource(MindRecordR.string.mindrecord_calendar_day_label_thu),
+                        stringResource(MindRecordR.string.mindrecord_calendar_day_label_fri),
+                        stringResource(MindRecordR.string.mindrecord_calendar_day_label_sat),
+                    )
 
                 Spacer(modifier = Modifier.height(16.dp))
                 Row(modifier = Modifier.fillMaxWidth()) {
@@ -119,6 +132,8 @@ fun DailyCalendar(
 fun buildDays(
     year: Int,
     month: Int,
+    answeredDays: Set<Int>,
+    emotionByDay: Map<Int, String>,
 ): List<DayUiModel> {
     val calendar =
         Calendar.getInstance().apply {
@@ -127,23 +142,31 @@ fun buildDays(
     val firstDayOfWeek = calendar.get(Calendar.DAY_OF_WEEK) - 1 // 0=일
     val daysInMonth = calendar.getActualMaximum(Calendar.DAY_OF_MONTH)
 
+    val now = Calendar.getInstance()
     val today =
-        Calendar
-            .getInstance()
-            .get(Calendar.DAY_OF_MONTH)
-            .takeIf { Calendar.getInstance().get(Calendar.MONTH) == month - 1 }
+        if (now.get(Calendar.YEAR) == year && now.get(Calendar.MONTH) == month - 1) {
+            now.get(Calendar.DAY_OF_MONTH)
+        } else {
+            null
+        }
 
     return buildList {
         // 앞 빈 셀
         repeat(firstDayOfWeek) { add(DayUiModel(day = null)) }
-        // 날짜 셀 (실제 상태는 ViewModel에서 주입)
         for (day in 1..daysInMonth) {
             val state =
-                when (day) {
-                    today -> DayState.TODAY
-                    else -> DayState.ANSWERED // ViewModel에서 실제 데이터로 교체
+                when {
+                    day == today -> DayState.TODAY
+                    day in answeredDays -> DayState.ANSWERED
+                    else -> DayState.NONE
                 }
-            add(DayUiModel(day = day, state = state))
+            add(
+                DayUiModel(
+                    day = day,
+                    state = state,
+                    emotion = emotionByDay[day],
+                ),
+            )
         }
     }
 }
@@ -153,11 +176,28 @@ fun buildDays(
 private fun DailyCalendarPreview() {
     AfternoteTheme {
         DailyCalendar(
-            year = 2022,
+            year = 2026,
             month = 1,
             type = MindRecordCategoryUi.DailyQuestion,
             onNextMonth = {},
             onPrevMonth = {},
+            answeredDays = setOf(3, 7, 14),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DailyCalendarDiaryPreview() {
+    AfternoteTheme {
+        DailyCalendar(
+            year = 2026,
+            month = 1,
+            type = MindRecordCategoryUi.Diary,
+            onNextMonth = {},
+            onPrevMonth = {},
+            answeredDays = setOf(3, 7, 14),
+            emotionByDay = mapOf(3 to "😊", 7 to "😢", 14 to "😐"),
         )
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyCalendar.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyCalendar.kt
@@ -27,8 +27,8 @@ import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.model.DayState
 import com.afternote.feature.mindrecord.presentation.model.DayUiModel
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
-import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 import java.util.Calendar
+import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 
 @Composable
 fun DailyCalendar(

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyDeepThoughtCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyDeepThoughtCard.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
@@ -69,7 +70,7 @@ fun DailyDeepThoughtCard(modifier: Modifier = Modifier) {
 
             Spacer(modifier = Modifier.height(18.dp))
             Text(
-                text = "생각은 깊이를 더할수록 진실에 가까워진다.",
+                text = stringResource(R.string.mindrecord_daily_deepthought_default_text),
                 style = AfternoteDesign.typography.bodyLargeB,
                 color = AfternoteDesign.colors.gray8,
             )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyQuestionWriteHeaderCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyQuestionWriteHeaderCard.kt
@@ -23,16 +23,18 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.R
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 
 @Composable
 fun DailyQuestionWriteHeaderCard(
     modifier: Modifier = Modifier,
-    questionText: String = "오늘 하루, \n누구에게 가장 고마웠나요?",
+    questionText: String = stringResource(MindRecordR.string.mindrecord_daily_question_default_thanks),
     onAnswerClick: () -> Unit = {},
 ) {
     OutlinedCard(
@@ -80,7 +82,7 @@ fun DailyQuestionWriteHeaderCard(
             Spacer(modifier = Modifier.height(7.5.dp))
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = "답변하러가기",
+                    text = stringResource(MindRecordR.string.mindrecord_daily_question_go_answer),
                     style = AfternoteDesign.typography.captionLargeR,
                     color = AfternoteDesign.colors.gray6,
                 )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DayCell.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DayCell.kt
@@ -32,11 +32,24 @@ fun DayCell(
         return
     }
 
-    val (bgColor, textColor) =
+    // - TODAY: 검은 원 + 흰 글자
+    // - ANSWERED(작성한 날): 투명 배경 + 진한 글자 + 하단 인디케이터 (diary 는 이모지, 그 외는 점)
+    // - NONE/UNANSWERED: 투명 배경 + 회색 글자, 인디케이터 없음
+    val bgColor =
         when (model.state) {
-            DayState.TODAY -> Color(0xFF1A1A1A) to AfternoteDesign.colors.white
-            DayState.ANSWERED -> AfternoteDesign.colors.gray2 to AfternoteDesign.colors.gray9
-            DayState.UNANSWERED, DayState.NONE -> Color.Transparent to AfternoteDesign.colors.gray5
+            DayState.TODAY -> Color(0xFF1A1A1A)
+            else -> Color.Transparent
+        }
+    val textColor =
+        when (model.state) {
+            DayState.TODAY -> AfternoteDesign.colors.white
+            DayState.ANSWERED -> AfternoteDesign.colors.gray9
+            DayState.UNANSWERED, DayState.NONE -> AfternoteDesign.colors.gray5
+        }
+    val textStyle =
+        when (model.state) {
+            DayState.TODAY, DayState.ANSWERED -> AfternoteDesign.typography.captionLargeB
+            DayState.UNANSWERED, DayState.NONE -> AfternoteDesign.typography.captionLargeR
         }
 
     Box(
@@ -57,10 +70,10 @@ fun DayCell(
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(
                     text = model.day.toString(),
-                    style = AfternoteDesign.typography.captionLargeB,
+                    style = textStyle,
                     color = textColor,
                 )
-                if (model.state == DayState.ANSWERED || model.state == DayState.UNANSWERED) {
+                if (model.state == DayState.ANSWERED) {
                     Spacer(modifier = Modifier.height(2.dp))
                     type.DayIndicator(model = model, textColor = textColor)
                 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryReportCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryReportCard.kt
@@ -15,10 +15,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R
 
 @Composable
 fun DiaryReportCard(modifier: Modifier = Modifier) {
@@ -44,13 +46,13 @@ fun DiaryReportCard(modifier: Modifier = Modifier) {
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 Text(
-                    text = "이번 달",
+                    text = stringResource(R.string.mindrecord_weekly_report_this_month),
                     style = AfternoteDesign.typography.mono,
                     color = AfternoteDesign.colors.gray6,
                 )
 
                 Text(
-                    text = "주간 평균 기분",
+                    text = stringResource(R.string.mindrecord_weekly_report_avg_mood_weekly),
                     style = AfternoteDesign.typography.mono,
                     color = AfternoteDesign.colors.gray6,
                 )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/EmotionKeywordCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/EmotionKeywordCard.kt
@@ -20,11 +20,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R
 
 // ───────────────────────────────────────────────
 // 데이터 모델
@@ -47,9 +49,9 @@ data class EmotionBubble(
 @Composable
 fun EmotionKeywordCard(
     modifier: Modifier = Modifier,
-    title: String = "나의 감정 키워드",
+    title: String = stringResource(R.string.mindrecord_emotion_card_title),
     bubbles: List<EmotionBubble> = defaultBubbles(),
-    descriptionText: String = "이번 주 박서연 님의 기록에서는\n'가족'을 위한 '감사'의 마음이 엿보입니다.",
+    descriptionText: String = stringResource(R.string.mindrecord_emotion_card_default_description),
 ) {
     val canvasHeight = 180.dp // 버블 영역 고정 높이
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/FlowTags.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/FlowTags.kt
@@ -8,8 +8,10 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
+import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.model.Tag
 
 @Composable
@@ -29,7 +31,7 @@ fun FlowTags(
             onClick = { onclick() },
             label = {
                 Text(
-                    "전체",
+                    stringResource(R.string.mindrecord_tag_all),
                     style = AfternoteDesign.typography.captionLargeB,
                     color = if (selectedTag == null) AfternoteDesign.colors.gray1 else AfternoteDesign.colors.gray6,
                 )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/InsightCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/InsightCard.kt
@@ -12,13 +12,18 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R
 
 @Composable
-fun InsightCard(modifier: Modifier = Modifier) {
+fun InsightCard(
+    modifier: Modifier = Modifier,
+    bodyText: String = stringResource(R.string.mindrecord_insight_card_default_body),
+) {
     OutlinedCard(
         colors =
             CardDefaults.cardColors(
@@ -37,7 +42,7 @@ fun InsightCard(modifier: Modifier = Modifier) {
             Spacer(modifier = Modifier.height(17.dp))
 
             Text(
-                text = "이번주는 가족과 함께하는 시간을 가장 많이 기록하셨네요. 일상의 소중함을 느끼는 한주였던 것 같아요.",
+                text = bodyText,
                 style = AfternoteDesign.typography.bodySmallB,
                 color = AfternoteDesign.colors.black.copy(alpha = 0.7f),
             )
@@ -45,7 +50,7 @@ fun InsightCard(modifier: Modifier = Modifier) {
             Spacer(modifier = Modifier.height(17.dp))
 
             Text(
-                text = "매일 꾸준히 기록하는 습관이 정말 멋져요!",
+                text = stringResource(R.string.mindrecord_insight_card_footer),
                 style = AfternoteDesign.typography.captionLargeR,
                 color = AfternoteDesign.colors.gray6,
             )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/KeyBoardToolBar.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/KeyBoardToolBar.kt
@@ -53,7 +53,7 @@ fun BottomToolbar(
     ) {
         IconButton(onClick = onLinkClick) {
             Icon(
-                painter = painterResource(R.drawable.mindrecord_link),
+                painter = painterResource(com.afternote.core.ui.R.drawable.core_ui_ic_link),
                 contentDescription = stringResource(R.string.mindrecord_toolbar_link_cd),
             )
         }
@@ -156,7 +156,7 @@ fun TextStyleToolbar(
             ) {
                 IconActionButton(onClick = onLinkClick) {
                     Icon(
-                        painter = painterResource(R.drawable.mindrecord_link),
+                        painter = painterResource(com.afternote.core.ui.R.drawable.core_ui_ic_link),
                         contentDescription = stringResource(R.string.mindrecord_toolbar_link_cd),
                         tint = AfternoteDesign.colors.gray9,
                     )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/KeyBoardToolBar.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/KeyBoardToolBar.kt
@@ -352,9 +352,21 @@ private fun HeaderTypeRow(
     val items =
         listOf(
             HeaderTypeItem(TextStyleType.TITLE, stringResource(R.string.mindrecord_toolbar_style_title), AfternoteDesign.typography.h3),
-            HeaderTypeItem(TextStyleType.HEADER, stringResource(R.string.mindrecord_toolbar_style_header), AfternoteDesign.typography.bodyLargeB),
-            HeaderTypeItem(TextStyleType.SUBHEADER, stringResource(R.string.mindrecord_toolbar_style_subheader), AfternoteDesign.typography.bodySmallB),
-            HeaderTypeItem(TextStyleType.BODY, stringResource(R.string.mindrecord_toolbar_style_body), AfternoteDesign.typography.captionLargeR),
+            HeaderTypeItem(
+                TextStyleType.HEADER,
+                stringResource(R.string.mindrecord_toolbar_style_header),
+                AfternoteDesign.typography.bodyLargeB,
+            ),
+            HeaderTypeItem(
+                TextStyleType.SUBHEADER,
+                stringResource(R.string.mindrecord_toolbar_style_subheader),
+                AfternoteDesign.typography.bodySmallB,
+            ),
+            HeaderTypeItem(
+                TextStyleType.BODY,
+                stringResource(R.string.mindrecord_toolbar_style_body),
+                AfternoteDesign.typography.captionLargeR,
+            ),
         )
     Row(
         modifier =

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/KeyBoardToolBar.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/KeyBoardToolBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -34,7 +35,6 @@ import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.model.TextStyleState
 import com.afternote.feature.mindrecord.presentation.model.TextStyleType
-import com.afternote.core.ui.R as CoreUiR
 
 @Composable
 fun BottomToolbar(
@@ -52,7 +52,10 @@ fun BottomToolbar(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         IconButton(onClick = onLinkClick) {
-            Icon(painter = painterResource(CoreUiR.drawable.core_ui_ic_link), contentDescription = "링크")
+            Icon(
+                painter = painterResource(R.drawable.mindrecord_link),
+                contentDescription = stringResource(R.string.mindrecord_toolbar_link_cd),
+            )
         }
         Spacer(modifier = Modifier.width(8.dp))
 
@@ -66,19 +69,28 @@ fun BottomToolbar(
         Spacer(modifier = Modifier.width(8.dp))
 
         IconButton(onClick = { onAlignChange(TextAlign.Start) }) {
-            Icon(painter = painterResource(R.drawable.mindrecord_align_left), contentDescription = "왼쪽 정렬")
+            Icon(
+                painter = painterResource(R.drawable.mindrecord_align_left),
+                contentDescription = stringResource(R.string.mindrecord_toolbar_align_left_cd),
+            )
         }
         IconButton(onClick = { onAlignChange(TextAlign.Center) }) {
-            Icon(painter = painterResource(R.drawable.mindrecord_align_center), contentDescription = "가운데 정렬")
+            Icon(
+                painter = painterResource(R.drawable.mindrecord_align_center),
+                contentDescription = stringResource(R.string.mindrecord_toolbar_align_center_cd),
+            )
         }
         IconButton(onClick = { onAlignChange(TextAlign.End) }) {
-            Icon(painter = painterResource(R.drawable.mindrecord_align_right), contentDescription = "오른쪽 정렬")
+            Icon(
+                painter = painterResource(R.drawable.mindrecord_align_right),
+                contentDescription = stringResource(R.string.mindrecord_toolbar_align_right_cd),
+            )
         }
 
         Spacer(modifier = Modifier.weight(1f))
 
         Text(
-            text = "임시저장 1",
+            text = stringResource(R.string.mindrecord_toolbar_draft_count, 1),
             style = AfternoteDesign.typography.captionLargeR,
             color = AfternoteDesign.colors.gray6,
         )
@@ -120,7 +132,7 @@ fun TextStyleToolbar(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = "텍스트 설정",
+                text = stringResource(R.string.mindrecord_toolbar_text_settings),
                 style = AfternoteDesign.typography.bodyBase,
                 color = AfternoteDesign.colors.gray6,
             )
@@ -144,8 +156,8 @@ fun TextStyleToolbar(
             ) {
                 IconActionButton(onClick = onLinkClick) {
                     Icon(
-                        painter = painterResource(CoreUiR.drawable.core_ui_ic_link),
-                        contentDescription = "링크",
+                        painter = painterResource(R.drawable.mindrecord_link),
+                        contentDescription = stringResource(R.string.mindrecord_toolbar_link_cd),
                         tint = AfternoteDesign.colors.gray9,
                     )
                 }
@@ -193,7 +205,7 @@ private fun CloseButton(onClick: () -> Unit) {
     ) {
         Icon(
             painter = painterResource(R.drawable.mindrecord_close),
-            contentDescription = "닫기",
+            contentDescription = stringResource(R.string.mindrecord_toolbar_close_cd),
             tint = AfternoteDesign.colors.gray9,
             modifier = Modifier.size(10.dp),
         )
@@ -339,10 +351,10 @@ private fun HeaderTypeRow(
 ) {
     val items =
         listOf(
-            HeaderTypeItem(TextStyleType.TITLE, "제목", AfternoteDesign.typography.h3),
-            HeaderTypeItem(TextStyleType.HEADER, "머릿말", AfternoteDesign.typography.bodyLargeB),
-            HeaderTypeItem(TextStyleType.SUBHEADER, "부머릿말", AfternoteDesign.typography.bodySmallB),
-            HeaderTypeItem(TextStyleType.BODY, "본문", AfternoteDesign.typography.captionLargeR),
+            HeaderTypeItem(TextStyleType.TITLE, stringResource(R.string.mindrecord_toolbar_style_title), AfternoteDesign.typography.h3),
+            HeaderTypeItem(TextStyleType.HEADER, stringResource(R.string.mindrecord_toolbar_style_header), AfternoteDesign.typography.bodyLargeB),
+            HeaderTypeItem(TextStyleType.SUBHEADER, stringResource(R.string.mindrecord_toolbar_style_subheader), AfternoteDesign.typography.bodySmallB),
+            HeaderTypeItem(TextStyleType.BODY, stringResource(R.string.mindrecord_toolbar_style_body), AfternoteDesign.typography.captionLargeR),
         )
     Row(
         modifier =

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/MemoriesCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/MemoriesCard.kt
@@ -75,13 +75,13 @@ fun MemoriesCard(modifier: Modifier = Modifier) {
                     .padding(16.dp),
         ) {
             Text(
-                text = "\"내 인생에서 가장 소중했던 순간은?\"",
+                text = stringResource(R.string.mindrecord_memories_card_question),
                 style = AfternoteDesign.typography.bodySmallR,
                 color = AfternoteDesign.colors.gray8,
             )
             Spacer(Modifier.height(1.dp))
             Text(
-                text = "- 아이가 태어났을 때...",
+                text = stringResource(R.string.mindrecord_memories_card_answer),
                 style = AfternoteDesign.typography.captionLargeR,
                 color = AfternoteDesign.colors.gray6,
             )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/MindRecordEmptyState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/MindRecordEmptyState.kt
@@ -12,17 +12,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afternote.core.common.R
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 
 @Composable
 fun MindRecordEmptyState(
     modifier: Modifier = Modifier,
-    title: String = "아직 등록된 답변이 없어요.",
-    description: String = "답변을 등록해 자신을 알아 보아요.",
+    title: String = stringResource(MindRecordR.string.mindrecord_empty_state_title),
+    description: String = stringResource(MindRecordR.string.mindrecord_empty_state_description),
 ) {
     Column(
         modifier =

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/TodayQuestionCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/TodayQuestionCard.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.sp
 import com.afternote.core.ui.button.AfternoteActionButton
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R.string.mindrecord_daily_question_default_today
 import com.afternote.feature.mindrecord.presentation.R.string.mindrecord_today_question_answer_cta
 import com.afternote.feature.mindrecord.presentation.R.string.mindrecord_today_question_header
 
@@ -35,7 +36,7 @@ private val TodayQuestionCardGradientEnd = Color(0xFFB7CDC0)
 fun TodayQuestionCard(
     modifier: Modifier = Modifier,
     dateText: String = "2026.04.10",
-    questionText: String = "오늘 하루,\n무엇이 가장 고마웠나요?",
+    questionText: String = stringResource(mindrecord_daily_question_default_today),
     onAnswerClick: () -> Unit = {},
 ) {
     val gradientBrush =

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyEmotionCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyEmotionCard.kt
@@ -11,10 +11,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R
 
 @Composable
 fun WeeklyEmotionCard(modifier: Modifier = Modifier) {
@@ -35,13 +37,13 @@ fun WeeklyEmotionCard(modifier: Modifier = Modifier) {
                     .padding(horizontal = 17.dp, vertical = 9.dp),
         ) {
             Text(
-                text = "주간 평균 감정",
+                text = stringResource(R.string.mindrecord_weekly_report_avg_emotion_weekly),
                 style = AfternoteDesign.typography.captionLargeR,
                 color = AfternoteDesign.colors.gray9,
             )
 
             Text(
-                text = "\uD83D\uDE0A 좋음",
+                text = stringResource(R.string.mindrecord_weekly_report_avg_mood_good),
                 style = AfternoteDesign.typography.captionLargeR,
                 color = AfternoteDesign.colors.gray9,
             )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyModelCalendar.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyModelCalendar.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -30,6 +31,7 @@ import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.model.DayBackground
 import com.afternote.feature.mindrecord.presentation.model.DayContent
 import com.afternote.feature.mindrecord.presentation.model.DayItem
+import java.time.DayOfWeek
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -83,7 +85,7 @@ private fun DayCell(
     ) {
         // 요일 텍스트
         Text(
-            text = dayItem.label,
+            text = stringResource(dayOfWeekLabelRes(dayItem.dayOfWeek)),
             color = AfternoteDesign.colors.gray5,
             style = AfternoteDesign.typography.captionLargeR,
         )
@@ -158,15 +160,27 @@ private fun DayCell(
     }
 }
 
+@androidx.annotation.StringRes
+private fun dayOfWeekLabelRes(dayOfWeek: DayOfWeek): Int =
+    when (dayOfWeek) {
+        DayOfWeek.MONDAY -> R.string.mindrecord_calendar_day_label_mon
+        DayOfWeek.TUESDAY -> R.string.mindrecord_calendar_day_label_tue
+        DayOfWeek.WEDNESDAY -> R.string.mindrecord_calendar_day_label_wed
+        DayOfWeek.THURSDAY -> R.string.mindrecord_calendar_day_label_thu
+        DayOfWeek.FRIDAY -> R.string.mindrecord_calendar_day_label_fri
+        DayOfWeek.SATURDAY -> R.string.mindrecord_calendar_day_label_sat
+        DayOfWeek.SUNDAY -> R.string.mindrecord_calendar_day_label_sun
+    }
+
 private fun defaultPreviewDays(): List<DayItem> =
     listOf(
-        DayItem("월", DayContent.NumberOnly(10)),
-        DayItem("화", DayContent.NumberWithDot(2)),
-        DayItem("수", DayContent.NumberOnly(12)),
-        DayItem("목", DayContent.EmojiWithDot("😊"), DayBackground.Green),
-        DayItem("금", DayContent.EmojiOnly("😊"), DayBackground.Green),
-        DayItem("토", DayContent.NumberWithDot(2)),
-        DayItem("일", DayContent.EmojiOnly("🥹"), DayBackground.Pink),
+        DayItem(DayOfWeek.MONDAY, DayContent.NumberOnly(10)),
+        DayItem(DayOfWeek.TUESDAY, DayContent.NumberWithDot(2)),
+        DayItem(DayOfWeek.WEDNESDAY, DayContent.NumberOnly(12)),
+        DayItem(DayOfWeek.THURSDAY, DayContent.EmojiWithDot("😊"), DayBackground.Green),
+        DayItem(DayOfWeek.FRIDAY, DayContent.EmojiOnly("😊"), DayBackground.Green),
+        DayItem(DayOfWeek.SATURDAY, DayContent.NumberWithDot(2)),
+        DayItem(DayOfWeek.SUNDAY, DayContent.EmojiOnly("🥹"), DayBackground.Pink),
     )
 
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyModelCalendar.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyModelCalendar.kt
@@ -33,19 +33,10 @@ import com.afternote.feature.mindrecord.presentation.model.DayItem
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun WeeklyMoodCalendar(modifier: Modifier = Modifier) {
-    // 이미지 기준 샘플 데이터
-    val days =
-        listOf(
-            DayItem("월", DayContent.NumberOnly(10)),
-            DayItem("화", DayContent.NumberWithDot(2)),
-            DayItem("수", DayContent.NumberOnly(12)),
-            DayItem("목", DayContent.EmojiWithDot("😊"), DayBackground.Green),
-            DayItem("금", DayContent.EmojiOnly("😊"), DayBackground.Green),
-            DayItem("토", DayContent.NumberWithDot(2)),
-            DayItem("일", DayContent.EmojiOnly("🥹"), DayBackground.Pink),
-        )
-
+fun WeeklyMoodCalendar(
+    modifier: Modifier = Modifier,
+    days: List<DayItem> = defaultPreviewDays(),
+) {
     Column(
         modifier =
             modifier
@@ -166,6 +157,17 @@ private fun DayCell(
         }
     }
 }
+
+private fun defaultPreviewDays(): List<DayItem> =
+    listOf(
+        DayItem("월", DayContent.NumberOnly(10)),
+        DayItem("화", DayContent.NumberWithDot(2)),
+        DayItem("수", DayContent.NumberOnly(12)),
+        DayItem("목", DayContent.EmojiWithDot("😊"), DayBackground.Green),
+        DayItem("금", DayContent.EmojiOnly("😊"), DayBackground.Green),
+        DayItem("토", DayContent.NumberWithDot(2)),
+        DayItem("일", DayContent.EmojiOnly("🥹"), DayBackground.Pink),
+    )
 
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
 @Composable

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyReportCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyReportCard.kt
@@ -15,11 +15,13 @@ import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R
 
 @Composable
 fun WeeklyReportCard(modifier: Modifier = Modifier) {
@@ -38,12 +40,12 @@ fun WeeklyReportCard(modifier: Modifier = Modifier) {
                     .padding(21.dp),
         ) {
             Text(
-                text = "주간 리포트",
+                text = stringResource(R.string.mindrecord_weekly_report_title),
                 style = AfternoteDesign.typography.bodyLargeB,
             )
             Spacer(modifier = Modifier.height(8.dp))
             Text(
-                text = "이번 주 나의 기록들을 확인해 보세요.",
+                text = stringResource(R.string.mindrecord_weekly_report_subtitle),
                 style = AfternoteDesign.typography.captionLargeR,
                 color = AfternoteDesign.colors.gray5,
             )
@@ -61,7 +63,7 @@ fun WeeklyReportCard(modifier: Modifier = Modifier) {
                     )
 
                     Text(
-                        text = "총 기록",
+                        text = stringResource(R.string.mindrecord_weekly_report_total_record),
                         style =
                             AfternoteDesign.typography.captionLargeR.copy(
                                 fontSize = 11.sp,
@@ -83,7 +85,7 @@ fun WeeklyReportCard(modifier: Modifier = Modifier) {
                     )
 
                     Text(
-                        text = "이번 주",
+                        text = stringResource(R.string.mindrecord_weekly_report_this_week),
                         style =
                             AfternoteDesign.typography.captionLargeR.copy(
                                 fontSize = 11.sp,

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyReportReviewCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyReportReviewCard.kt
@@ -55,8 +55,9 @@ fun WeeklyReportReviewCard(
         ),
 ) {
     var expanded by remember { mutableStateOf(false) }
+    val selectedOption = weekOptions.firstOrNull { it.monday == selectedMonday }
     val selectedLabel =
-        weekOptions.firstOrNull { it.monday == selectedMonday }?.label
+        selectedOption?.let { weekLabel(it.monday) }
             ?: stringResource(R.string.mindrecord_weekly_report_label_fallback)
 
     OutlinedCard(
@@ -130,7 +131,7 @@ fun WeeklyReportReviewCard(
                         DropdownMenuItem(
                             text = {
                                 Text(
-                                    text = option.label,
+                                    text = weekLabel(option.monday),
                                     style = AfternoteDesign.typography.h3,
                                     color =
                                         if (option.monday == selectedMonday) {
@@ -182,6 +183,14 @@ fun WeeklyReportReviewCard(
         }
     }
 }
+
+@Composable
+private fun weekLabel(monday: LocalDate): String =
+    stringResource(
+        R.string.mindrecord_weekly_report_label_format,
+        monday.monthValue,
+        (monday.dayOfMonth - 1) / 7 + 1,
+    )
 
 @Preview(showBackground = true)
 @Composable

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyReportReviewCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyReportReviewCard.kt
@@ -45,7 +45,7 @@ fun WeeklyReportReviewCard(
     modifier: Modifier = Modifier,
     selectedMonday: LocalDate? = null,
     weekOptions: List<WeekOption> = emptyList(),
-    onWeekSelected: (LocalDate) -> Unit = {},
+    onWeekSelect: (LocalDate) -> Unit = {},
     dateRange: String = "2025.11.10. - 2025.11.16.",
     counts: List<Pair<Int, MindRecordCategoryUi>> =
         listOf(
@@ -143,7 +143,7 @@ fun WeeklyReportReviewCard(
                             onClick = {
                                 expanded = false
                                 if (option.monday != selectedMonday) {
-                                    onWeekSelected(option.monday)
+                                    onWeekSelect(option.monday)
                                 }
                             },
                         )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyReportReviewCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyReportReviewCard.kt
@@ -30,31 +30,34 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
+import com.afternote.feature.mindrecord.presentation.viewmodel.WeekOption
+import java.time.LocalDate
 
 @Composable
-fun WeeklyReportReviewCard(modifier: Modifier = Modifier) {
-    var expanded by remember { mutableStateOf(false) }
-    var selectedReport by remember { mutableStateOf("11월 2주차 리포트") }
-    val reportOptions =
-        listOf(
-            "11월 2주차 리포트",
-            "11월 1주차 리포트",
-            "10월 4주차 리포트",
-            "10월 3주차 리포트",
-            "10월 2주차 리포트",
-        )
-    val report =
+fun WeeklyReportReviewCard(
+    modifier: Modifier = Modifier,
+    selectedMonday: LocalDate? = null,
+    weekOptions: List<WeekOption> = emptyList(),
+    onWeekSelected: (LocalDate) -> Unit = {},
+    dateRange: String = "2025.11.10. - 2025.11.16.",
+    counts: List<Pair<Int, MindRecordCategoryUi>> =
         listOf(
             5 to MindRecordCategoryUi.DailyQuestion,
             4 to MindRecordCategoryUi.Diary,
             3 to MindRecordCategoryUi.DeepThought,
-        )
+        ),
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val selectedLabel =
+        weekOptions.firstOrNull { it.monday == selectedMonday }?.label
+            ?: stringResource(R.string.mindrecord_weekly_report_label_fallback)
 
     OutlinedCard(
         border = BorderStroke(1.dp, color = AfternoteDesign.colors.gray2),
@@ -107,7 +110,7 @@ fun WeeklyReportReviewCard(modifier: Modifier = Modifier) {
                     modifier = Modifier.clickable { expanded = true },
                 ) {
                     Text(
-                        text = selectedReport,
+                        text = selectedLabel,
                         style = AfternoteDesign.typography.h2,
                         color = AfternoteDesign.colors.black.copy(alpha = 0.9f),
                     )
@@ -123,14 +126,14 @@ fun WeeklyReportReviewCard(modifier: Modifier = Modifier) {
                     onDismissRequest = { expanded = false },
                     containerColor = Color.White,
                 ) {
-                    reportOptions.forEach { option ->
+                    weekOptions.forEach { option ->
                         DropdownMenuItem(
                             text = {
                                 Text(
-                                    text = option,
+                                    text = option.label,
                                     style = AfternoteDesign.typography.h3,
                                     color =
-                                        if (option == selectedReport) {
+                                        if (option.monday == selectedMonday) {
                                             AfternoteDesign.colors.black.copy(alpha = 0.9f)
                                         } else {
                                             AfternoteDesign.colors.black.copy(alpha = 0.3f)
@@ -138,8 +141,10 @@ fun WeeklyReportReviewCard(modifier: Modifier = Modifier) {
                                 )
                             },
                             onClick = {
-                                selectedReport = option
                                 expanded = false
+                                if (option.monday != selectedMonday) {
+                                    onWeekSelected(option.monday)
+                                }
                             },
                         )
                     }
@@ -149,7 +154,7 @@ fun WeeklyReportReviewCard(modifier: Modifier = Modifier) {
             Spacer(modifier = Modifier.height(10.dp))
 
             Text(
-                text = "2025.11.10. - 2025.11.16.",
+                text = dateRange,
                 style = AfternoteDesign.typography.bodySmallR,
                 color = AfternoteDesign.colors.gray6,
             )
@@ -160,14 +165,14 @@ fun WeeklyReportReviewCard(modifier: Modifier = Modifier) {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
-                report.forEach { (count, category) ->
+                counts.forEach { (count, category) ->
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Text(
                             text = count.toString(),
                             color = AfternoteDesign.colors.black.copy(alpha = 0.9f),
                         )
                         Text(
-                            text = category.title,
+                            text = stringResource(category.titleRes),
                             color = AfternoteDesign.colors.black.copy(alpha = 0.4f),
                             style = AfternoteDesign.typography.captionLargeR,
                         )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WriteTextField.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WriteTextField.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.ParagraphStyle
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontStyle
@@ -32,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.model.TextStyleState
 import com.afternote.feature.mindrecord.presentation.model.TextStyleType
 import com.mohamedrejeb.richeditor.model.rememberRichTextState
@@ -103,13 +105,13 @@ fun WriteTextField(
             )
             if (state.annotatedString.text.isEmpty()) {
                 Text(
-                    text = "당신의 오늘을 기록해보세요",
+                    text = stringResource(R.string.mindrecord_write_field_placeholder),
                     color = AfternoteDesign.colors.gray4,
                     modifier = Modifier.padding(16.dp),
                 )
             }
             Text(
-                text = "${state.annotatedString.text.length} 글자",
+                text = stringResource(R.string.mindrecord_write_field_character_count, state.annotatedString.text.length),
                 color = AfternoteDesign.colors.gray4,
                 modifier =
                     Modifier

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/hometab/HomeTabMindRecordLazyItems.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/hometab/HomeTabMindRecordLazyItems.kt
@@ -53,8 +53,8 @@ fun LazyListScope.homeTabMindRecordQuestionAndCategories(
                 modifier =
                     Modifier.weight(1f),
                 iconResId = CoreUiR.drawable.core_ui_ic_diary,
-                title = MindRecordCategoryUi.Diary.title,
-                subtitle = MindRecordCategoryUi.Diary.description,
+                title = stringResource(MindRecordCategoryUi.Diary.titleRes),
+                subtitle = stringResource(MindRecordCategoryUi.Diary.descriptionRes),
                 totalCount = categoryCounts[MindRecordCategory.DIARY] ?: 0,
                 onClick = { onRecordCategoryClick(MindRecordCategory.DIARY) },
                 useDiaryIconLayout = true,
@@ -64,8 +64,8 @@ fun LazyListScope.homeTabMindRecordQuestionAndCategories(
                 modifier =
                     Modifier.weight(1f),
                 iconResId = CoreUiR.drawable.core_ui_ic_deep_thought,
-                title = MindRecordCategoryUi.DeepThought.title,
-                subtitle = MindRecordCategoryUi.DeepThought.description,
+                title = stringResource(MindRecordCategoryUi.DeepThought.titleRes),
+                subtitle = stringResource(MindRecordCategoryUi.DeepThought.descriptionRes),
                 totalCount = categoryCounts[MindRecordCategory.DEEP_THOUGHT] ?: 0,
                 onClick = { onRecordCategoryClick(MindRecordCategory.DEEP_THOUGHT) },
                 isCountLoading = isCategoryCountLoading,

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/mapper/MindRecordUiMapper.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/mapper/MindRecordUiMapper.kt
@@ -44,7 +44,7 @@ fun DeepThought.toUi(): DeepThoughtModel =
         id = deepThoughtId,
         title = title,
         content = content,
-        date = LocalDate.now(),
+        date = parseLocalDate(createdAt),
         tag = tags.map { Tag(name = it, count = 0) },
         category = category,
         isDraft = isDraft,

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/model/DayContent.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/model/DayContent.kt
@@ -1,5 +1,7 @@
 package com.afternote.feature.mindrecord.presentation.model
 
+import java.time.DayOfWeek
+
 sealed class DayContent {
     data class NumberOnly(
         val day: Int,
@@ -26,7 +28,7 @@ enum class DayBackground {
 }
 
 data class DayItem(
-    val label: String, // 요일 레이블
+    val dayOfWeek: DayOfWeek, // 요일 (라벨 문자열은 UI 측에서 stringResource 로 매핑)
     val content: DayContent,
     val background: DayBackground = DayBackground.None,
 )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/model/MindRecordCategoryUi.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/model/MindRecordCategoryUi.kt
@@ -1,6 +1,7 @@
 package com.afternote.feature.mindrecord.presentation.model
 
 import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
@@ -16,14 +17,14 @@ import com.afternote.feature.mindrecord.presentation.R
 
 sealed class MindRecordCategoryUi(
     val category: MindRecordCategory,
-    val title: String,
-    val description: String,
+    @StringRes val titleRes: Int,
+    @StringRes val descriptionRes: Int,
     @DrawableRes val imageRes: Int,
 ) {
     data object DailyQuestion : MindRecordCategoryUi(
         category = MindRecordCategory.DAILY_QUESTION,
-        title = "데일리 질문",
-        description = "매일 다른 질문을 남겨 보세요.",
+        titleRes = R.string.mindrecord_category_daily_question_title,
+        descriptionRes = R.string.mindrecord_category_daily_question_description,
         imageRes = R.drawable.mindrecord_dailyquestion,
     ) {
         @Composable
@@ -37,8 +38,8 @@ sealed class MindRecordCategoryUi(
 
     data object Diary : MindRecordCategoryUi(
         category = MindRecordCategory.DIARY,
-        title = "일기",
-        description = "나의 매일을 기록하세요",
+        titleRes = R.string.mindrecord_category_diary_title,
+        descriptionRes = R.string.mindrecord_category_diary_description,
         imageRes = R.drawable.mindrecord_diary,
     ) {
         @Composable
@@ -54,8 +55,8 @@ sealed class MindRecordCategoryUi(
 
     data object DeepThought : MindRecordCategoryUi(
         category = MindRecordCategory.DEEP_THOUGHT,
-        title = "깊은 생각",
-        description = "오늘의 생각을 남기세요",
+        titleRes = R.string.mindrecord_category_deep_thought_title,
+        descriptionRes = R.string.mindrecord_category_deep_thought_description,
         imageRes = R.drawable.mindrecord_deepthought,
     ) {
         @Composable
@@ -69,8 +70,8 @@ sealed class MindRecordCategoryUi(
 
     data object WeeklyReport : MindRecordCategoryUi(
         category = MindRecordCategory.WEEKLY_REPORT,
-        title = "주간리포트",
-        description = "",
+        titleRes = R.string.mindrecord_category_weekly_report_title,
+        descriptionRes = 0,
         imageRes = 0,
     ) {
         @Composable

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionAnswerListScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionAnswerListScreen.kt
@@ -24,8 +24,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.theme.AfternoteDesign
-import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.component.DailyCalendar
 import com.afternote.feature.mindrecord.presentation.component.DailyQuestionListCard
 import com.afternote.feature.mindrecord.presentation.component.DailyQuestionWriteHeaderCard

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionAnswerListScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionAnswerListScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.afternote.core.ui.asString
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R
@@ -51,7 +52,7 @@ fun DailyQuestionAnswerListScreen(
         }
 
         is DailyQuestionListUiState.Error -> {
-            ErrorBox(message = state.message, modifier = modifier)
+            ErrorBox(message = state.message.asString(), modifier = modifier)
         }
 
         is DailyQuestionListUiState.Success -> {

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionAnswerListScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionAnswerListScreen.kt
@@ -18,11 +18,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.theme.AfternoteDesign
+import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.component.DailyCalendar
 import com.afternote.feature.mindrecord.presentation.component.DailyQuestionListCard
@@ -33,6 +35,7 @@ import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
 import com.afternote.feature.mindrecord.presentation.viewmodel.DailyQuestionListUiState
 import com.afternote.feature.mindrecord.presentation.viewmodel.DailyQuestionListViewModel
 import com.afternote.feature.mindrecord.presentation.viewmodel.TodayQuestionUi
+import java.time.LocalDate
 
 @Composable
 fun DailyQuestionAnswerListScreen(
@@ -74,7 +77,7 @@ private fun DailyQuestionListContent(
         return
     }
 
-    val headerText = todayQuestion?.content ?: "오늘의 질문이 없습니다."
+    val headerText = todayQuestion?.content ?: stringResource(R.string.mindrecord_daily_question_write_none)
 
     LazyColumn(
         modifier = modifier,
@@ -84,13 +87,20 @@ private fun DailyQuestionListContent(
             item { DailyQuestionWriteHeaderCard(questionText = headerText) }
             items(answers, key = { it.id }) { DailyQuestionListCard(answer = it) }
         } else {
+            val today = LocalDate.now()
+            val answeredDays =
+                answers
+                    .filter { it.date.year == today.year && it.date.monthValue == today.monthValue }
+                    .map { it.date.dayOfMonth }
+                    .toSet()
             item {
                 DailyCalendar(
-                    year = 2026,
-                    month = 3,
+                    year = today.year,
+                    month = today.monthValue,
                     type = MindRecordCategoryUi.DailyQuestion,
                     onPrevMonth = {},
                     onNextMonth = {},
+                    answeredDays = answeredDays,
                 )
             }
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionWriteScreen.kt
@@ -24,10 +24,10 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.theme.AfternoteDesign
-import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.core.ui.theme.Red
 import com.afternote.core.ui.topbar.DetailTopBar
+import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.component.DailyQuestionWriteHeaderCard
 import com.afternote.feature.mindrecord.presentation.component.WriteTextField
 import com.afternote.feature.mindrecord.presentation.viewmodel.DailyQuestionWriteViewModel

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionWriteScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.afternote.core.ui.asString
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.core.ui.theme.Red
@@ -79,10 +80,11 @@ fun DailyQuestionWriteScreen(
     ) { paddingValues ->
         Column {
             Column(modifier = Modifier.padding(paddingValues).padding(horizontal = 20.dp)) {
+                val questionLoadErrorText = uiState.questionLoadError?.asString()
                 val headerText =
                     when {
                         uiState.isQuestionLoading -> stringResource(R.string.mindrecord_daily_question_write_loading)
-                        uiState.questionLoadError != null -> uiState.questionLoadError!!
+                        questionLoadErrorText != null -> questionLoadErrorText
                         uiState.questionContent.isNotEmpty() -> uiState.questionContent
                         else -> stringResource(R.string.mindrecord_daily_question_write_none)
                     }
@@ -103,7 +105,7 @@ fun DailyQuestionWriteScreen(
                 }
                 Spacer(modifier = Modifier.height(10.dp))
 
-                val errorMessage = (uiState.submitState as? SubmitState.Failed)?.message
+                val errorMessage = (uiState.submitState as? SubmitState.Failed)?.message?.asString()
                 if (errorMessage != null) {
                     Text(
                         text = errorMessage,

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionWriteScreen.kt
@@ -18,11 +18,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.theme.AfternoteDesign
+import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.core.ui.theme.Red
 import com.afternote.core.ui.topbar.DetailTopBar
@@ -64,7 +66,7 @@ fun DailyQuestionWriteScreen(
                             ),
                     ) {
                         Text(
-                            text = "등록",
+                            text = stringResource(R.string.mindrecord_action_register),
                             style = AfternoteDesign.typography.bodySmallB,
                             color = AfternoteDesign.colors.gray6,
                         )
@@ -79,10 +81,10 @@ fun DailyQuestionWriteScreen(
             Column(modifier = Modifier.padding(paddingValues).padding(horizontal = 20.dp)) {
                 val headerText =
                     when {
-                        uiState.isQuestionLoading -> "오늘의 질문을 불러오는 중..."
+                        uiState.isQuestionLoading -> stringResource(R.string.mindrecord_daily_question_write_loading)
                         uiState.questionLoadError != null -> uiState.questionLoadError!!
                         uiState.questionContent.isNotEmpty() -> uiState.questionContent
-                        else -> "오늘의 질문이 없습니다."
+                        else -> stringResource(R.string.mindrecord_daily_question_write_none)
                     }
                 DailyQuestionWriteHeaderCard(
                     questionText = headerText,

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
@@ -31,11 +31,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.R
+import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.component.CategoryActionSheet
@@ -125,9 +127,9 @@ fun DeepThoughtScreen(
 
     if (addingCategory) {
         CategoryNameDialog(
-            title = "새 카테고리 만들기",
+            title = stringResource(MindRecordR.string.mindrecord_category_new_title),
             initialName = "",
-            confirmLabel = "추가",
+            confirmLabel = stringResource(MindRecordR.string.mindrecord_action_add),
             onDismiss = { addingCategory = false },
             onConfirm = { name ->
                 categoryViewModel.addCategory(name = name)
@@ -138,9 +140,9 @@ fun DeepThoughtScreen(
 
     renameTarget?.let { target ->
         CategoryNameDialog(
-            title = "카테고리 이름 수정",
+            title = stringResource(MindRecordR.string.mindrecord_category_rename_title),
             initialName = target.name,
-            confirmLabel = "저장",
+            confirmLabel = stringResource(MindRecordR.string.mindrecord_action_save),
             onDismiss = { renameTarget = null },
             onConfirm = { name ->
                 target.id.toLongOrNull()?.let { id ->
@@ -165,9 +167,10 @@ private fun DeepThoughtContent(
     items: List<DeepThoughtModel>,
     modifier: Modifier = Modifier,
 ) {
+    val allCategoryLabel = stringResource(MindRecordR.string.mindrecord_category_all)
     val tabs =
         buildList {
-            add(null to "전체 카테고리")
+            add(null to allCategoryLabel)
             categories.forEach { add(it.name to it.name) }
         }
     val selectedIndex =
@@ -223,7 +226,7 @@ private fun DeepThoughtContent(
                 }
                 Icon(
                     painter = painterResource(R.drawable.core_ui_settings),
-                    contentDescription = "카테고리 설정",
+                    contentDescription = stringResource(MindRecordR.string.mindrecord_category_setting_cd),
                     tint = AfternoteDesign.colors.gray9,
                     modifier =
                         Modifier
@@ -265,14 +268,21 @@ private fun DeepThoughtContent(
             }
         }
     } else {
+        val today = java.time.LocalDate.now()
+        val answeredDays =
+            items
+                .filter { it.date.year == today.year && it.date.monthValue == today.monthValue }
+                .map { it.date.dayOfMonth }
+                .toSet()
         LazyColumn(modifier = modifier) {
             item {
                 DailyCalendar(
-                    year = 2026,
-                    month = 3,
+                    year = today.year,
+                    month = today.monthValue,
                     type = MindRecordCategoryUi.DeepThought,
                     onNextMonth = {},
                     onPrevMonth = {},
+                    answeredDays = answeredDays,
                 )
                 Spacer(modifier = Modifier.height(16.dp))
             }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.R
+import com.afternote.core.ui.asString
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.component.CategoryActionSheet
@@ -81,7 +82,7 @@ fun DeepThoughtScreen(
         }
 
         is DeepThoughtListUiState.Error -> {
-            ErrorBox(message = state.message, modifier = modifier)
+            ErrorBox(message = state.message.asString(), modifier = modifier)
         }
 
         is DeepThoughtListUiState.Success -> {

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.R
-import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.component.CategoryActionSheet
@@ -54,6 +53,7 @@ import com.afternote.feature.mindrecord.presentation.model.Tag
 import com.afternote.feature.mindrecord.presentation.viewmodel.DeepThoughtCategoryViewModel
 import com.afternote.feature.mindrecord.presentation.viewmodel.DeepThoughtListUiState
 import com.afternote.feature.mindrecord.presentation.viewmodel.DeepThoughtListViewModel
+import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 
 @Composable
 fun DeepThoughtScreen(

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtWriteScreen.kt
@@ -26,11 +26,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.R
+import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.core.ui.theme.Red
@@ -63,7 +65,7 @@ fun DeepThoughtWriteScreen(
     Scaffold(
         topBar = {
             DetailTopBar(
-                title = "깊은 생각 기록하기",
+                title = stringResource(MindRecordR.string.mindrecord_deep_thought_write_title),
                 onBackClick = onBackClick,
                 actions = {
                     Button(
@@ -76,7 +78,7 @@ fun DeepThoughtWriteScreen(
                             ),
                     ) {
                         Text(
-                            text = "등록",
+                            text = stringResource(MindRecordR.string.mindrecord_action_register),
                             style = AfternoteDesign.typography.bodySmallB,
                             color = AfternoteDesign.colors.gray6,
                         )
@@ -106,7 +108,7 @@ fun DeepThoughtWriteScreen(
                     ),
                 placeholder = {
                     Text(
-                        text = "제목",
+                        text = stringResource(MindRecordR.string.mindrecord_deep_thought_write_title_label),
                         style = AfternoteDesign.typography.h3,
                         color = AfternoteDesign.colors.black.copy(alpha = 0.2f),
                     )
@@ -121,7 +123,7 @@ fun DeepThoughtWriteScreen(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = "카테고리",
+                    text = stringResource(MindRecordR.string.mindrecord_deep_thought_write_category_label),
                     style = AfternoteDesign.typography.bodySmallB,
                     color = AfternoteDesign.colors.gray7,
                 )
@@ -166,9 +168,9 @@ fun DeepThoughtWriteScreen(
             CategorySettingBottomSheet(
                 categories =
                     listOf(
-                        CategoryUiModel("1", "나의 가치관", Color(0xFF1A1A1A)),
-                        CategoryUiModel("2", "오늘 떠올린 생각", Color(0xFFFFB3A7)),
-                        CategoryUiModel("3", "인생을 되돌아 보며", Color(0xFFA8C8E8)),
+                        CategoryUiModel("1", stringResource(MindRecordR.string.mindrecord_deep_thought_write_default_category), Color(0xFF1A1A1A)),
+                        CategoryUiModel("2", stringResource(MindRecordR.string.mindrecord_deep_thought_sample_category_today), Color(0xFFFFB3A7)),
+                        CategoryUiModel("3", stringResource(MindRecordR.string.mindrecord_deep_thought_sample_category_retrospective), Color(0xFFA8C8E8)),
                     ),
                 onDismiss = { showCategorySheet = false },
                 onBackClick = { showCategorySheet = false },

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtWriteScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.R
-import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.core.ui.theme.Red
@@ -43,6 +42,7 @@ import com.afternote.feature.mindrecord.presentation.component.WriteTextField
 import com.afternote.feature.mindrecord.presentation.model.CategoryUiModel
 import com.afternote.feature.mindrecord.presentation.viewmodel.DeepThoughtWriteViewModel
 import com.afternote.feature.mindrecord.presentation.viewmodel.SubmitState
+import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 
 @Composable
 fun DeepThoughtWriteScreen(
@@ -168,9 +168,21 @@ fun DeepThoughtWriteScreen(
             CategorySettingBottomSheet(
                 categories =
                     listOf(
-                        CategoryUiModel("1", stringResource(MindRecordR.string.mindrecord_deep_thought_write_default_category), Color(0xFF1A1A1A)),
-                        CategoryUiModel("2", stringResource(MindRecordR.string.mindrecord_deep_thought_sample_category_today), Color(0xFFFFB3A7)),
-                        CategoryUiModel("3", stringResource(MindRecordR.string.mindrecord_deep_thought_sample_category_retrospective), Color(0xFFA8C8E8)),
+                        CategoryUiModel(
+                            "1",
+                            stringResource(MindRecordR.string.mindrecord_deep_thought_write_default_category),
+                            Color(0xFF1A1A1A),
+                        ),
+                        CategoryUiModel(
+                            "2",
+                            stringResource(MindRecordR.string.mindrecord_deep_thought_sample_category_today),
+                            Color(0xFFFFB3A7),
+                        ),
+                        CategoryUiModel(
+                            "3",
+                            stringResource(MindRecordR.string.mindrecord_deep_thought_sample_category_retrospective),
+                            Color(0xFFA8C8E8),
+                        ),
                     ),
                 onDismiss = { showCategorySheet = false },
                 onBackClick = { showCategorySheet = false },

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtWriteScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.R
+import com.afternote.core.ui.asString
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.core.ui.theme.Red
@@ -54,6 +55,14 @@ fun DeepThoughtWriteScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var showCategorySheet by remember { mutableStateOf(false) }
     val currentOnSubmitSuccess by rememberUpdatedState(onSubmitSuccess)
+
+    // VM 은 Context 를 들고 있지 않으므로, 초기 진입 시 화면에서 기본 카테고리 문자열을 시드한다.
+    val defaultCategory = stringResource(MindRecordR.string.mindrecord_deep_thought_write_default_category)
+    LaunchedEffect(Unit) {
+        if (uiState.category.isBlank()) {
+            viewModel.onCategoryChanged(defaultCategory)
+        }
+    }
 
     LaunchedEffect(uiState.submitState) {
         if (uiState.submitState is SubmitState.Succeeded) {
@@ -149,7 +158,7 @@ fun DeepThoughtWriteScreen(
                 }
             }
 
-            val errorMessage = (uiState.submitState as? SubmitState.Failed)?.message
+            val errorMessage = (uiState.submitState as? SubmitState.Failed)?.message?.asString()
             if (errorMessage != null) {
                 Text(
                     text = errorMessage,

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.afternote.core.ui.asString
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.component.DailyCalendar
@@ -53,7 +54,7 @@ fun DiaryScreen(
         }
 
         is DiaryListUiState.Error -> {
-            ErrorBox(message = state.message, modifier = modifier)
+            ErrorBox(message = state.message.asString(), modifier = modifier)
         }
 
         is DiaryListUiState.Success -> {

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryScreen.kt
@@ -36,6 +36,7 @@ import com.afternote.feature.mindrecord.presentation.model.DailyDiary
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
 import com.afternote.feature.mindrecord.presentation.viewmodel.DiaryListUiState
 import com.afternote.feature.mindrecord.presentation.viewmodel.DiaryListViewModel
+import java.time.LocalDate
 import androidx.compose.foundation.lazy.grid.items as gridItems
 
 @Composable
@@ -76,15 +77,25 @@ private fun DiaryListContent(
         return
     }
 
+    val today = LocalDate.now()
+    val currentMonthDiaries = diaries.filter { it.date.year == today.year && it.date.monthValue == today.monthValue }
+    val answeredDays = currentMonthDiaries.map { it.date.dayOfMonth }.toSet()
+    val emotionByDay =
+        currentMonthDiaries
+            .mapNotNull { diary -> diary.emotion?.let { diary.date.dayOfMonth to it } }
+            .toMap()
+
     if (isListView) {
         LazyColumn(modifier = modifier) {
             item {
                 DailyCalendar(
-                    year = 2026,
-                    month = 3,
+                    year = today.year,
+                    month = today.monthValue,
                     type = MindRecordCategoryUi.Diary,
                     onNextMonth = {},
                     onPrevMonth = {},
+                    answeredDays = answeredDays,
+                    emotionByDay = emotionByDay,
                 )
                 Spacer(modifier = Modifier.height(10.dp))
             }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.R
+import com.afternote.core.ui.asString
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.core.ui.theme.Red
@@ -212,7 +213,7 @@ fun DiaryWriteScreen(
                 }
             }
 
-            val errorMessage = (uiState.submitState as? SubmitState.Failed)?.message
+            val errorMessage = (uiState.submitState as? SubmitState.Failed)?.message?.asString()
             if (errorMessage != null) {
                 Text(
                     text = errorMessage,

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.R
-import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.core.ui.theme.Red
@@ -51,6 +50,7 @@ import com.afternote.feature.mindrecord.presentation.component.BottomSheetCalend
 import com.afternote.feature.mindrecord.presentation.component.WriteTextField
 import com.afternote.feature.mindrecord.presentation.viewmodel.DiaryWriteViewModel
 import com.afternote.feature.mindrecord.presentation.viewmodel.SubmitState
+import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 
 @Composable
 fun DiaryWriteScreen(

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
@@ -35,11 +35,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.R
+import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.core.ui.theme.Red
@@ -71,7 +73,7 @@ fun DiaryWriteScreen(
     Scaffold(
         topBar = {
             DetailTopBar(
-                title = "일기 기록하기",
+                title = stringResource(MindRecordR.string.mindrecord_diary_write_title),
                 onBackClick = onBackClick,
                 actions = {
                     Button(
@@ -84,7 +86,7 @@ fun DiaryWriteScreen(
                             ),
                     ) {
                         Text(
-                            text = "등록",
+                            text = stringResource(MindRecordR.string.mindrecord_action_register),
                             style = AfternoteDesign.typography.bodySmallB,
                             color = AfternoteDesign.colors.gray6,
                         )
@@ -132,7 +134,7 @@ fun DiaryWriteScreen(
                     ),
                 placeholder = {
                     Text(
-                        text = "제목을 입력하세요.",
+                        text = stringResource(MindRecordR.string.mindrecord_diary_write_title_placeholder),
                         style = AfternoteDesign.typography.h2,
                         color = AfternoteDesign.colors.black.copy(alpha = 0.2f),
                     )
@@ -150,7 +152,7 @@ fun DiaryWriteScreen(
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    text = "오늘의 기분",
+                    text = stringResource(MindRecordR.string.mindrecord_diary_write_mood_label),
                     style = AfternoteDesign.typography.captionLargeR,
                     color = AfternoteDesign.colors.black.copy(alpha = 0.4f),
                 )
@@ -182,7 +184,7 @@ fun DiaryWriteScreen(
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
-                        text = "위치 추가",
+                        text = stringResource(MindRecordR.string.mindrecord_diary_write_add_location),
                         style = AfternoteDesign.typography.captionLargeR,
                         color = AfternoteDesign.colors.black.copy(alpha = 0.6f),
                     )
@@ -203,7 +205,7 @@ fun DiaryWriteScreen(
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
-                        text = "사진 추가",
+                        text = stringResource(MindRecordR.string.mindrecord_diary_write_add_photo),
                         style = AfternoteDesign.typography.captionLargeR,
                         color = AfternoteDesign.colors.black.copy(alpha = 0.6f),
                     )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/HomeScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/HomeScreen.kt
@@ -32,11 +32,11 @@ import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.core.ui.topbar.TitleTopBar
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
-import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 import com.afternote.feature.mindrecord.presentation.viewmodel.DailyQuestionListViewModel
 import com.afternote.feature.mindrecord.presentation.viewmodel.DeepThoughtListViewModel
 import com.afternote.feature.mindrecord.presentation.viewmodel.DiaryListViewModel
 import kotlinx.coroutines.flow.drop
+import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 
 @Composable
 fun HomeScreen(

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/HomeScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/HomeScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -31,6 +32,7 @@ import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.core.ui.topbar.TitleTopBar
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
+import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 import com.afternote.feature.mindrecord.presentation.viewmodel.DailyQuestionListViewModel
 import com.afternote.feature.mindrecord.presentation.viewmodel.DeepThoughtListViewModel
 import com.afternote.feature.mindrecord.presentation.viewmodel.DiaryListViewModel
@@ -75,7 +77,7 @@ fun HomeScreen(
         modifier = modifier,
         topBar = {
             TitleTopBar(
-                title = "마음의 기록",
+                title = stringResource(MindRecordR.string.mindrecord_home_title),
                 actions = {
                     ViewModeSwitcher(
                         isListView = isListView,
@@ -122,7 +124,7 @@ fun HomeScreen(
                         onClick = { selectedIndex = index },
                         text = {
                             Text(
-                                text = category.title,
+                                text = stringResource(category.titleRes),
                                 color = if (selectedIndex == index) AfternoteDesign.colors.gray9 else AfternoteDesign.colors.gray4,
                             )
                         },

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/WeeklyReportScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/WeeklyReportScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.afternote.core.ui.asString
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R
@@ -47,7 +48,7 @@ fun WeeklyReportScreen(
         }
 
         is WeeklyReportUiState.Error -> {
-            ErrorBox(message = state.message, modifier = modifier)
+            ErrorBox(message = state.message.asString(), modifier = modifier)
         }
 
         is WeeklyReportUiState.Success -> {

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/WeeklyReportScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/WeeklyReportScreen.kt
@@ -71,7 +71,7 @@ private fun WeeklyReportContent(
         }
 
         item {
-            Text(text = recordedSummary(recordedDays = state.recordedDays))
+            Text(text = recordedSummary(userName = state.userName, recordedDays = state.recordedDays))
         }
 
         item {
@@ -107,9 +107,11 @@ private fun WeeklyReportContent(
 }
 
 @Composable
-private fun recordedSummary(recordedDays: Int): androidx.compose.ui.text.AnnotatedString {
+private fun recordedSummary(
+    userName: String,
+    recordedDays: Int,
+): androidx.compose.ui.text.AnnotatedString {
     val prefix = stringResource(R.string.mindrecord_weekly_report_recorded_prefix)
-    val userName = stringResource(R.string.mindrecord_weekly_report_user_default_name)
     val middle = stringResource(R.string.mindrecord_weekly_report_recorded_middle)
     val daysText = stringResource(R.string.mindrecord_weekly_report_days_format, recordedDays)
     val suffix = stringResource(R.string.mindrecord_weekly_report_recorded_suffix)
@@ -180,6 +182,7 @@ private fun WeeklyReportScreenPreview() {
                     selectedMonday = java.time.LocalDate.of(2025, 11, 10),
                     weekOptions = emptyList(),
                     dateRange = "2025.11.10. - 2025.11.16.",
+                    userName = "박서연",
                     recordedDays = 3,
                     counts = emptyList(),
                     weekDays = emptyList(),

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/WeeklyReportScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/WeeklyReportScreen.kt
@@ -24,8 +24,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.theme.AfternoteDesign
-import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.component.DailyQuestionListCard
 import com.afternote.feature.mindrecord.presentation.component.EmotionKeywordCard
 import com.afternote.feature.mindrecord.presentation.component.InsightCard
@@ -42,21 +42,28 @@ fun WeeklyReportScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     when (val state = uiState) {
-        WeeklyReportUiState.Loading -> LoadingBox(modifier)
-        is WeeklyReportUiState.Error -> ErrorBox(message = state.message, modifier = modifier)
-        is WeeklyReportUiState.Success ->
+        WeeklyReportUiState.Loading -> {
+            LoadingBox(modifier)
+        }
+
+        is WeeklyReportUiState.Error -> {
+            ErrorBox(message = state.message, modifier = modifier)
+        }
+
+        is WeeklyReportUiState.Success -> {
             WeeklyReportContent(
                 state = state,
-                onWeekSelected = viewModel::selectWeek,
+                onWeekSelect = viewModel::selectWeek,
                 modifier = modifier,
             )
+        }
     }
 }
 
 @Composable
 private fun WeeklyReportContent(
     state: WeeklyReportUiState.Success,
-    onWeekSelected: (java.time.LocalDate) -> Unit,
+    onWeekSelect: (java.time.LocalDate) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyColumn(modifier = modifier) {
@@ -64,7 +71,7 @@ private fun WeeklyReportContent(
             WeeklyReportReviewCard(
                 selectedMonday = state.selectedMonday,
                 weekOptions = state.weekOptions,
-                onWeekSelected = onWeekSelected,
+                onWeekSelect = onWeekSelect,
                 dateRange = state.dateRange,
                 counts = state.counts,
             )
@@ -190,7 +197,7 @@ private fun WeeklyReportScreenPreview() {
                     summaryText = "이번 주는 차분히 마음을 정리한 한 주였어요.",
                     dailyQuestions = emptyList(),
                 ),
-            onWeekSelected = {},
+            onWeekSelect = {},
         )
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/WeeklyReportScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/WeeklyReportScreen.kt
@@ -1,122 +1,172 @@
 package com.afternote.feature.mindrecord.presentation.screen.sender
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.theme.AfternoteDesign
+import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.component.DailyQuestionListCard
 import com.afternote.feature.mindrecord.presentation.component.EmotionKeywordCard
 import com.afternote.feature.mindrecord.presentation.component.InsightCard
 import com.afternote.feature.mindrecord.presentation.component.WeeklyMoodCalendar
 import com.afternote.feature.mindrecord.presentation.component.WeeklyReportReviewCard
-import com.afternote.feature.mindrecord.presentation.model.DailyQuestion
-import java.time.LocalDate
+import com.afternote.feature.mindrecord.presentation.viewmodel.WeeklyReportUiState
+import com.afternote.feature.mindrecord.presentation.viewmodel.WeeklyReportViewModel
 
 @Composable
-fun WeeklyReportScreen(modifier: Modifier = Modifier) {
+fun WeeklyReportScreen(
+    modifier: Modifier = Modifier,
+    viewModel: WeeklyReportViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when (val state = uiState) {
+        WeeklyReportUiState.Loading -> LoadingBox(modifier)
+        is WeeklyReportUiState.Error -> ErrorBox(message = state.message, modifier = modifier)
+        is WeeklyReportUiState.Success ->
+            WeeklyReportContent(
+                state = state,
+                onWeekSelected = viewModel::selectWeek,
+                modifier = modifier,
+            )
+    }
+}
+
+@Composable
+private fun WeeklyReportContent(
+    state: WeeklyReportUiState.Success,
+    onWeekSelected: (java.time.LocalDate) -> Unit,
+    modifier: Modifier = Modifier,
+) {
     LazyColumn(modifier = modifier) {
         item {
-            WeeklyReportReviewCard()
-        }
-
-        item {
-            Text(
-                text =
-                    buildAnnotatedString {
-                        withStyle(
-                            style = AfternoteDesign.typography.bodyLargeB.toSpanStyle(),
-                        ) {
-                            append("이번 주, ")
-                            withStyle(
-                                style =
-                                    AfternoteDesign.typography.bodyLargeB
-                                        .copy(color = AfternoteDesign.colors.b1)
-                                        .toSpanStyle(),
-                            ) {
-                                append("박서연")
-                            }
-                            append("님은 ")
-                            withStyle(
-                                style =
-                                    AfternoteDesign.typography.bodyLargeB
-                                        .copy(color = AfternoteDesign.colors.b1)
-                                        .toSpanStyle(),
-                            ) {
-                                append("3일")
-                            }
-                            append("의 마음을 기록하셨네요.")
-                        }
-                    },
+            WeeklyReportReviewCard(
+                selectedMonday = state.selectedMonday,
+                weekOptions = state.weekOptions,
+                onWeekSelected = onWeekSelected,
+                dateRange = state.dateRange,
+                counts = state.counts,
             )
         }
 
         item {
-            WeeklyMoodCalendar()
+            Text(text = recordedSummary(recordedDays = state.recordedDays))
         }
 
         item {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = "TOP KEYWORDS",
-                    style = AfternoteDesign.typography.mono,
-                    color = AfternoteDesign.colors.black.copy(alpha = 0.4f),
-                )
+            WeeklyMoodCalendar(days = state.weekDays)
+        }
 
-                HorizontalDivider(modifier = Modifier.padding(start = 12.dp))
-            }
-
+        item {
+            SectionHeader(title = "TOP KEYWORDS")
             Spacer(modifier = Modifier.height(10.dp))
         }
 
         item {
-            EmotionKeywordCard()
-        }
-        item {
-            InsightCard()
-            Spacer(modifier = Modifier.height(10.dp))
-        }
-
-        item {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = "HISTORY",
-                    style = AfternoteDesign.typography.mono,
-                    color = AfternoteDesign.colors.black.copy(alpha = 0.4f),
-                )
-
-                HorizontalDivider(modifier = Modifier.padding(start = 12.dp))
-            }
-
-            Spacer(modifier = Modifier.height(10.dp))
-
-            DailyQuestionListCard(
-                answer =
-                    DailyQuestion(
-                        title = "오늘하루",
-                        date = LocalDate.now(),
-                        content = "오늘 하루",
-                    ),
+            EmotionKeywordCard(
+                bubbles = state.emotionBubbles,
+                descriptionText = state.summaryText,
             )
         }
+
+        item {
+            InsightCard(bodyText = state.summaryText)
+            Spacer(modifier = Modifier.height(10.dp))
+        }
+
+        item {
+            SectionHeader(title = "HISTORY")
+            Spacer(modifier = Modifier.height(10.dp))
+        }
+
+        items(state.dailyQuestions, key = { it.id to it.date }) { dailyQuestion ->
+            DailyQuestionListCard(answer = dailyQuestion)
+        }
+    }
+}
+
+@Composable
+private fun recordedSummary(recordedDays: Int): androidx.compose.ui.text.AnnotatedString {
+    val prefix = stringResource(R.string.mindrecord_weekly_report_recorded_prefix)
+    val userName = stringResource(R.string.mindrecord_weekly_report_user_default_name)
+    val middle = stringResource(R.string.mindrecord_weekly_report_recorded_middle)
+    val daysText = stringResource(R.string.mindrecord_weekly_report_days_format, recordedDays)
+    val suffix = stringResource(R.string.mindrecord_weekly_report_recorded_suffix)
+    return buildAnnotatedString {
+        withStyle(style = AfternoteDesign.typography.bodyLargeB.toSpanStyle()) {
+            append(prefix)
+            withStyle(
+                style =
+                    AfternoteDesign.typography.bodyLargeB
+                        .copy(color = AfternoteDesign.colors.b1)
+                        .toSpanStyle(),
+            ) {
+                append(userName)
+            }
+            append(middle)
+            withStyle(
+                style =
+                    AfternoteDesign.typography.bodyLargeB
+                        .copy(color = AfternoteDesign.colors.b1)
+                        .toSpanStyle(),
+            ) {
+                append(daysText)
+            }
+            append(suffix)
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = AfternoteDesign.typography.mono,
+            color = AfternoteDesign.colors.black.copy(alpha = 0.4f),
+        )
+        HorizontalDivider(modifier = Modifier.padding(start = 12.dp))
+    }
+}
+
+@Composable
+private fun LoadingBox(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun ErrorBox(
+    message: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.fillMaxSize().padding(20.dp), contentAlignment = Alignment.Center) {
+        Text(text = message, color = AfternoteDesign.colors.gray9)
     }
 }
 
@@ -124,6 +174,20 @@ fun WeeklyReportScreen(modifier: Modifier = Modifier) {
 @Composable
 private fun WeeklyReportScreenPreview() {
     AfternoteTheme {
-        WeeklyReportScreen()
+        WeeklyReportContent(
+            state =
+                WeeklyReportUiState.Success(
+                    selectedMonday = java.time.LocalDate.of(2025, 11, 10),
+                    weekOptions = emptyList(),
+                    dateRange = "2025.11.10. - 2025.11.16.",
+                    recordedDays = 3,
+                    counts = emptyList(),
+                    weekDays = emptyList(),
+                    emotionBubbles = emptyList(),
+                    summaryText = "이번 주는 차분히 마음을 정리한 한 주였어요.",
+                    dailyQuestions = emptyList(),
+                ),
+            onWeekSelected = {},
+        )
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/CategoryError.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/CategoryError.kt
@@ -1,0 +1,36 @@
+package com.afternote.feature.mindrecord.presentation.viewmodel
+
+/**
+ * DeepThoughtCategoryViewModel 가 화면에 노출하는 에러 상태.
+ *
+ * VM 은 "어떤 도메인 에러가 발생했는가" 만 표현하고, 사용자에게 보여줄 문자열로의 매핑은
+ * [com.afternote.feature.mindrecord.presentation.screen.sender.DeepThoughtScreen] 같은
+ * Composable 측에서 stringResource 로 수행한다.
+ */
+sealed interface CategoryError {
+    /** 입력한 카테고리 이름이 trim 후 비어 있음 (도메인 검증 실패). */
+    data object EmptyName : CategoryError
+
+    /** 도메인 검증은 실패했지만 EmptyName 외 사유 (예: 길이/문자 제약). */
+    data object NameInvalid : CategoryError
+
+    /** 카테고리 목록 조회 실패. */
+    data class ListFailed(
+        val message: String?,
+    ) : CategoryError
+
+    /** 카테고리 추가 실패. */
+    data class AddFailed(
+        val message: String?,
+    ) : CategoryError
+
+    /** 카테고리 이름 변경 실패. */
+    data class UpdateFailed(
+        val message: String?,
+    ) : CategoryError
+
+    /** 카테고리 삭제 실패. */
+    data class DeleteFailed(
+        val message: String?,
+    ) : CategoryError
+}

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionListUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionListUiState.kt
@@ -1,5 +1,6 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
+import com.afternote.core.ui.UiText
 import com.afternote.feature.mindrecord.presentation.model.DailyQuestion
 
 sealed interface DailyQuestionListUiState {
@@ -11,7 +12,7 @@ sealed interface DailyQuestionListUiState {
     ) : DailyQuestionListUiState
 
     data class Error(
-        val message: String,
+        val message: UiText,
     ) : DailyQuestionListUiState
 }
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionListViewModel.kt
@@ -1,12 +1,15 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.afternote.feature.mindrecord.domain.model.DailyQuestion
 import com.afternote.feature.mindrecord.domain.model.TodayDailyQuestion
 import com.afternote.feature.mindrecord.domain.repository.DailyQuestionRepository
+import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.mapper.toUi
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -20,6 +23,7 @@ import javax.inject.Inject
 class DailyQuestionListViewModel
     @Inject
     constructor(
+        @ApplicationContext private val context: Context,
         private val repository: DailyQuestionRepository,
     ) : ViewModel() {
         private val internalState = MutableStateFlow(InternalState())
@@ -51,7 +55,8 @@ class DailyQuestionListViewModel
 
                 if (today == null && listResult.isFailure) {
                     val message =
-                        listResult.exceptionOrNull()?.message ?: "데일리 질문을 불러오지 못했습니다."
+                        listResult.exceptionOrNull()?.message
+                            ?: context.getString(R.string.mindrecord_error_daily_question_list_failed)
                     internalState.update { it.copy(loadPhase = LoadPhase.Failed(message)) }
                 } else {
                     internalState.update { it.copy(loadPhase = LoadPhase.Loaded(today, list)) }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionListViewModel.kt
@@ -1,15 +1,14 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.core.ui.UiText
 import com.afternote.feature.mindrecord.domain.model.DailyQuestion
 import com.afternote.feature.mindrecord.domain.model.TodayDailyQuestion
 import com.afternote.feature.mindrecord.domain.repository.DailyQuestionRepository
 import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.mapper.toUi
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -23,7 +22,6 @@ import javax.inject.Inject
 class DailyQuestionListViewModel
     @Inject
     constructor(
-        @ApplicationContext private val context: Context,
         private val repository: DailyQuestionRepository,
     ) : ViewModel() {
         private val internalState = MutableStateFlow(InternalState())
@@ -55,8 +53,10 @@ class DailyQuestionListViewModel
 
                 if (today == null && listResult.isFailure) {
                     val message =
-                        listResult.exceptionOrNull()?.message
-                            ?: context.getString(R.string.mindrecord_error_daily_question_list_failed)
+                        UiText.DynamicOrResource(
+                            value = listResult.exceptionOrNull()?.message,
+                            fallbackResId = R.string.mindrecord_error_daily_question_list_failed,
+                        )
                     internalState.update { it.copy(loadPhase = LoadPhase.Failed(message)) }
                 } else {
                     internalState.update { it.copy(loadPhase = LoadPhase.Loaded(today, list)) }
@@ -77,7 +77,7 @@ class DailyQuestionListViewModel
             ) : LoadPhase
 
             data class Failed(
-                val message: String,
+                val message: UiText,
             ) : LoadPhase
         }
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionWriteUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionWriteUiState.kt
@@ -1,12 +1,14 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
+import com.afternote.core.ui.UiText
+
 data class DailyQuestionWriteUiState(
     val questionId: Long? = null,
     val questionContent: String = "",
     val answer: String = "",
     val imageUrl: String? = null,
     val isQuestionLoading: Boolean = true,
-    val questionLoadError: String? = null,
+    val questionLoadError: UiText? = null,
     val submitState: SubmitState = SubmitState.Idle,
 ) {
     val canSubmit: Boolean
@@ -21,6 +23,6 @@ sealed interface SubmitState {
     data object Succeeded : SubmitState
 
     data class Failed(
-        val message: String,
+        val message: UiText,
     ) : SubmitState
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionWriteViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionWriteViewModel.kt
@@ -1,13 +1,12 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.core.ui.UiText
 import com.afternote.feature.mindrecord.domain.model.DailyQuestionCreatePayload
 import com.afternote.feature.mindrecord.domain.repository.DailyQuestionRepository
 import com.afternote.feature.mindrecord.presentation.R
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -19,7 +18,6 @@ import javax.inject.Inject
 class DailyQuestionWriteViewModel
     @Inject
     constructor(
-        @ApplicationContext private val context: Context,
         private val repository: DailyQuestionRepository,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(DailyQuestionWriteUiState())
@@ -47,7 +45,10 @@ class DailyQuestionWriteViewModel
                             it.copy(
                                 isQuestionLoading = false,
                                 questionLoadError =
-                                    e.message ?: context.getString(R.string.mindrecord_error_daily_question_today_failed),
+                                    UiText.DynamicOrResource(
+                                        value = e.message,
+                                        fallbackResId = R.string.mindrecord_error_daily_question_today_failed,
+                                    ),
                             )
                         }
                     }
@@ -80,7 +81,10 @@ class DailyQuestionWriteViewModel
                             it.copy(
                                 submitState =
                                     SubmitState.Failed(
-                                        e.message ?: context.getString(R.string.mindrecord_error_daily_question_submit_failed),
+                                        UiText.DynamicOrResource(
+                                            value = e.message,
+                                            fallbackResId = R.string.mindrecord_error_daily_question_submit_failed,
+                                        ),
                                     ),
                             )
                         }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionWriteViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionWriteViewModel.kt
@@ -1,10 +1,13 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.afternote.feature.mindrecord.domain.model.DailyQuestionCreatePayload
 import com.afternote.feature.mindrecord.domain.repository.DailyQuestionRepository
+import com.afternote.feature.mindrecord.presentation.R
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,6 +19,7 @@ import javax.inject.Inject
 class DailyQuestionWriteViewModel
     @Inject
     constructor(
+        @ApplicationContext private val context: Context,
         private val repository: DailyQuestionRepository,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(DailyQuestionWriteUiState())
@@ -42,7 +46,8 @@ class DailyQuestionWriteViewModel
                         _uiState.update {
                             it.copy(
                                 isQuestionLoading = false,
-                                questionLoadError = e.message ?: "오늘의 질문을 불러오지 못했습니다.",
+                                questionLoadError =
+                                    e.message ?: context.getString(R.string.mindrecord_error_daily_question_today_failed),
                             )
                         }
                     }
@@ -72,7 +77,12 @@ class DailyQuestionWriteViewModel
                         _uiState.update { it.copy(submitState = SubmitState.Succeeded) }
                     }.onFailure { e ->
                         _uiState.update {
-                            it.copy(submitState = SubmitState.Failed(e.message ?: "등록에 실패했습니다."))
+                            it.copy(
+                                submitState =
+                                    SubmitState.Failed(
+                                        e.message ?: context.getString(R.string.mindrecord_error_daily_question_submit_failed),
+                                    ),
+                            )
                         }
                     }
             }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtCategoryUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtCategoryUiState.kt
@@ -6,5 +6,5 @@ data class DeepThoughtCategoryUiState(
     val isLoading: Boolean = false,
     val isMutating: Boolean = false,
     val categories: List<CategoryUiModel> = emptyList(),
-    val errorMessage: String? = null,
+    val error: CategoryError? = null,
 )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtCategoryViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtCategoryViewModel.kt
@@ -1,6 +1,5 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategoryCreatePayload
@@ -8,10 +7,8 @@ import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategoryName
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategoryUpdatePayload
 import com.afternote.feature.mindrecord.domain.model.MindRecordError
 import com.afternote.feature.mindrecord.domain.repository.DeepThoughtRepository
-import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.mapper.toUi
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -23,7 +20,6 @@ import javax.inject.Inject
 class DeepThoughtCategoryViewModel
     @Inject
     constructor(
-        @ApplicationContext private val context: Context,
         private val repository: DeepThoughtRepository,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(DeepThoughtCategoryUiState())
@@ -43,7 +39,7 @@ class DeepThoughtCategoryViewModel
                 .from(name)
                 .onSuccess { categoryName ->
                     viewModelScope.launch {
-                        _uiState.update { it.copy(isMutating = true, errorMessage = null) }
+                        _uiState.update { it.copy(isMutating = true, error = null) }
                         repository
                             .createCategory(
                                 DeepThoughtCategoryCreatePayload(
@@ -58,11 +54,11 @@ class DeepThoughtCategoryViewModel
                                     )
                                 }
                             }.onFailure { e ->
-                                emitError(resolveMessage(e, R.string.mindrecord_error_category_add_failed))
+                                emitError(CategoryError.AddFailed(e.message))
                             }
                     }
                 }.onFailure { e ->
-                    emitError(resolveMessage(e, R.string.mindrecord_error_category_name_invalid))
+                    emitError(toValidationError(e))
                 }
         }
 
@@ -74,7 +70,7 @@ class DeepThoughtCategoryViewModel
                 .from(newName)
                 .onSuccess { categoryName ->
                     viewModelScope.launch {
-                        _uiState.update { it.copy(isMutating = true, errorMessage = null) }
+                        _uiState.update { it.copy(isMutating = true, error = null) }
                         repository
                             .updateCategory(
                                 categoryId = categoryId,
@@ -88,17 +84,17 @@ class DeepThoughtCategoryViewModel
                                     )
                                 }
                             }.onFailure { e ->
-                                emitError(resolveMessage(e, R.string.mindrecord_error_category_update_failed))
+                                emitError(CategoryError.UpdateFailed(e.message))
                             }
                     }
                 }.onFailure { e ->
-                    emitError(resolveMessage(e, R.string.mindrecord_error_category_name_invalid))
+                    emitError(toValidationError(e))
                 }
         }
 
         fun deleteCategory(categoryId: Long) {
             viewModelScope.launch {
-                _uiState.update { it.copy(isMutating = true, errorMessage = null) }
+                _uiState.update { it.copy(isMutating = true, error = null) }
                 repository
                     .deleteCategory(categoryId)
                     .onSuccess {
@@ -109,31 +105,28 @@ class DeepThoughtCategoryViewModel
                             )
                         }
                     }.onFailure { e ->
-                        emitError(resolveMessage(e, R.string.mindrecord_error_category_delete_failed))
+                        emitError(CategoryError.DeleteFailed(e.message))
                     }
             }
         }
 
         fun consumeError() {
-            _uiState.update { it.copy(errorMessage = null) }
+            _uiState.update { it.copy(error = null) }
         }
 
-        private fun emitError(message: String) {
-            _uiState.update { it.copy(isMutating = false, errorMessage = message) }
+        private fun emitError(error: CategoryError) {
+            _uiState.update { it.copy(isMutating = false, error = error) }
         }
 
-        private fun resolveMessage(
-            error: Throwable,
-            fallback: Int,
-        ): String =
+        private fun toValidationError(error: Throwable): CategoryError =
             when (error) {
-                MindRecordError.EmptyCategoryName -> context.getString(R.string.mindrecord_error_category_name_empty)
-                else -> error.message ?: context.getString(fallback)
+                MindRecordError.EmptyCategoryName -> CategoryError.EmptyName
+                else -> CategoryError.NameInvalid
             }
 
         private fun load() {
             viewModelScope.launch {
-                _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+                _uiState.update { it.copy(isLoading = true, error = null) }
                 repository
                     .getCategories()
                     .onSuccess { list ->
@@ -147,7 +140,7 @@ class DeepThoughtCategoryViewModel
                         _uiState.update {
                             it.copy(
                                 isLoading = false,
-                                errorMessage = resolveMessage(e, R.string.mindrecord_error_category_list_failed),
+                                error = CategoryError.ListFailed(e.message),
                             )
                         }
                     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtCategoryViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtCategoryViewModel.kt
@@ -1,13 +1,17 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategoryCreatePayload
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategoryName
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategoryUpdatePayload
+import com.afternote.feature.mindrecord.domain.model.MindRecordError
 import com.afternote.feature.mindrecord.domain.repository.DeepThoughtRepository
+import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.mapper.toUi
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -19,6 +23,7 @@ import javax.inject.Inject
 class DeepThoughtCategoryViewModel
     @Inject
     constructor(
+        @ApplicationContext private val context: Context,
         private val repository: DeepThoughtRepository,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(DeepThoughtCategoryUiState())
@@ -52,9 +57,13 @@ class DeepThoughtCategoryViewModel
                                         categories = it.categories + created.toUi(),
                                     )
                                 }
-                            }.onFailure { e -> emitError(e.message ?: "카테고리 추가에 실패했습니다.") }
+                            }.onFailure { e ->
+                                emitError(resolveMessage(e, R.string.mindrecord_error_category_add_failed))
+                            }
                     }
-                }.onFailure { e -> emitError(e.message ?: "카테고리 이름이 올바르지 않습니다.") }
+                }.onFailure { e ->
+                    emitError(resolveMessage(e, R.string.mindrecord_error_category_name_invalid))
+                }
         }
 
         fun renameCategory(
@@ -78,9 +87,13 @@ class DeepThoughtCategoryViewModel
                                         categories = state.categories.map { if (it.id == ui.id) ui else it },
                                     )
                                 }
-                            }.onFailure { e -> emitError(e.message ?: "카테고리 수정에 실패했습니다.") }
+                            }.onFailure { e ->
+                                emitError(resolveMessage(e, R.string.mindrecord_error_category_update_failed))
+                            }
                     }
-                }.onFailure { e -> emitError(e.message ?: "카테고리 이름이 올바르지 않습니다.") }
+                }.onFailure { e ->
+                    emitError(resolveMessage(e, R.string.mindrecord_error_category_name_invalid))
+                }
         }
 
         fun deleteCategory(categoryId: Long) {
@@ -95,7 +108,9 @@ class DeepThoughtCategoryViewModel
                                 categories = state.categories.filterNot { it.id == categoryId.toString() },
                             )
                         }
-                    }.onFailure { e -> emitError(e.message ?: "카테고리 삭제에 실패했습니다.") }
+                    }.onFailure { e ->
+                        emitError(resolveMessage(e, R.string.mindrecord_error_category_delete_failed))
+                    }
             }
         }
 
@@ -106,6 +121,15 @@ class DeepThoughtCategoryViewModel
         private fun emitError(message: String) {
             _uiState.update { it.copy(isMutating = false, errorMessage = message) }
         }
+
+        private fun resolveMessage(
+            error: Throwable,
+            fallback: Int,
+        ): String =
+            when (error) {
+                MindRecordError.EmptyCategoryName -> context.getString(R.string.mindrecord_error_category_name_empty)
+                else -> error.message ?: context.getString(fallback)
+            }
 
         private fun load() {
             viewModelScope.launch {
@@ -123,7 +147,7 @@ class DeepThoughtCategoryViewModel
                         _uiState.update {
                             it.copy(
                                 isLoading = false,
-                                errorMessage = e.message ?: "카테고리 목록을 불러오지 못했습니다.",
+                                errorMessage = resolveMessage(e, R.string.mindrecord_error_category_list_failed),
                             )
                         }
                     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtListUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtListUiState.kt
@@ -1,5 +1,6 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
+import com.afternote.core.ui.UiText
 import com.afternote.feature.mindrecord.presentation.model.CategoryUiModel
 import com.afternote.feature.mindrecord.presentation.model.DeepThoughtModel
 import com.afternote.feature.mindrecord.presentation.model.Tag
@@ -18,6 +19,6 @@ sealed interface DeepThoughtListUiState {
     ) : DeepThoughtListUiState
 
     data class Error(
-        val message: String,
+        val message: UiText,
     ) : DeepThoughtListUiState
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtListViewModel.kt
@@ -1,8 +1,8 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.core.ui.UiText
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategory
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtList
 import com.afternote.feature.mindrecord.domain.model.RandomDeepThought
@@ -11,7 +11,6 @@ import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.mapper.toUi
 import com.afternote.feature.mindrecord.presentation.model.Tag
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -25,7 +24,6 @@ import javax.inject.Inject
 class DeepThoughtListViewModel
     @Inject
     constructor(
-        @ApplicationContext private val context: Context,
         private val repository: DeepThoughtRepository,
     ) : ViewModel() {
         private val internalState = MutableStateFlow(InternalState())
@@ -76,7 +74,10 @@ class DeepThoughtListViewModel
                             it.copy(
                                 loadPhase =
                                     LoadPhase.Failed(
-                                        e.message ?: context.getString(R.string.mindrecord_error_deep_thought_list_failed),
+                                        UiText.DynamicOrResource(
+                                            value = e.message,
+                                            fallbackResId = R.string.mindrecord_error_deep_thought_list_failed,
+                                        ),
                                     ),
                             )
                         }
@@ -100,7 +101,7 @@ class DeepThoughtListViewModel
             ) : LoadPhase
 
             data class Failed(
-                val message: String,
+                val message: UiText,
             ) : LoadPhase
         }
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtListViewModel.kt
@@ -106,7 +106,9 @@ class DeepThoughtListViewModel
 
         private fun InternalState.toUiState(): DeepThoughtListUiState =
             when (val phase = loadPhase) {
-                LoadPhase.Loading -> DeepThoughtListUiState.Loading
+                LoadPhase.Loading -> {
+                    DeepThoughtListUiState.Loading
+                }
 
                 is LoadPhase.Loaded -> {
                     val items = phase.list.items.map { it.toUi() }
@@ -122,6 +124,8 @@ class DeepThoughtListViewModel
                     )
                 }
 
-                is LoadPhase.Failed -> DeepThoughtListUiState.Error(phase.message)
+                is LoadPhase.Failed -> {
+                    DeepThoughtListUiState.Error(phase.message)
+                }
             }
     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtListViewModel.kt
@@ -1,14 +1,17 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.afternote.feature.mindrecord.domain.model.DeepThought
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCategory
+import com.afternote.feature.mindrecord.domain.model.DeepThoughtList
 import com.afternote.feature.mindrecord.domain.model.RandomDeepThought
 import com.afternote.feature.mindrecord.domain.repository.DeepThoughtRepository
+import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.mapper.toUi
 import com.afternote.feature.mindrecord.presentation.model.Tag
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -22,6 +25,7 @@ import javax.inject.Inject
 class DeepThoughtListViewModel
     @Inject
     constructor(
+        @ApplicationContext private val context: Context,
         private val repository: DeepThoughtRepository,
     ) : ViewModel() {
         private val internalState = MutableStateFlow(InternalState())
@@ -69,7 +73,12 @@ class DeepThoughtListViewModel
                         }
                     }.onFailure { e ->
                         internalState.update {
-                            it.copy(loadPhase = LoadPhase.Failed(e.message ?: "깊은 생각을 불러오지 못했습니다."))
+                            it.copy(
+                                loadPhase =
+                                    LoadPhase.Failed(
+                                        e.message ?: context.getString(R.string.mindrecord_error_deep_thought_list_failed),
+                                    ),
+                            )
                         }
                     }
             }
@@ -86,7 +95,7 @@ class DeepThoughtListViewModel
 
             data class Loaded(
                 val random: RandomDeepThought?,
-                val items: List<DeepThought>,
+                val list: DeepThoughtList,
                 val categories: List<DeepThoughtCategory>,
             ) : LoadPhase
 
@@ -97,18 +106,11 @@ class DeepThoughtListViewModel
 
         private fun InternalState.toUiState(): DeepThoughtListUiState =
             when (val phase = loadPhase) {
-                LoadPhase.Loading -> {
-                    DeepThoughtListUiState.Loading
-                }
+                LoadPhase.Loading -> DeepThoughtListUiState.Loading
 
                 is LoadPhase.Loaded -> {
-                    val items = phase.items.map { it.toUi() }
-                    val tags =
-                        items
-                            .flatMap { it.tag }
-                            .groupingBy { it.name }
-                            .eachCount()
-                            .map { (name, count) -> Tag(name = name, count = count) }
+                    val items = phase.list.items.map { it.toUi() }
+                    val tags = phase.list.tagCounts.map { Tag(name = it.tag, count = it.count) }
                     DeepThoughtListUiState.Success(
                         randomThoughtTitle = phase.random?.title,
                         randomThoughtCreatedAt = phase.random?.createdAt,
@@ -120,8 +122,6 @@ class DeepThoughtListViewModel
                     )
                 }
 
-                is LoadPhase.Failed -> {
-                    DeepThoughtListUiState.Error(phase.message)
-                }
+                is LoadPhase.Failed -> DeepThoughtListUiState.Error(phase.message)
             }
     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtWriteUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtWriteUiState.kt
@@ -3,7 +3,7 @@ package com.afternote.feature.mindrecord.presentation.viewmodel
 data class DeepThoughtWriteUiState(
     val title: String = "",
     val content: String = "",
-    val category: String = "나의 가치관",
+    val category: String = "",
     val tags: List<String> = emptyList(),
     val imageUrl: String? = null,
     val submitState: SubmitState = SubmitState.Idle,

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtWriteViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtWriteViewModel.kt
@@ -1,13 +1,12 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.core.ui.UiText
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCreatePayload
 import com.afternote.feature.mindrecord.domain.repository.DeepThoughtRepository
 import com.afternote.feature.mindrecord.presentation.R
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -19,15 +18,9 @@ import javax.inject.Inject
 class DeepThoughtWriteViewModel
     @Inject
     constructor(
-        @ApplicationContext private val context: Context,
         private val repository: DeepThoughtRepository,
     ) : ViewModel() {
-        private val _uiState =
-            MutableStateFlow(
-                DeepThoughtWriteUiState(
-                    category = context.getString(R.string.mindrecord_deep_thought_write_default_category),
-                ),
-            )
+        private val _uiState = MutableStateFlow(DeepThoughtWriteUiState())
         val uiState: StateFlow<DeepThoughtWriteUiState> = _uiState.asStateFlow()
 
         fun onTitleChanged(value: String) {
@@ -69,7 +62,10 @@ class DeepThoughtWriteViewModel
                             it.copy(
                                 submitState =
                                     SubmitState.Failed(
-                                        e.message ?: context.getString(R.string.mindrecord_error_deep_thought_submit_failed),
+                                        UiText.DynamicOrResource(
+                                            value = e.message,
+                                            fallbackResId = R.string.mindrecord_error_deep_thought_submit_failed,
+                                        ),
                                     ),
                             )
                         }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtWriteViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtWriteViewModel.kt
@@ -1,10 +1,13 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.afternote.feature.mindrecord.domain.model.DeepThoughtCreatePayload
 import com.afternote.feature.mindrecord.domain.repository.DeepThoughtRepository
+import com.afternote.feature.mindrecord.presentation.R
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,9 +19,15 @@ import javax.inject.Inject
 class DeepThoughtWriteViewModel
     @Inject
     constructor(
+        @ApplicationContext private val context: Context,
         private val repository: DeepThoughtRepository,
     ) : ViewModel() {
-        private val _uiState = MutableStateFlow(DeepThoughtWriteUiState())
+        private val _uiState =
+            MutableStateFlow(
+                DeepThoughtWriteUiState(
+                    category = context.getString(R.string.mindrecord_deep_thought_write_default_category),
+                ),
+            )
         val uiState: StateFlow<DeepThoughtWriteUiState> = _uiState.asStateFlow()
 
         fun onTitleChanged(value: String) {
@@ -57,7 +66,12 @@ class DeepThoughtWriteViewModel
                         _uiState.update { it.copy(submitState = SubmitState.Succeeded) }
                     }.onFailure { e ->
                         _uiState.update {
-                            it.copy(submitState = SubmitState.Failed(e.message ?: "깊은 생각 등록에 실패했습니다."))
+                            it.copy(
+                                submitState =
+                                    SubmitState.Failed(
+                                        e.message ?: context.getString(R.string.mindrecord_error_deep_thought_submit_failed),
+                                    ),
+                            )
                         }
                     }
             }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryListUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryListUiState.kt
@@ -1,5 +1,6 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
+import com.afternote.core.ui.UiText
 import com.afternote.feature.mindrecord.presentation.model.DailyDiary
 
 sealed interface DiaryListUiState {
@@ -10,6 +11,6 @@ sealed interface DiaryListUiState {
     ) : DiaryListUiState
 
     data class Error(
-        val message: String,
+        val message: UiText,
     ) : DiaryListUiState
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryListViewModel.kt
@@ -1,14 +1,13 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.core.ui.UiText
 import com.afternote.feature.mindrecord.domain.model.Diary
 import com.afternote.feature.mindrecord.domain.repository.DiaryRepository
 import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.mapper.toUi
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -23,7 +22,6 @@ import javax.inject.Inject
 class DiaryListViewModel
     @Inject
     constructor(
-        @ApplicationContext private val context: Context,
         private val repository: DiaryRepository,
     ) : ViewModel() {
         private val internalState = MutableStateFlow(InternalState())
@@ -57,7 +55,10 @@ class DiaryListViewModel
                             it.copy(
                                 loadPhase =
                                     LoadPhase.Failed(
-                                        e.message ?: context.getString(R.string.mindrecord_error_diary_list_failed),
+                                        UiText.DynamicOrResource(
+                                            value = e.message,
+                                            fallbackResId = R.string.mindrecord_error_diary_list_failed,
+                                        ),
                                     ),
                             )
                         }
@@ -77,7 +78,7 @@ class DiaryListViewModel
             ) : LoadPhase
 
             data class Failed(
-                val message: String,
+                val message: UiText,
             ) : LoadPhase
         }
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryListViewModel.kt
@@ -1,11 +1,14 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.afternote.feature.mindrecord.domain.model.Diary
 import com.afternote.feature.mindrecord.domain.repository.DiaryRepository
+import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.mapper.toUi
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -20,6 +23,7 @@ import javax.inject.Inject
 class DiaryListViewModel
     @Inject
     constructor(
+        @ApplicationContext private val context: Context,
         private val repository: DiaryRepository,
     ) : ViewModel() {
         private val internalState = MutableStateFlow(InternalState())
@@ -45,12 +49,17 @@ class DiaryListViewModel
             viewModelScope.launch {
                 internalState.update { it.copy(loadPhase = LoadPhase.Loading) }
                 repository
-                    .getList(yearMonth = yearMonth.toString(), draftOnly = true)
+                    .getList(yearMonth = yearMonth.toString(), draftOnly = null)
                     .onSuccess { list ->
                         internalState.update { it.copy(loadPhase = LoadPhase.Loaded(list)) }
                     }.onFailure { e ->
                         internalState.update {
-                            it.copy(loadPhase = LoadPhase.Failed(e.message ?: "일기를 불러오지 못했습니다."))
+                            it.copy(
+                                loadPhase =
+                                    LoadPhase.Failed(
+                                        e.message ?: context.getString(R.string.mindrecord_error_diary_list_failed),
+                                    ),
+                            )
                         }
                     }
             }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteViewModel.kt
@@ -1,11 +1,14 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.afternote.feature.mindrecord.domain.model.DiaryCreatePayload
 import com.afternote.feature.mindrecord.domain.model.TodayMood
 import com.afternote.feature.mindrecord.domain.repository.DiaryRepository
+import com.afternote.feature.mindrecord.presentation.R
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -18,6 +21,7 @@ import javax.inject.Inject
 class DiaryWriteViewModel
     @Inject
     constructor(
+        @ApplicationContext private val context: Context,
         private val repository: DiaryRepository,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(DiaryWriteUiState())
@@ -58,7 +62,12 @@ class DiaryWriteViewModel
                         _uiState.update { it.copy(submitState = SubmitState.Succeeded) }
                     }.onFailure { e ->
                         _uiState.update {
-                            it.copy(submitState = SubmitState.Failed(e.message ?: "일기 등록에 실패했습니다."))
+                            it.copy(
+                                submitState =
+                                    SubmitState.Failed(
+                                        e.message ?: context.getString(R.string.mindrecord_error_diary_submit_failed),
+                                    ),
+                            )
                         }
                     }
             }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteViewModel.kt
@@ -1,14 +1,13 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.core.ui.UiText
 import com.afternote.feature.mindrecord.domain.model.DiaryCreatePayload
 import com.afternote.feature.mindrecord.domain.model.TodayMood
 import com.afternote.feature.mindrecord.domain.repository.DiaryRepository
 import com.afternote.feature.mindrecord.presentation.R
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,7 +20,6 @@ import javax.inject.Inject
 class DiaryWriteViewModel
     @Inject
     constructor(
-        @ApplicationContext private val context: Context,
         private val repository: DiaryRepository,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(DiaryWriteUiState())
@@ -65,7 +63,10 @@ class DiaryWriteViewModel
                             it.copy(
                                 submitState =
                                     SubmitState.Failed(
-                                        e.message ?: context.getString(R.string.mindrecord_error_diary_submit_failed),
+                                        UiText.DynamicOrResource(
+                                            value = e.message,
+                                            fallbackResId = R.string.mindrecord_error_diary_submit_failed,
+                                        ),
                                     ),
                             )
                         }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportUiState.kt
@@ -1,0 +1,32 @@
+package com.afternote.feature.mindrecord.presentation.viewmodel
+
+import com.afternote.feature.mindrecord.presentation.component.EmotionBubble
+import com.afternote.feature.mindrecord.presentation.model.DailyQuestion
+import com.afternote.feature.mindrecord.presentation.model.DayItem
+import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
+import java.time.LocalDate
+
+data class WeekOption(
+    val monday: LocalDate,
+    val label: String,
+)
+
+sealed interface WeeklyReportUiState {
+    data object Loading : WeeklyReportUiState
+
+    data class Success(
+        val selectedMonday: LocalDate,
+        val weekOptions: List<WeekOption>,
+        val dateRange: String,
+        val recordedDays: Int,
+        val counts: List<Pair<Int, MindRecordCategoryUi>>,
+        val weekDays: List<DayItem>,
+        val emotionBubbles: List<EmotionBubble>,
+        val summaryText: String,
+        val dailyQuestions: List<DailyQuestion>,
+    ) : WeeklyReportUiState
+
+    data class Error(
+        val message: String,
+    ) : WeeklyReportUiState
+}

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportUiState.kt
@@ -1,14 +1,17 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
+import com.afternote.core.ui.UiText
 import com.afternote.feature.mindrecord.presentation.component.EmotionBubble
 import com.afternote.feature.mindrecord.presentation.model.DailyQuestion
 import com.afternote.feature.mindrecord.presentation.model.DayItem
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
 import java.time.LocalDate
 
+/**
+ * 드롭다운 표시용. 라벨 문자열은 [monday] 로부터 UI 측에서 포맷팅한다 (월/주차).
+ */
 data class WeekOption(
     val monday: LocalDate,
-    val label: String,
 )
 
 sealed interface WeeklyReportUiState {
@@ -28,6 +31,6 @@ sealed interface WeeklyReportUiState {
     ) : WeeklyReportUiState
 
     data class Error(
-        val message: String,
+        val message: UiText,
     ) : WeeklyReportUiState
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportUiState.kt
@@ -18,6 +18,7 @@ sealed interface WeeklyReportUiState {
         val selectedMonday: LocalDate,
         val weekOptions: List<WeekOption>,
         val dateRange: String,
+        val userName: String,
         val recordedDays: Int,
         val counts: List<Pair<Int, MindRecordCategoryUi>>,
         val weekDays: List<DayItem>,

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.core.domain.repository.UserRepository
 import com.afternote.feature.mindrecord.domain.model.TodayMood
 import com.afternote.feature.mindrecord.domain.model.WeeklyReport
 import com.afternote.feature.mindrecord.domain.model.WeeklyReportDailyQuestion
@@ -21,6 +22,8 @@ import com.afternote.feature.mindrecord.presentation.model.DayItem
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -39,6 +42,7 @@ class WeeklyReportViewModel
     constructor(
         @ApplicationContext private val context: Context,
         private val repository: WeeklyReportRepository,
+        private val userRepository: UserRepository,
     ) : ViewModel() {
         // 월~일 순서. 캘린더 셀 라벨 매핑용.
         private val weekdayLabels: List<String> =
@@ -82,10 +86,24 @@ class WeeklyReportViewModel
         private fun load(monday: LocalDate) {
             viewModelScope.launch {
                 internalState.update { it.copy(loadPhase = LoadPhase.Loading) }
-                repository
-                    .getWeeklyReport(date = monday.format(API_DATE_FORMATTER))
-                    .onSuccess { report ->
-                        internalState.update { it.copy(loadPhase = LoadPhase.Loaded(monday, report)) }
+                val result =
+                    runCatching {
+                        coroutineScope {
+                            val reportDeferred =
+                                async {
+                                    repository
+                                        .getWeeklyReport(date = monday.format(API_DATE_FORMATTER))
+                                        .getOrThrow()
+                                }
+                            val profileDeferred = async { userRepository.getMyProfile() }
+                            reportDeferred.await() to profileDeferred.await()
+                        }
+                    }
+                result
+                    .onSuccess { (report, profile) ->
+                        internalState.update {
+                            it.copy(loadPhase = LoadPhase.Loaded(monday, report, profile.name))
+                        }
                     }.onFailure { e ->
                         internalState.update {
                             it.copy(
@@ -157,6 +175,7 @@ class WeeklyReportViewModel
             data class Loaded(
                 val monday: LocalDate,
                 val report: WeeklyReport,
+                val userName: String,
             ) : LoadPhase
 
             data class Failed(
@@ -177,6 +196,7 @@ class WeeklyReportViewModel
                 selectedMonday = monday,
                 weekOptions = weekOptions,
                 dateRange = "${monday.format(RANGE_FORMATTER)} - ${sunday.format(RANGE_FORMATTER)}",
+                userName = userName,
                 recordedDays = report.week.count { it.isDiary },
                 counts =
                     listOf(

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportViewModel.kt
@@ -1,12 +1,12 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
-import android.content.Context
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.afternote.core.domain.repository.UserRepository
+import com.afternote.core.ui.UiText
 import com.afternote.feature.mindrecord.domain.model.TodayMood
 import com.afternote.feature.mindrecord.domain.model.WeeklyReport
 import com.afternote.feature.mindrecord.domain.model.WeeklyReportDailyQuestion
@@ -21,7 +21,6 @@ import com.afternote.feature.mindrecord.presentation.model.DayContent
 import com.afternote.feature.mindrecord.presentation.model.DayItem
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -40,22 +39,9 @@ import javax.inject.Inject
 class WeeklyReportViewModel
     @Inject
     constructor(
-        @ApplicationContext private val context: Context,
         private val repository: WeeklyReportRepository,
         private val userRepository: UserRepository,
     ) : ViewModel() {
-        // 월~일 순서. 캘린더 셀 라벨 매핑용.
-        private val weekdayLabels: List<String> =
-            listOf(
-                context.getString(R.string.mindrecord_calendar_day_label_mon),
-                context.getString(R.string.mindrecord_calendar_day_label_tue),
-                context.getString(R.string.mindrecord_calendar_day_label_wed),
-                context.getString(R.string.mindrecord_calendar_day_label_thu),
-                context.getString(R.string.mindrecord_calendar_day_label_fri),
-                context.getString(R.string.mindrecord_calendar_day_label_sat),
-                context.getString(R.string.mindrecord_calendar_day_label_sun),
-            )
-
         private val weekOptions: List<WeekOption> =
             buildWeekOptions(today = LocalDate.now(), count = WEEK_OPTION_COUNT)
 
@@ -109,8 +95,10 @@ class WeeklyReportViewModel
                             it.copy(
                                 loadPhase =
                                     LoadPhase.Failed(
-                                        e.message
-                                            ?: context.getString(R.string.mindrecord_error_weekly_report_failed),
+                                        UiText.DynamicOrResource(
+                                            value = e.message,
+                                            fallbackResId = R.string.mindrecord_error_weekly_report_failed,
+                                        ),
                                     ),
                             )
                         }
@@ -124,16 +112,7 @@ class WeeklyReportViewModel
         ): List<WeekOption> {
             val thisMonday = today.with(DayOfWeek.MONDAY)
             return (0 until count).map { weeksAgo ->
-                val monday = thisMonday.minusWeeks(weeksAgo.toLong())
-                WeekOption(
-                    monday = monday,
-                    label =
-                        context.getString(
-                            R.string.mindrecord_weekly_report_label_format,
-                            monday.monthValue,
-                            weekOfMonth(monday),
-                        ),
-                )
+                WeekOption(monday = thisMonday.minusWeeks(weeksAgo.toLong()))
             }
         }
 
@@ -141,14 +120,14 @@ class WeeklyReportViewModel
             monday: LocalDate,
             week: List<WeeklyReportDay>,
         ): List<DayItem> =
-            List(weekdayLabels.size) { index ->
+            List(WEEK_LENGTH) { index ->
                 val date = monday.plusDays(index.toLong())
                 val apiDay = week.getOrNull(index)
                 val dayOfMonth = apiDay?.day ?: date.dayOfMonth
                 val isDiary = apiDay?.isDiary == true
                 val emoji = apiDay?.emotion?.toEmoji()
                 DayItem(
-                    label = weekdayLabels[index],
+                    dayOfWeek = date.dayOfWeek,
                     content =
                         when {
                             emoji != null && isDiary -> DayContent.EmojiWithDot(emoji)
@@ -179,7 +158,7 @@ class WeeklyReportViewModel
             ) : LoadPhase
 
             data class Failed(
-                val message: String,
+                val message: UiText,
             ) : LoadPhase
         }
 
@@ -213,11 +192,10 @@ class WeeklyReportViewModel
 
         companion object {
             private const val WEEK_OPTION_COUNT = 5
+            private const val WEEK_LENGTH = 7
 
             private val API_DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
             private val RANGE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd.")
-
-            private fun weekOfMonth(date: LocalDate): Int = (date.dayOfMonth - 1) / 7 + 1
 
             private fun TodayMood.toEmoji(): String =
                 when (this) {

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportViewModel.kt
@@ -1,0 +1,264 @@
+package com.afternote.feature.mindrecord.presentation.viewmodel
+
+import android.content.Context
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.afternote.feature.mindrecord.domain.model.TodayMood
+import com.afternote.feature.mindrecord.domain.model.WeeklyReport
+import com.afternote.feature.mindrecord.domain.model.WeeklyReportDailyQuestion
+import com.afternote.feature.mindrecord.domain.model.WeeklyReportDay
+import com.afternote.feature.mindrecord.domain.model.WeeklyReportEmotion
+import com.afternote.feature.mindrecord.domain.repository.WeeklyReportRepository
+import com.afternote.feature.mindrecord.presentation.R
+import com.afternote.feature.mindrecord.presentation.component.EmotionBubble
+import com.afternote.feature.mindrecord.presentation.model.DailyQuestion
+import com.afternote.feature.mindrecord.presentation.model.DayBackground
+import com.afternote.feature.mindrecord.presentation.model.DayContent
+import com.afternote.feature.mindrecord.presentation.model.DayItem
+import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+@HiltViewModel
+class WeeklyReportViewModel
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+        private val repository: WeeklyReportRepository,
+    ) : ViewModel() {
+        // 월~일 순서. 캘린더 셀 라벨 매핑용.
+        private val weekdayLabels: List<String> =
+            listOf(
+                context.getString(R.string.mindrecord_calendar_day_label_mon),
+                context.getString(R.string.mindrecord_calendar_day_label_tue),
+                context.getString(R.string.mindrecord_calendar_day_label_wed),
+                context.getString(R.string.mindrecord_calendar_day_label_thu),
+                context.getString(R.string.mindrecord_calendar_day_label_fri),
+                context.getString(R.string.mindrecord_calendar_day_label_sat),
+                context.getString(R.string.mindrecord_calendar_day_label_sun),
+            )
+
+        private val weekOptions: List<WeekOption> =
+            buildWeekOptions(today = LocalDate.now(), count = WEEK_OPTION_COUNT)
+
+        private val internalState = MutableStateFlow(InternalState())
+
+        val uiState: StateFlow<WeeklyReportUiState> =
+            internalState
+                .map { it.toUiState() }
+                .stateIn(
+                    scope = viewModelScope,
+                    started = SharingStarted.WhileSubscribed(5_000),
+                    initialValue = WeeklyReportUiState.Loading,
+                )
+
+        init {
+            load(weekOptions.first().monday)
+        }
+
+        fun selectWeek(monday: LocalDate) = load(monday)
+
+        fun refresh() {
+            val current =
+                (internalState.value.loadPhase as? LoadPhase.Loaded)?.monday
+                    ?: weekOptions.first().monday
+            load(current)
+        }
+
+        private fun load(monday: LocalDate) {
+            viewModelScope.launch {
+                internalState.update { it.copy(loadPhase = LoadPhase.Loading) }
+                repository
+                    .getWeeklyReport(date = monday.format(API_DATE_FORMATTER))
+                    .onSuccess { report ->
+                        internalState.update { it.copy(loadPhase = LoadPhase.Loaded(monday, report)) }
+                    }.onFailure { e ->
+                        internalState.update {
+                            it.copy(
+                                loadPhase =
+                                    LoadPhase.Failed(
+                                        e.message
+                                            ?: context.getString(R.string.mindrecord_error_weekly_report_failed),
+                                    ),
+                            )
+                        }
+                    }
+            }
+        }
+
+        private fun buildWeekOptions(
+            today: LocalDate,
+            count: Int,
+        ): List<WeekOption> {
+            val thisMonday = today.with(DayOfWeek.MONDAY)
+            return (0 until count).map { weeksAgo ->
+                val monday = thisMonday.minusWeeks(weeksAgo.toLong())
+                WeekOption(
+                    monday = monday,
+                    label =
+                        context.getString(
+                            R.string.mindrecord_weekly_report_label_format,
+                            monday.monthValue,
+                            weekOfMonth(monday),
+                        ),
+                )
+            }
+        }
+
+        private fun mapWeekDays(
+            monday: LocalDate,
+            week: List<WeeklyReportDay>,
+        ): List<DayItem> =
+            List(weekdayLabels.size) { index ->
+                val date = monday.plusDays(index.toLong())
+                val apiDay = week.getOrNull(index)
+                val dayOfMonth = apiDay?.day ?: date.dayOfMonth
+                val isDiary = apiDay?.isDiary == true
+                val emoji = apiDay?.emotion?.toEmoji()
+                DayItem(
+                    label = weekdayLabels[index],
+                    content =
+                        when {
+                            emoji != null && isDiary -> DayContent.EmojiWithDot(emoji)
+                            emoji != null -> DayContent.EmojiOnly(emoji)
+                            isDiary -> DayContent.NumberWithDot(dayOfMonth)
+                            else -> DayContent.NumberOnly(dayOfMonth)
+                        },
+                    background =
+                        when (apiDay?.emotion) {
+                            TodayMood.HAPPY -> DayBackground.Green
+                            TodayMood.SAD -> DayBackground.Pink
+                            else -> DayBackground.None
+                        },
+                )
+            }
+
+        private data class InternalState(
+            val loadPhase: LoadPhase = LoadPhase.Loading,
+        )
+
+        private sealed interface LoadPhase {
+            data object Loading : LoadPhase
+
+            data class Loaded(
+                val monday: LocalDate,
+                val report: WeeklyReport,
+            ) : LoadPhase
+
+            data class Failed(
+                val message: String,
+            ) : LoadPhase
+        }
+
+        private fun InternalState.toUiState(): WeeklyReportUiState =
+            when (val phase = loadPhase) {
+                LoadPhase.Loading -> WeeklyReportUiState.Loading
+                is LoadPhase.Failed -> WeeklyReportUiState.Error(phase.message)
+                is LoadPhase.Loaded -> phase.toSuccessUiState()
+            }
+
+        private fun LoadPhase.Loaded.toSuccessUiState(): WeeklyReportUiState.Success {
+            val sunday = monday.plusDays(6)
+            return WeeklyReportUiState.Success(
+                selectedMonday = monday,
+                weekOptions = weekOptions,
+                dateRange = "${monday.format(RANGE_FORMATTER)} - ${sunday.format(RANGE_FORMATTER)}",
+                recordedDays = report.week.count { it.isDiary },
+                counts =
+                    listOf(
+                        report.dailyQuestionAmount to MindRecordCategoryUi.DailyQuestion,
+                        report.diaryAmount to MindRecordCategoryUi.Diary,
+                        report.deepThoughtAmount to MindRecordCategoryUi.DeepThought,
+                    ),
+                weekDays = mapWeekDays(monday, report.week),
+                emotionBubbles = mapEmotionBubbles(report.emotions),
+                summaryText = report.summaryText,
+                dailyQuestions = report.dailyQuestions.map { it.toUi() },
+            )
+        }
+
+        companion object {
+            private const val WEEK_OPTION_COUNT = 5
+
+            private val API_DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+            private val RANGE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd.")
+
+            private fun weekOfMonth(date: LocalDate): Int = (date.dayOfMonth - 1) / 7 + 1
+
+            private fun TodayMood.toEmoji(): String =
+                when (this) {
+                    TodayMood.HAPPY -> "😊"
+                    TodayMood.SOSO -> "😐"
+                    TodayMood.SAD -> "😢"
+                }
+
+            // 4개 슬롯의 크기/위치/색상은 디자인 시안에 맞춰 고정. API 의 emotions 를 percentage
+            // 내림차순으로 정렬해 슬롯에 채워 넣어, 1위가 가장 크고 진한 버블이 되도록 배치.
+            private val BUBBLE_SLOTS: List<BubbleSlot> =
+                listOf(
+                    BubbleSlot(size = 100.dp, bgColor = Color(0xFF212121), offsetX = 0.dp, offsetY = 30.dp),
+                    BubbleSlot(size = 82.dp, bgColor = Color(0xFF424242), offsetX = 88.dp, offsetY = 0.dp),
+                    BubbleSlot(size = 68.dp, bgColor = Color(0xFF616161), offsetX = 158.dp, offsetY = 68.dp),
+                    BubbleSlot(size = 58.dp, bgColor = Color(0xFF9E9E9E), offsetX = 230.dp, offsetY = 42.dp),
+                )
+
+            private fun mapEmotionBubbles(emotions: List<WeeklyReportEmotion>): List<EmotionBubble> =
+                emotions
+                    .sortedByDescending { it.percentage }
+                    .take(BUBBLE_SLOTS.size)
+                    .mapIndexed { index, emotion ->
+                        val slot = BUBBLE_SLOTS[index]
+                        EmotionBubble(
+                            keyword = emotion.keyword,
+                            count = emotion.percentage,
+                            size = slot.size,
+                            bgColor = slot.bgColor,
+                            offsetX = slot.offsetX,
+                            offsetY = slot.offsetY,
+                        )
+                    }
+
+            private fun WeeklyReportDailyQuestion.toUi(): DailyQuestion =
+                DailyQuestion(
+                    title = title,
+                    date = parseLocalDate(date),
+                    content = content,
+                )
+
+            // 서버는 "yyyy.MM.dd 요일" 또는 ISO 포맷으로 내려옴 — 둘 다 허용.
+            private val DATE_FORMATTERS: List<DateTimeFormatter> =
+                listOf(
+                    DateTimeFormatter.ofPattern("yyyy.MM.dd"),
+                    DateTimeFormatter.ISO_DATE,
+                )
+
+            private fun parseLocalDate(raw: String): LocalDate {
+                val datePart = raw.substringBefore(' ').trim()
+                for (formatter in DATE_FORMATTERS) {
+                    runCatching { return LocalDate.parse(datePart, formatter) }
+                }
+                return LocalDate.now()
+            }
+        }
+
+        private data class BubbleSlot(
+            val size: Dp,
+            val bgColor: Color,
+            val offsetX: Dp,
+            val offsetY: Dp,
+        )
+    }

--- a/feature/mindrecord/presentation/src/main/res/values/strings.xml
+++ b/feature/mindrecord/presentation/src/main/res/values/strings.xml
@@ -84,7 +84,6 @@
     <string name="mindrecord_weekly_report_avg_mood_good">😊 좋음</string>
     <string name="mindrecord_weekly_report_label_format">%1$d월 %2$d주차 리포트</string>
     <string name="mindrecord_weekly_report_label_fallback">11월 2주차 리포트</string>
-    <string name="mindrecord_weekly_report_user_default_name">박서연</string>
     <string name="mindrecord_weekly_report_recorded_prefix">이번 주, </string>
     <string name="mindrecord_weekly_report_recorded_middle">님은 </string>
     <string name="mindrecord_weekly_report_recorded_suffix">의 마음을 기록하셨네요.</string>

--- a/feature/mindrecord/presentation/src/main/res/values/strings.xml
+++ b/feature/mindrecord/presentation/src/main/res/values/strings.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Home tab -->
     <string name="mindrecord_home_tab_memories_section_title">MEMORIES</string>
     <string name="mindrecord_home_tab_memories_section_click_label">기억 공간으로 이동</string>
-
     <string name="mindrecord_total_label">TOTAL</string>
     <string name="mindrecord_record_category_accessibility">%1$s 카테고리, 총 %2$s개</string>
-
     <string name="mindrecord_today_question_header">TODAY\'S QUESTION</string>
     <string name="mindrecord_today_question_answer_cta">데일리질문 답변하기</string>
 
@@ -13,6 +12,144 @@
     <string name="mindrecord_memory_space_title">MEMORY SPACE</string>
     <string name="mindrecord_memory_space_subtitle">마우스를 움직여 공간을 탐색하세요</string>
     <string name="mindrecord_memory_space_back">돌아가기</string>
-
     <string name="mindrecord_read_again">그날의 기록 다시 읽기</string>
+
+    <!-- Common action labels -->
+    <string name="mindrecord_action_register">등록</string>
+    <string name="mindrecord_action_save">저장</string>
+    <string name="mindrecord_action_add">추가</string>
+    <string name="mindrecord_action_cancel">취소</string>
+    <string name="mindrecord_action_delete">삭제</string>
+    <string name="mindrecord_action_rename">이름 수정</string>
+
+    <!-- Mind record category meta (MindRecordCategoryUi) -->
+    <string name="mindrecord_category_daily_question_title">데일리 질문</string>
+    <string name="mindrecord_category_daily_question_description">매일 다른 질문을 남겨 보세요.</string>
+    <string name="mindrecord_category_diary_title">일기</string>
+    <string name="mindrecord_category_diary_description">나의 매일을 기록하세요</string>
+    <string name="mindrecord_category_deep_thought_title">깊은 생각</string>
+    <string name="mindrecord_category_deep_thought_description">오늘의 생각을 남기세요</string>
+    <string name="mindrecord_category_weekly_report_title">주간리포트</string>
+
+    <!-- Home screen -->
+    <string name="mindrecord_home_title">마음의 기록</string>
+
+    <!-- Write screens -->
+    <string name="mindrecord_diary_write_title">일기 기록하기</string>
+    <string name="mindrecord_diary_write_title_placeholder">제목을 입력하세요.</string>
+    <string name="mindrecord_diary_write_mood_label">오늘의 기분</string>
+    <string name="mindrecord_diary_write_add_location">위치 추가</string>
+    <string name="mindrecord_diary_write_add_photo">사진 추가</string>
+
+    <string name="mindrecord_deep_thought_write_title">깊은 생각 기록하기</string>
+    <string name="mindrecord_deep_thought_write_title_label">제목</string>
+    <string name="mindrecord_deep_thought_write_category_label">카테고리</string>
+    <string name="mindrecord_deep_thought_write_default_category">나의 가치관</string>
+
+    <string name="mindrecord_daily_question_write_loading">오늘의 질문을 불러오는 중...</string>
+    <string name="mindrecord_daily_question_write_none">오늘의 질문이 없습니다.</string>
+
+    <!-- Calendar -->
+    <string name="mindrecord_calendar_year_month">%1$d년 %2$d월</string>
+    <string name="mindrecord_calendar_answered_count">%d개의 답변 완료</string>
+    <string name="mindrecord_calendar_day_label_sun">일</string>
+    <string name="mindrecord_calendar_day_label_mon">월</string>
+    <string name="mindrecord_calendar_day_label_tue">화</string>
+    <string name="mindrecord_calendar_day_label_wed">수</string>
+    <string name="mindrecord_calendar_day_label_thu">목</string>
+    <string name="mindrecord_calendar_day_label_fri">금</string>
+    <string name="mindrecord_calendar_day_label_sat">토</string>
+    <string name="mindrecord_calendar_send_date_title">발송 날짜</string>
+
+    <!-- Category management -->
+    <string name="mindrecord_category_setting_title">카테고리 설정하기</string>
+    <string name="mindrecord_category_new_title">새 카테고리 만들기</string>
+    <string name="mindrecord_category_rename_title">카테고리 이름 수정</string>
+    <string name="mindrecord_category_all">전체 카테고리</string>
+    <string name="mindrecord_category_setting_cd">카테고리 설정</string>
+
+    <!-- Daily question -->
+    <string name="mindrecord_daily_question_default_today">오늘 하루,\n무엇이 가장 고마웠나요?</string>
+    <string name="mindrecord_daily_question_default_thanks">오늘 하루, \n누구에게 가장 고마웠나요?</string>
+    <string name="mindrecord_daily_question_go_answer">답변하러가기</string>
+
+    <!-- Weekly report -->
+    <string name="mindrecord_weekly_report_title">주간 리포트</string>
+    <string name="mindrecord_weekly_report_subtitle">이번 주 나의 기록들을 확인해 보세요.</string>
+    <string name="mindrecord_weekly_report_total_record">총 기록</string>
+    <string name="mindrecord_weekly_report_this_week">이번 주</string>
+    <string name="mindrecord_weekly_report_this_month">이번 달</string>
+    <string name="mindrecord_weekly_report_avg_mood_weekly">주간 평균 기분</string>
+    <string name="mindrecord_weekly_report_avg_emotion_weekly">주간 평균 감정</string>
+    <string name="mindrecord_weekly_report_avg_mood_good">😊 좋음</string>
+    <string name="mindrecord_weekly_report_label_format">%1$d월 %2$d주차 리포트</string>
+    <string name="mindrecord_weekly_report_label_fallback">11월 2주차 리포트</string>
+    <string name="mindrecord_weekly_report_user_default_name">박서연</string>
+    <string name="mindrecord_weekly_report_recorded_prefix">이번 주, </string>
+    <string name="mindrecord_weekly_report_recorded_middle">님은 </string>
+    <string name="mindrecord_weekly_report_recorded_suffix">의 마음을 기록하셨네요.</string>
+    <string name="mindrecord_weekly_report_days_format">%d일</string>
+    <string name="mindrecord_weekly_report_summary_preview">이번 주는 차분히 마음을 정리한 한 주였어요.</string>
+
+    <!-- Insight card -->
+    <string name="mindrecord_insight_card_default_body">이번주는 가족과 함께하는 시간을 가장 많이 기록하셨네요. 일상의 소중함을 느끼는 한주였던 것 같아요.</string>
+    <string name="mindrecord_insight_card_footer">매일 꾸준히 기록하는 습관이 정말 멋져요!</string>
+
+    <!-- Emotion keyword card -->
+    <string name="mindrecord_emotion_card_title">나의 감정 키워드</string>
+    <string name="mindrecord_emotion_card_default_description">이번 주 박서연 님의 기록에서는\n\'가족\'을 위한 \'감사\'의 마음이 엿보입니다.</string>
+
+    <!-- Empty state -->
+    <string name="mindrecord_empty_state_title">아직 등록된 답변이 없어요.</string>
+    <string name="mindrecord_empty_state_description">답변을 등록해 자신을 알아 보아요.</string>
+
+    <!-- Daily / DeepThought card -->
+    <string name="mindrecord_daily_deepthought_default_text">생각은 깊이를 더할수록 진실에 가까워진다.</string>
+
+    <!-- Memories card sample question/answer -->
+    <string name="mindrecord_memories_card_question">\"내 인생에서 가장 소중했던 순간은?\"</string>
+    <string name="mindrecord_memories_card_answer">- 아이가 태어났을 때...</string>
+
+    <!-- DeepThought write screen sample categories -->
+    <string name="mindrecord_deep_thought_sample_category_today">오늘 떠올린 생각</string>
+    <string name="mindrecord_deep_thought_sample_category_retrospective">인생을 되돌아 보며</string>
+
+    <!-- Keyboard toolbar -->
+    <string name="mindrecord_toolbar_link_cd">링크</string>
+    <string name="mindrecord_toolbar_align_left_cd">왼쪽 정렬</string>
+    <string name="mindrecord_toolbar_align_center_cd">가운데 정렬</string>
+    <string name="mindrecord_toolbar_align_right_cd">오른쪽 정렬</string>
+    <string name="mindrecord_toolbar_close_cd">닫기</string>
+    <string name="mindrecord_toolbar_draft_count">임시저장 %d</string>
+    <string name="mindrecord_toolbar_text_settings">텍스트 설정</string>
+    <string name="mindrecord_toolbar_style_title">제목</string>
+    <string name="mindrecord_toolbar_style_header">머릿말</string>
+    <string name="mindrecord_toolbar_style_subheader">부머릿말</string>
+    <string name="mindrecord_toolbar_style_body">본문</string>
+
+    <!-- Write text field -->
+    <string name="mindrecord_write_field_placeholder">당신의 오늘을 기록해보세요</string>
+    <string name="mindrecord_write_field_character_count">%d 글자</string>
+
+    <!-- Tags / common -->
+    <string name="mindrecord_tag_all">전체</string>
+    <string name="mindrecord_back_cd">뒤로가기</string>
+    <string name="mindrecord_more_cd">더보기</string>
+
+    <!-- VM/Domain error messages -->
+    <string name="mindrecord_error_generic">알 수 없는 오류가 발생했습니다.</string>
+    <string name="mindrecord_error_daily_question_list_failed">데일리 질문을 불러오지 못했습니다.</string>
+    <string name="mindrecord_error_daily_question_today_failed">오늘의 질문을 불러오지 못했습니다.</string>
+    <string name="mindrecord_error_diary_list_failed">일기를 불러오지 못했습니다.</string>
+    <string name="mindrecord_error_diary_submit_failed">일기 등록에 실패했습니다.</string>
+    <string name="mindrecord_error_deep_thought_list_failed">깊은 생각을 불러오지 못했습니다.</string>
+    <string name="mindrecord_error_deep_thought_submit_failed">깊은 생각 등록에 실패했습니다.</string>
+    <string name="mindrecord_error_daily_question_submit_failed">등록에 실패했습니다.</string>
+    <string name="mindrecord_error_weekly_report_failed">주간 리포트를 불러오지 못했습니다.</string>
+    <string name="mindrecord_error_category_list_failed">카테고리 목록을 불러오지 못했습니다.</string>
+    <string name="mindrecord_error_category_add_failed">카테고리 추가에 실패했습니다.</string>
+    <string name="mindrecord_error_category_update_failed">카테고리 수정에 실패했습니다.</string>
+    <string name="mindrecord_error_category_delete_failed">카테고리 삭제에 실패했습니다.</string>
+    <string name="mindrecord_error_category_name_empty">카테고리 이름이 비어 있습니다.</string>
+    <string name="mindrecord_error_category_name_invalid">카테고리 이름이 올바르지 않습니다.</string>
 </resources>


### PR DESCRIPTION
## Summary
- 위클리 리포트 화면 API 연동 및 과거 주차 드롭다운 추가, 상단 요약에 `/users/me` 응답의 사용자 이름 연동
- 마음의 기록 캘린더 시각 규칙 정비 + 작성일 데이터 연동(일기/딥띵킹)
- DeepThought API 실제 스펙 반영, `DeepThoughtRepository.getList` 반환 타입 정합 수정, Diary 작성일 캘린더 반영
- 하드코딩 문자열 `strings.xml` 이동 + 도메인 레이어 typed exception 도입
- `:feature:mindrecord:presentation` 모듈 ktlintFormat 일괄 적용 및 `onWeekSelected → onWeekSelect` (Compose 현재형 규칙)

closes #253

## Test plan
- [ ] 홈 → 위클리 리포트 진입 시 상단에 로그인한 사용자 이름이 노출되는지 확인
- [ ] 과거 주차 드롭다운에서 다른 주를 선택하면 캘린더/카운트/일기 목록이 해당 주 데이터로 갱신되는지 확인
- [ ] 마음의 기록 캘린더에서 작성된 날짜(일기/딥띵킹)에 점 표시가 정확히 나오는지 확인
- [ ] 딥띵킹 목록/작성 화면이 정상 동작하는지 확인 (API 스펙 반영 검증)
- [ ] `/users/me` 호출 실패 시 위클리 리포트가 에러 상태로 전이되는지 확인
- [ ] `:feature:mindrecord:presentation:ktlintCheck` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)