### PR TITLE
refactor(core): VideoUploadRepository 신설 — Memorial Video Impl 의 S3 PUT 분리 (#257)

### DIFF
--- a/core/data/src/main/java/com/afternote/core/data/repoimpl/VideoUploadRepositoryImpl.kt
+++ b/core/data/src/main/java/com/afternote/core/data/repoimpl/VideoUploadRepositoryImpl.kt
@@ -1,0 +1,91 @@
+package com.afternote.core.data.repoimpl
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.net.toUri
+import com.afternote.core.common.di.IoDispatcher
+import com.afternote.core.domain.repository.VideoUploadRepository
+import com.afternote.core.network.dto.PresignedUrlRequestDto
+import com.afternote.core.network.model.requireData
+import com.afternote.core.network.service.ImageApiService
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.asRequestBody
+import java.io.File
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+
+/** MIME 타입에서 확장자를 못 뽑았을 때 폴백. 대부분의 안드로이드 영상이 mp4 라 합리적 디폴트. */
+private const val DEFAULT_VIDEO_EXTENSION = "mp4"
+
+class VideoUploadRepositoryImpl
+    @Inject
+    constructor(
+        @param:ApplicationContext private val context: Context,
+        private val imageApi: ImageApiService,
+        @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    ) : VideoUploadRepository {
+        override suspend fun upload(
+            uriString: String,
+            directory: String,
+        ): Result<String> =
+            try {
+                val uri = uriString.toUri()
+                val extension = videoExtensionFromUri(uri)
+
+                val presigned =
+                    imageApi
+                        .getPresignedUrl(
+                            PresignedUrlRequestDto(
+                                directory = directory,
+                                extension = extension,
+                            ),
+                        ).requireData()
+
+                val tempFile =
+                    withContext(ioDispatcher) {
+                        val file = File.createTempFile("video_upload_", ".$extension", context.cacheDir)
+                        context.contentResolver.openInputStream(uri)?.use { input ->
+                            file.outputStream().use { output -> input.copyTo(output) }
+                        } ?: throw IllegalStateException("Could not read video from URI")
+                        file
+                    }
+
+                try {
+                    val contentType = presigned.contentType.ifBlank { "video/$extension" }
+                    val requestBody = tempFile.asRequestBody(contentType.toMediaType())
+
+                    val response =
+                        imageApi.uploadToS3(
+                            url = presigned.presignedUrl,
+                            file = requestBody,
+                            contentType = contentType,
+                        )
+                    check(response.isSuccessful) {
+                        "S3 video upload failed: ${response.code()} ${response.message()}"
+                    }
+
+                    Result.success(presigned.fileUrl)
+                } finally {
+                    tempFile.delete()
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+
+        private fun videoExtensionFromUri(uri: Uri): String {
+            val mime = context.contentResolver.getType(uri) ?: return DEFAULT_VIDEO_EXTENSION
+            return when {
+                mime == "video/mp4" -> "mp4"
+                mime == "video/quicktime" -> "mov"
+                mime.startsWith("video/") ->
+                    mime.removePrefix("video/").takeIf { it.isNotBlank() }
+                        ?: DEFAULT_VIDEO_EXTENSION
+                else -> DEFAULT_VIDEO_EXTENSION
+            }
+        }
+    }

--- a/core/di/src/main/java/com/afternote/core/di/CoreRepositoryModule.kt
+++ b/core/di/src/main/java/com/afternote/core/di/CoreRepositoryModule.kt
@@ -2,10 +2,12 @@ package com.afternote.core.di
 
 import com.afternote.core.data.repoimpl.PhotoUploadRepositoryImpl
 import com.afternote.core.data.repoimpl.UserRepositoryImpl
+import com.afternote.core.data.repoimpl.VideoUploadRepositoryImpl
 import com.afternote.core.data.repoimpl.account.AccountRepositoryImpl
 import com.afternote.core.data.repoimpl.auth.AuthRepositoryImpl
 import com.afternote.core.domain.repository.PhotoUploadRepository
 import com.afternote.core.domain.repository.UserRepository
+import com.afternote.core.domain.repository.VideoUploadRepository
 import com.afternote.core.domain.repository.account.AccountRepository
 import com.afternote.core.domain.repository.auth.AuthRepository
 import dagger.Binds
@@ -24,6 +26,10 @@ interface CoreRepositoryModule {
     @Binds
     @Singleton
     fun bindPhotoUploadRepository(impl: PhotoUploadRepositoryImpl): PhotoUploadRepository
+
+    @Binds
+    @Singleton
+    fun bindVideoUploadRepository(impl: VideoUploadRepositoryImpl): VideoUploadRepository
 
     @Binds
     @Singleton

--- a/core/domain/src/main/java/com/afternote/core/domain/repository/VideoUploadRepository.kt
+++ b/core/domain/src/main/java/com/afternote/core/domain/repository/VideoUploadRepository.kt
@@ -1,0 +1,18 @@
+package com.afternote.core.domain.repository
+
+/**
+ * Core video upload: content URI → presigned URL → S3 PUT → file URL.
+ * Reusable for memorial video, and any other video upload that uses
+ * POST /files/presigned-url and the same S3 flow.
+ */
+fun interface VideoUploadRepository {
+    /**
+     * @param uriString content URI of the selected video (e.g. from gallery / Photo Picker).
+     * @param directory target directory for the file (e.g. "afternotes").
+     * @return Success with video URL (https) or failure.
+     */
+    suspend fun upload(
+        uriString: String,
+        directory: String,
+    ): Result<String>
+}

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/author/MemorialVideoUploadRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/author/MemorialVideoUploadRepositoryImpl.kt
@@ -1,30 +1,12 @@
 package com.afternote.feature.afternote.data.repositoryimpl.author
 
-import android.content.Context
-import android.net.Uri
-import androidx.core.net.toUri
-import com.afternote.core.common.di.IoDispatcher
-import com.afternote.core.network.dto.PresignedUrlRequestDto
-import com.afternote.core.network.model.requireData
-import com.afternote.core.network.service.ImageApiService
+import com.afternote.core.domain.repository.VideoUploadRepository
 import com.afternote.feature.afternote.domain.repository.author.MemorialVideoUploadRepository
 import com.afternote.feature.afternote.domain.repository.author.VideoUploadOutcome
-import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody.Companion.asRequestBody
-import java.io.File
 import javax.inject.Inject
-import javax.inject.Named
 
 /** 서버 S3 의 애프터노트 미디어 폴더명. presigned URL 경로에 박혀 `bucket/afternotes/<file>` 형태가 됨. 서버와 약속된 문자열. */
 private const val DIRECTORY_AFTERNOTES = "afternotes"
-
-/** MIME 타입에서 확장자를 못 뽑았을 때 폴백. 대부분의 안드로이드 영상이 mp4 라 합리적 디폴트. */
-private const val DEFAULT_VIDEO_EXTENSION = "mp4"
 
 /** Android 의 *로컬 파일 URI* 스킴. 갤러리/카메라 picker 결과는 `content://...` 로 시작 → "아직 서버에 없음, 업로드 필요" 의 신호. `https://...` 같은 원격 URL 과 구분하는 용도. */
 private const val LOCAL_CONTENT_SCHEME = "content://"
@@ -33,97 +15,25 @@ private const val LOCAL_CONTENT_SCHEME = "content://"
  * 추모 영상 *상태 해석* + 필요 시 업로드.
  *
  * 입력 String 의 형식을 판별해 sealed 분기로 반환:
- * - 로컬 `content://` URI → presigned PUT 으로 S3 업로드 후 [VideoUploadOutcome.FreshlyUploaded]
+ * - 로컬 `content://` URI → [VideoUploadRepository] 위임 후 [VideoUploadOutcome.FreshlyUploaded]
  * - 원격 HTTPS URL → 입력 그대로 [VideoUploadOutcome.Existing]
  * - null/blank → [VideoUploadOutcome.Empty]
  *
  * `content://` prefix 비교는 *data 레이어 안* 에 격리 — 도메인은 인프라 형식 디테일을 모름.
+ * S3 PUT·MIME 추론·temp 파일 관리는 [VideoUploadRepository] 가 담당. 본 클래스는 분기 라우팅만.
  */
 class MemorialVideoUploadRepositoryImpl
     @Inject
     constructor(
-        @param:ApplicationContext private val context: Context,
-        private val imageApi: ImageApiService,
-        @param:Named("S3Upload") private val okHttpClient: OkHttpClient,
-        @param:IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+        private val videoUploadRepository: VideoUploadRepository,
     ) : MemorialVideoUploadRepository {
         override suspend fun resolveVideo(input: String?): Result<VideoUploadOutcome> {
             if (input.isNullOrBlank()) return Result.success(VideoUploadOutcome.Empty)
             if (!input.startsWith(LOCAL_CONTENT_SCHEME)) {
                 return Result.success(VideoUploadOutcome.Existing(input))
             }
-            return uploadLocalVideo(input).map { VideoUploadOutcome.FreshlyUploaded(it) }
-        }
-
-        private suspend fun uploadLocalVideo(contentUriString: String): Result<String> =
-            runCatching {
-                val uri = contentUriString.toUri()
-                val extension = videoExtensionFromUri(uri)
-                val presigned =
-                    imageApi
-                        .getPresignedUrl(
-                            PresignedUrlRequestDto(
-                                directory = DIRECTORY_AFTERNOTES,
-                                extension = extension,
-                            ),
-                        ).requireData()
-
-                val tempFile =
-                    withContext(ioDispatcher) {
-                        context.contentResolver.openInputStream(uri)?.use { input ->
-                            val file = File.createTempFile("memorial_video_", ".$extension")
-                            file.outputStream().use { output ->
-                                input.copyTo(output)
-                            }
-                            file
-                        } ?: throw IllegalStateException("Could not read video from URI")
-                    }
-
-                try {
-                    val contentType = presigned.contentType.ifBlank { "video/$extension" }
-                    val requestBody = tempFile.asRequestBody(contentType.toMediaType())
-                    val putRequest =
-                        Request
-                            .Builder()
-                            .url(presigned.presignedUrl)
-                            .put(requestBody)
-                            .header("Content-Type", contentType)
-                            .build()
-
-                    withContext(ioDispatcher) {
-                        okHttpClient.newCall(putRequest).execute().use { response ->
-                            check(response.isSuccessful) {
-                                "S3 video upload failed: ${response.code} ${response.message}"
-                            }
-                        }
-                    }
-                    presigned.fileUrl
-                } finally {
-                    if (!tempFile.delete()) {
-                        // Temp file cleanup failed; file may remain until system cleanup
-                    }
-                }
-            }
-
-        private fun videoExtensionFromUri(uri: Uri): String {
-            val mime = context.contentResolver.getType(uri) ?: return DEFAULT_VIDEO_EXTENSION
-            return when {
-                mime == "video/mp4" -> {
-                    "mp4"
-                }
-
-                mime == "video/quicktime" -> {
-                    "mov"
-                }
-
-                mime.startsWith("video/") -> {
-                    mime.removePrefix("video/").takeIf { it.isNotBlank() }
-                        ?: DEFAULT_VIDEO_EXTENSION
-                }
-
-                else -> {
-                    DEFAULT_VIDEO_EXTENSION
-                }
-            }
+            return videoUploadRepository
+                .upload(input, DIRECTORY_AFTERNOTES)
+                .map { VideoUploadOutcome.FreshlyUploaded(it) }
         }
     }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

closed refactor(core): VideoUploadRepository 신설 — Memorial Video Impl 의 S3 PUT 분리 #257

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

`MemorialVideoUploadRepositoryImpl` 에 inline 으로 들어있던 영상 S3 PUT 로직을 `core` 의 공용 `VideoUploadRepository` 로 분리. Photo 패턴([core.domain.PhotoUploadRepository](core/domain/src/main/java/com/afternote/core/domain/repository/PhotoUploadRepository.kt) + [core.data.PhotoUploadRepositoryImpl](core/data/src/main/java/com/afternote/core/data/repoimpl/PhotoUploadRepositoryImpl.kt)) 미러링.

- `core/domain/.../VideoUploadRepository.kt` 신설 — `fun interface`, 시그니처 `upload(uriString, directory): Result<String>` (Photo 와 동일)
- `core/data/.../VideoUploadRepositoryImpl.kt` 신설 — presigned URL flow + temp file + S3 PUT + MIME 추론. 기존 Memorial Video Impl 의 inline 코드 이동
- `core/di/CoreRepositoryModule.kt` 에 `@Binds @Singleton` 바인딩 추가
- `MemorialVideoUploadRepositoryImpl` 축소 — **~125줄 → ~37줄**. Photo Impl 과 동일한 분기 라우터 구조 (sealed Outcome 분기 + core 위임)
- `imageApi.uploadToS3` 통합 호출로 raw `OkHttpClient` (`@Named("S3Upload")`) 의존 제거. NetworkModule 의 provider 자체는 `MemorialThumbnailUploadRepositoryImpl` 와 `ReceiverDeliveryDocumentUploadRepositoryImpl` 가 여전히 사용 중이라 유지

### Repository → Repository 의존의 정당성
`MemorialVideoUploadRepositoryImpl` 가 `VideoUploadRepository` 를 주입받음. 공식 가이드의 *Multiple levels of repositories* 패턴:
> [Android Architecture Guide](https://developer.android.com/topic/architecture/data-layer?hl=ko#multiple-levels-of-repositories): *"a repository might need to depend on other repositories ... because the responsibility needs to be encapsulated in another repository class"*

본 PR 의 분담:
- `MemorialVideoUploadRepository` (feature): 추모 영상 도메인 책임 (분기 + sealed Outcome)
- `VideoUploadRepository` (core): 공용 메커니즘 (S3 업로드 자체)

Photo 도 같은 패턴 (`MemorialPhotoUploadRepositoryImpl` → `PhotoUploadRepository`) 으로 이미 정착됨.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

위치 이동·디자인 동일. 시각 결과 동일.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- **#247 (PR #263) 의 stack PR**: 베이스 `feat/247`. PR #263 머지 후 GitHub 가 자동으로 본 PR 의 베이스를 `develop` 으로 재타겟. 또는 본 PR 도 PR #263 같이 검토하고 PR #263 머지 직후 본 PR 머지하는 흐름
- **mindrecord / timeletter 가 영상 첨부 도입 시** core 의 `VideoUploadRepository` 그대로 재사용 가능 — 본 분리의 직접 효과
- **회귀 검증 필요**: 영상 첨부 → 저장 (POST) / 영상 교체 → 저장 (PATCH) / 영상 미변경 → 저장 (PATCH) 3 케이스. Pixel_7 에뮬레이터로 동작 확인 권장
- **`@Named("S3Upload")` OkHttpClient 잔여 사용처 2건** (`MemorialThumbnailUploadRepositoryImpl`, `ReceiverDeliveryDocumentUploadRepositoryImpl`) — 본 PR 범위 밖. 같은 패턴으로 core 분리 가능하지만 별도 작업
- **본 PR 이 다루지 않는 후속**: 영상 URL 영구성 확인 후 `ResolvedMemorialMediaForSave` 의 PATCH 전용 필드 (`videoUrlForUpdate`, `funeralThumbnailUrlForUpdate`) 제거 검토는 #258 로 분리됨
