### PR TITLE
refactor(afternote): AddSongViewModel 의 Context 주입 제거 — UiText 도입 (#267)

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
 import com.afternote.afternote_fe.screen.HomeTabActions
 import com.afternote.afternote_fe.screen.receiver.ReceiverHomeActions
@@ -14,7 +13,6 @@ import com.afternote.core.ui.bottombar.BottomNavTab
 import com.afternote.feature.afternote.presentation.author.editor.model.EditorCategory
 import com.afternote.feature.afternote.presentation.author.navigation.AfternoteNavActions
 import com.afternote.feature.afternote.presentation.author.navigation.model.AfternoteRoute
-import com.afternote.feature.afternote.presentation.receiver.navigation.ReceiverFlowEntryPoint
 import com.afternote.feature.afternote.presentation.receiver.navigation.ReceiverNavActions
 import com.afternote.feature.afternote.presentation.receiver.navigation.model.ReceiverRoute
 import com.afternote.feature.mindrecord.presentation.navigation.MindRecordNavActions
@@ -25,7 +23,6 @@ import com.afternote.feature.setting.presentation.navigation.SettingNavActions
 import com.afternote.feature.setting.presentation.navigation.SettingRoute
 import com.afternote.feature.timeletter.presentation.navigation.TimeLetterNavActions
 import com.afternote.feature.timeletter.presentation.navigation.TimeLetterRoute
-import dagger.hilt.android.EntryPointAccessors
 
 @Composable
 fun rememberOnboardingNavActions(navController: NavController): OnboardingNavActions =

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/memorial/playlist/AddSongUiState.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/memorial/playlist/AddSongUiState.kt
@@ -1,13 +1,17 @@
 package com.afternote.feature.afternote.presentation.author.editor.memorial.playlist
 
+import com.afternote.core.ui.UiText
 import com.afternote.feature.afternote.presentation.shared.model.PlaylistSongDisplay
 
 /**
  * UI state for Add Song screen (search-driven list from API).
+ *
+ * errorMessage 는 [UiText] 로 들고 있어 ViewModel 이 Context/Resources 에 접근하지 않는다.
+ * Composable 측에서 [com.afternote.core.ui.asString] 으로 변환.
  */
 data class AddSongUiState(
     val songs: List<PlaylistSongDisplay> = emptyList(),
     val searchQuery: String = "",
     val isLoading: Boolean = false,
-    val errorMessage: String? = null,
+    val errorMessage: UiText? = null,
 )

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/memorial/playlist/AddSongViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/memorial/playlist/AddSongViewModel.kt
@@ -1,12 +1,11 @@
 package com.afternote.feature.afternote.presentation.author.editor.memorial.playlist
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.core.ui.UiText
 import com.afternote.feature.afternote.domain.repository.author.MusicSearchRepository
 import com.afternote.feature.afternote.presentation.R
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,7 +21,6 @@ private const val SEARCH_DEBOUNCE_MS = 300L
 class AddSongViewModel
     @Inject
     constructor(
-        @param:ApplicationContext private val appContext: Context,
         private val musicSearchRepository: MusicSearchRepository,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(AddSongUiState())
@@ -66,8 +64,10 @@ class AddSongViewModel
                                     songs = emptyList(),
                                     isLoading = false,
                                     errorMessage =
-                                        e.message
-                                            ?: appContext.getString(R.string.afternote_editor_search_failed_generic),
+                                        UiText.DynamicOrResource(
+                                            value = e.message,
+                                            fallbackResId = R.string.afternote_editor_search_failed_generic,
+                                        ),
                                 )
                             }
                         }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #267

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `AddSongViewModel` 에서 `@param:ApplicationContext Context` 주입 + `appContext.getString(R.string.x)` 호출 제거 — [공식 ViewModel 가이드 Best practices](https://developer.android.com/topic/libraries/architecture/viewmodel) ("ViewModels shouldn't hold any references of lifecycle-related APIs such as the Context or Resources") 준수
- `AddSongUiState.errorMessage` 타입: `String?` → `UiText?`
- 실패 메시지는 `UiText.DynamicOrResource(value = e.message, fallbackResId = R.string.afternote_editor_search_failed_generic)` 로 표현 — `e.message ?: getString(...)` 패턴을 그대로 1:1 대응
- `R.string` 키는 그대로 유지

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
UI 변경 없음 (ViewModel/UiState 타입 정리).

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- **이슈 본문이 권장한 sealed `AddSongError` 별도 도입 안 함.** 그 사이 develop 에 [`UiText`](https://github.com/Afternote/Afternote-FE/blob/develop/core/ui/src/main/kotlin/com/afternote/core/ui/UiText.kt) 가 도입돼 `DynamicOrResource(value, fallbackResId)` 가 이슈 본문의 `SearchFailedWithMessage(message)` / `SearchFailedGeneric` 두 분기를 1:1 으로 대체. 별도 sealed 신설은 동일 추상화 중복이라 회피.
- **표시 UI 미구현 (본 PR 범위 외)**: `AddSongUiState.errorMessage` 가 `AddSongScreen` / `SongPlaylistScreen` 어디서도 표시되지 않음 (시그니처에 errorMessage 인자 없음). 본 PR 은 *Context 안티패턴 정리* + *타입 일관성* 에만 집중. 표시 UI 는 디자인 시안 도착 후 별도 작업 대상.
- **테스트 가능성 개선**: ViewModel 이 Android Framework 의존 0 — Context mock 없이 순수 JVM 테스트 가능해짐.