### PR TITLE
chore(tooling): ADB MCP 서버 (claude-in-mobile) 프로젝트 등록 (#256)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,7 @@
     "mobile": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "claude-in-mobile@latest"]
+      "args": ["-y", "claude-in-mobile@3.8.1"]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "mobile": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "claude-in-mobile@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

closed chore(tooling): ADB MCP 서버 도입 — Claude UI 검증/디버깅 자동화 #256

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

Claude 가 대화 중 에뮬레이터에 직접 접근해 UI 결과 자기검증·logcat 추적이 가능하도록 ADB 기반 MCP 서버([AlexGladkov/claude-in-mobile](https://github.com/AlexGladkov/claude-in-mobile)) 프로젝트 등록.

- `.mcp.json` 신설 — `mcpServers.mobile` 등록, `npx -y claude-in-mobile@latest` 호출 (npx 기반 포터블 — 팀원 머신에서도 동작)
- 사용자 환경 변경(repo 외, 본 PR 범위 밖):
  - `brew install AlexGladkov/claude-in-mobile/claude-in-mobile` (3.8.1)
  - `~/.zshrc` 에 `ANDROID_HOME` + `$ANDROID_HOME/platform-tools` PATH 추가

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

개발 도구 등록이라 앱 시각 결과 없음. 스모크 테스트 결과로 대체:
- `mobile.device(list)` → `emulator-5554 - sdk_gphone64_arm64` 인식
- `mobile.ui(tree, compact)` → Pixel_7 홈 스크린 UI 트리 정상 (afternote-fe 앱 아이콘 포함)
- `mobile.system(logs)` → logcat 실시간 출력 정상

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- **선정 근거 (3개 후보 비교)**: 이슈 #256 본문 표 참조. AlexGladkov/claude-in-mobile 가 1차 검증 시나리오 (스크린샷 → UI 트리 → 텍스트 탭 → logcat) 8개 meta-tool 로 1급 지원. flow_batch 로 "앱 실행 → 화면 N 까지 네비게이션 → 스크린샷" 자동화 가능
- **포터블 설정 의도적**: `.mcp.json` 에 `/opt/homebrew/bin/npx` 같은 머신 고유 경로 박지 않음. `npx` + ANDROID_HOME 셸 환경 의존 → 팀원도 본인 셸에 ANDROID_HOME 설정만 하면 즉시 동작
- **로컬 셋업이 필요한 팀원이 있다면** (현재는 1hyok 만 사용 예상):
  1. `brew tap AlexGladkov/claude-in-mobile https://github.com/AlexGladkov/claude-in-mobile && brew install claude-in-mobile`
  2. `~/.zshrc` 에 `export ANDROID_HOME="$HOME/Library/Android/sdk"` + PATH 추가
  3. `claude-in-mobile doctor` 로 환경 검증
  4. Claude Code 재시작
- **#241 (Paparazzi) 와의 관계**: 보완 관계. Paparazzi 는 CI 시점 정적 시각 회귀 차단, 본 MCP 는 개발 중 Claude 의 자기 코드 1차 동작 검증. 다른 시점·다른 목적
- **보안**: 본 MCP 는 ADB 통해 에뮬레이터·기기 제어 가능. 개발 디바이스에만 적용, prod 디바이스 연결 금지 권장
