### PR TITLE
refactor(nav): *NavActions 작명 컨벤션 표준화 + 본인 영역 전수 리네임 (#239)

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
 import com.afternote.afternote_fe.screen.HomeTabActions
 import com.afternote.afternote_fe.screen.receiver.ReceiverHomeActions
@@ -14,7 +13,6 @@ import com.afternote.core.ui.bottombar.BottomNavTab
 import com.afternote.feature.afternote.presentation.author.editor.model.EditorCategory
 import com.afternote.feature.afternote.presentation.author.navigation.AfternoteNavActions
 import com.afternote.feature.afternote.presentation.author.navigation.model.AfternoteRoute
-import com.afternote.feature.afternote.presentation.receiver.navigation.ReceiverFlowEntryPoint
 import com.afternote.feature.afternote.presentation.receiver.navigation.ReceiverNavActions
 import com.afternote.feature.afternote.presentation.receiver.navigation.model.ReceiverRoute
 import com.afternote.feature.mindrecord.presentation.navigation.MindRecordNavActions
@@ -25,84 +23,59 @@ import com.afternote.feature.setting.presentation.navigation.SettingNavActions
 import com.afternote.feature.setting.presentation.navigation.SettingRoute
 import com.afternote.feature.timeletter.presentation.navigation.TimeLetterNavActions
 import com.afternote.feature.timeletter.presentation.navigation.TimeLetterRoute
-import dagger.hilt.android.EntryPointAccessors
 
 @Composable
 fun rememberOnboardingNavActions(navController: NavController): OnboardingNavActions =
     remember(navController) {
         object : OnboardingNavActions {
-            override fun onOnboardingComplete() {
+            override fun replaceOnboardingWithHome() {
                 navController.navigate(Route.Home) {
                     // 온보딩 흐름 전체를 stack 에서 비우고 Home 진입 — 뒤로가기로 온보딩으로 못 돌아가게(앱 종료).
                     popUpTo(0) { inclusive = true }
                 }
             }
 
-            override fun onNavigateWelcomeToSignUp() {
+            override fun navigateToSignUp() {
                 navController.navigate(OnboardingRoute.SignUpRoute)
             }
 
-            override fun onNavigateWelcomeToLogin() {
+            override fun navigateToLogin() {
                 navController.navigate(OnboardingRoute.LoginRoute)
             }
 
-            override fun onNavigateWelcomeToReceivedRecords() {
+            override fun navigateToReceivedRecords() {
                 navController.navigate(Route.Receiver)
             }
 
-            override fun onReplaceLoginWithSignUp() {
+            override fun replaceLoginWithSignUp() {
                 navController.navigate(OnboardingRoute.SignUpRoute) {
                     // Login 화면을 SignUp 으로 교체 — 뒤로가기 시 Login 으로 돌아가지 않고 그 이전(Welcome) 으로.
                     popUpTo<OnboardingRoute.LoginRoute> { inclusive = true }
                 }
             }
 
-            override fun onLoginBack() {
+            override fun popBack() {
                 navController.popBackStack()
             }
 
-            override fun onSignUpEmailNext() {
+            override fun proceedToSignUpResidentNumber() {
                 navController.navigate(OnboardingRoute.SignUpResidentNumberRoute)
             }
 
-            override fun onSignUpEmailBack() {
-                navController.popBackStack()
-            }
-
-            override fun onSignUpResidentNext() {
+            override fun proceedToSignUpPassword() {
                 navController.navigate(OnboardingRoute.SignUpPasswordRoute)
             }
 
-            override fun onSignUpResidentBack() {
-                navController.popBackStack()
-            }
-
-            override fun onSignUpPasswordNext() {
+            override fun proceedToTerms() {
                 navController.navigate(OnboardingRoute.TermsRoute)
             }
 
-            override fun onSignUpPasswordBack() {
-                navController.popBackStack()
-            }
-
-            override fun onTermsNext() {
+            override fun proceedToProfile() {
                 navController.navigate(OnboardingRoute.ProfileRoute)
             }
 
-            override fun onTermsBack() {
-                navController.popBackStack()
-            }
-
-            override fun onViewTerms() {
+            override fun navigateToTermsDetail() {
                 navController.navigate(OnboardingRoute.TermsDetailRoute)
-            }
-
-            override fun onTermsDetailBack() {
-                navController.popBackStack()
-            }
-
-            override fun onProfileBack() {
-                navController.popBackStack()
             }
         }
     }
@@ -358,33 +331,33 @@ fun rememberAfternoteNavActions(
     val onFingerprintErrorState by rememberUpdatedState(onFingerprintAuthError)
     return remember(appState) {
         object : AfternoteNavActions {
-            override fun onBottomNavTabSelected(tab: BottomNavTab) {
+            override fun navigateToBottomTab(tab: BottomNavTab) {
                 appState.navigateToBottomBarRoute(tab.route)
             }
 
-            override fun onPopBackStack() {
+            override fun popBack() {
                 appState.navController.popBackStack()
             }
 
-            override fun onNavigateToAfternoteDetail(itemId: String) {
+            override fun navigateToAfternoteDetail(itemId: String) {
                 appState.navController.navigate(AfternoteRoute.DetailRoute(itemId = itemId))
             }
 
-            override fun onNavigateToGalleryDetail(itemId: String) {
+            override fun navigateToGalleryDetail(itemId: String) {
                 appState.navController.navigate(AfternoteRoute.GalleryDetailRoute(itemId = itemId))
             }
 
-            override fun onNavigateToMemorialGuidelineDetail(itemId: String) {
+            override fun navigateToMemorialGuidelineDetail(itemId: String) {
                 appState.navController.navigate(
                     AfternoteRoute.MemorialGuidelineDetailRoute(itemId = itemId),
                 )
             }
 
-            override fun onNavigateToNewEditor(initialCategory: String?) {
+            override fun navigateToNewEditor(initialCategory: String?) {
                 appState.navController.navigate(AfternoteRoute.EditorRoute(initialCategory = initialCategory))
             }
 
-            override fun onNavigateToEditorForEdit(
+            override fun navigateToEditorForEdit(
                 itemId: String,
                 initialCategory: EditorCategory,
             ) {
@@ -396,15 +369,15 @@ fun rememberAfternoteNavActions(
                 )
             }
 
-            override fun onNavigateToMemorialPlaylist() {
+            override fun navigateToMemorialPlaylist() {
                 appState.navController.navigate(AfternoteRoute.MemorialPlaylistRoute)
             }
 
-            override fun onNavigateToAddSong() {
+            override fun navigateToAddSong() {
                 appState.navController.navigate(AfternoteRoute.AddSongRoute)
             }
 
-            override fun onFingerprintAuthSuccess() {
+            override fun replaceFingerprintLoginWithAfternoteHome() {
                 appState.navController.navigate(AfternoteRoute.AfternoteHomeRoute) {
                     // 지문 로그인 화면 pop — 인증 성공 후 뒤로가기로 다시 입력 요구하는 화면에 못 돌아가게.
                     popUpTo<AfternoteRoute.FingerprintLoginRoute> { inclusive = true }
@@ -412,11 +385,11 @@ fun rememberAfternoteNavActions(
                 }
             }
 
-            override fun onFingerprintAuthError(message: String) {
+            override fun onFingerprintAuthFailed(message: String) {
                 onFingerprintErrorState(message)
             }
 
-            override fun onEditorSaveSuccessNavigateHome() {
+            override fun popToAfternoteHome() {
                 appState.navController.navigate(AfternoteRoute.AfternoteHomeRoute) {
                     // 저장 성공 — Home 위의 화면들(에디터·미디어 선택 등) 만 pop, Home 자체는 유지(inclusive=false).
                     // launchSingleTop 으로 새 Home 인스턴스 생성 대신 기존 Home 위로 복귀.
@@ -439,42 +412,42 @@ fun rememberAfternoteNavActions(
 fun rememberReceiverNavActions(appState: AppState): ReceiverNavActions =
     remember(appState) {
         object : ReceiverNavActions {
-            override fun onPopBackStack() {
+            override fun popBack() {
                 appState.navController.popBackStack()
             }
 
-            override fun onNavigateToAfternoteList() {
+            override fun navigateToAfternoteList() {
                 appState.navController.navigate(ReceiverRoute.AfternoteListRoute)
             }
 
-            override fun onNavigateToReceivedAfternoteDetail(afternoteId: String) {
+            override fun navigateToReceivedAfternoteDetail(afternoteId: String) {
                 appState.navController.navigate(
                     ReceiverRoute.AfternoteDetailRoute(afternoteId = afternoteId),
                 )
             }
 
-            override fun onNavigateToSenderRegistration() {
+            override fun navigateToSenderRegistration() {
                 appState.navController.navigate(ReceiverRoute.SenderRegistrationRoute)
             }
 
-            override fun onNavigateToSenderDetail(senderId: String) {
+            override fun navigateToSenderDetail(senderId: String) {
                 appState.navController.navigate(
                     ReceiverRoute.SenderDetailRoute(senderId = senderId),
                 )
             }
 
-            override fun onRequestVerificationFlow(senderId: String) {
+            override fun navigateToDeliveryVerificationFlow(senderId: String) {
                 // nested 열람 신청 흐름 그래프 진입. 본인 확인 캐시 분기는 IntroRoute 의 LaunchedEffect 가 처리.
                 appState.navController.navigate(
                     ReceiverRoute.DeliveryVerificationFlowRoute(senderId = senderId),
                 )
             }
 
-            override fun onNavigateIdentityIntroToEmail() {
+            override fun navigateToIdentityVerificationEmail() {
                 appState.navController.navigate(ReceiverRoute.IdentityVerificationEmailRoute)
             }
 
-            override fun onIdentityFlowToMasterKey() {
+            override fun proceedToMasterKey() {
                 // 두 진입 경로 (Intro 의 캐시 hit jump / Email 인증 성공) 공통 — Intro 까지 pop 해서
                 // 뒤로가기로 본인 확인 화면들에 돌아오지 않게.
                 appState.navController.navigate(ReceiverRoute.MasterKeyRoute) {
@@ -482,21 +455,21 @@ fun rememberReceiverNavActions(appState: AppState): ReceiverNavActions =
                 }
             }
 
-            override fun onNavigateMasterKeyToDocumentUpload() {
+            override fun proceedToDocumentUpload() {
                 appState.navController.navigate(ReceiverRoute.DocumentUploadRoute) {
                     // 마스터 키 검증 성공 직후 — MasterKey 화면 pop. 뒤로가기로 이미 검증된 마스터 키 재입력 화면에 못 돌아가게.
                     popUpTo<ReceiverRoute.MasterKeyRoute> { inclusive = true }
                 }
             }
 
-            override fun onNavigateDocumentUploadToComplete() {
+            override fun proceedToDeliveryVerificationComplete() {
                 appState.navController.navigate(ReceiverRoute.DeliveryVerificationCompleteRoute) {
                     // 서류 제출 성공 직후 — DocumentUpload pop. 뒤로가기로 제출 끝난 업로드 화면에 못 돌아가게.
                     popUpTo<ReceiverRoute.DocumentUploadRoute> { inclusive = true }
                 }
             }
 
-            override fun onNavigateCompleteToReceivedRecords() {
+            override fun popToReceivedRecords() {
                 // 받은 기록함을 남기고 신청 흐름 화면들(완료/서류/마스터 키)을 모두 pop.
                 appState.navController.navigate(ReceiverRoute.ReceivedRecordsRoute) {
                     popUpTo<ReceiverRoute.ReceivedRecordsRoute> { inclusive = false }
@@ -504,7 +477,7 @@ fun rememberReceiverNavActions(appState: AppState): ReceiverNavActions =
                 }
             }
 
-            override fun onNavigateToReceiverHome() {
+            override fun navigateToReceiverHome() {
                 appState.navController.navigate(ReceiverRoute.HomeRoute)
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 tasks.register<Exec>("installGitHooks") {
     group = "verification"
-    description = "Installs git-hooks/pre-commit into .git/hooks (run once per clone)."
+    description = "Installs git-hooks/{pre-commit,pre-push} into .git/hooks (run once per clone)."
     workingDir(layout.projectDirectory)
     commandLine(
         "sh",
@@ -19,7 +19,9 @@ tasks.register<Exec>("installGitHooks") {
         "if test -d .git/hooks; then " +
             "cp git-hooks/pre-commit .git/hooks/pre-commit && " +
             "chmod +x .git/hooks/pre-commit && " +
-            "echo \"Installed .git/hooks/pre-commit\"; " +
+            "cp git-hooks/pre-push .git/hooks/pre-push && " +
+            "chmod +x .git/hooks/pre-push && " +
+            "echo \"Installed .git/hooks/{pre-commit,pre-push}\"; " +
             "else echo \"installGitHooks: .git/hooks not found, skipping\"; fi",
     )
 }

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/navigation/AfternoteNavActions.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/navigation/AfternoteNavActions.kt
@@ -6,34 +6,44 @@ import com.afternote.feature.afternote.presentation.author.editor.model.EditorCa
 /**
  * NavHost 루트에서 Afternote 서브그래프로 넘기는 네비게이션 명령 모음.
  *
- * [com.afternote.feature.onboarding.presentation.navigation.OnboardingNavActions]와 같은
- * “actions 객체 단일 전달” 패턴으로, 콜백 추가 시 시그니처 확장 없이 인터페이스만 갱신한다.
+ * 작명 컨벤션 (#239): `navigateTo<Where>` / `popBack` / `popTo<Where>` /
+ * `replace<X>With<Y>` / `proceedTo<Next>` / `on<Result>Succeeded|Failed`.
+ *
+ * Screen 콜백 인자(예: `onSongClick`)는 *도메인 이벤트* 자리로 본 인터페이스와 분리.
+ * NavGraph 가 둘을 매핑한다.
  */
 interface AfternoteNavActions {
-    fun onBottomNavTabSelected(tab: BottomNavTab)
+    fun navigateToBottomTab(tab: BottomNavTab)
 
-    fun onPopBackStack()
+    fun popBack()
 
-    fun onNavigateToAfternoteDetail(itemId: String)
+    fun navigateToAfternoteDetail(itemId: String)
 
-    fun onNavigateToGalleryDetail(itemId: String)
+    fun navigateToGalleryDetail(itemId: String)
 
-    fun onNavigateToMemorialGuidelineDetail(itemId: String)
+    fun navigateToMemorialGuidelineDetail(itemId: String)
 
-    fun onNavigateToNewEditor(initialCategory: String?)
+    fun navigateToNewEditor(initialCategory: String?)
 
-    fun onNavigateToEditorForEdit(
+    fun navigateToEditorForEdit(
         itemId: String,
         initialCategory: EditorCategory,
     )
 
-    fun onNavigateToMemorialPlaylist()
+    fun navigateToMemorialPlaylist()
 
-    fun onNavigateToAddSong()
+    fun navigateToAddSong()
 
-    fun onFingerprintAuthSuccess()
+    /** 지문 인증 성공 → Afternote 홈으로 진입하며 지문 로그인 화면 자체를 stack 에서 제거 (replace). */
+    fun replaceFingerprintLoginWithAfternoteHome()
 
-    fun onFingerprintAuthError(message: String)
+    /**
+     * 지문 인증 실패 통지 — *navigate 아닌 결과 알림* 이라 NavActions 자리에 두는 게 어색하지만,
+     * 현재 호출 측이 NavActions 를 통해 Toast 표시를 위임받는 구조라 본 인터페이스에 남겨둠.
+     * 향후 별도 ScreenCallback 으로 분리 (별 작업).
+     */
+    fun onFingerprintAuthFailed(message: String)
 
-    fun onEditorSaveSuccessNavigateHome()
+    /** Editor 저장 성공 → Afternote 홈 위 화면(에디터·미디어 등)만 pop. Home 자체는 유지. */
+    fun popToAfternoteHome()
 }

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/navigation/AfternoteNavGraph.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/navigation/AfternoteNavGraph.kt
@@ -36,28 +36,28 @@ fun NavGraphBuilder.afternoteNavGraph(
     navigation<Route.Afternote>(startDestination = AfternoteRoute.FingerprintLoginRoute) {
         afternoteComposable<AfternoteRoute.AfternoteHomeRoute> {
             AfternoteHomeNavigation(
-                onNavigateToDetail = actions::onNavigateToAfternoteDetail,
-                onNavigateToGalleryDetail = actions::onNavigateToGalleryDetail,
-                onNavigateToMemorialGuidelineDetail = actions::onNavigateToMemorialGuidelineDetail,
-                onNavigateToNewEditor = actions::onNavigateToNewEditor,
+                onNavigateToDetail = actions::navigateToAfternoteDetail,
+                onNavigateToGalleryDetail = actions::navigateToGalleryDetail,
+                onNavigateToMemorialGuidelineDetail = actions::navigateToMemorialGuidelineDetail,
+                onNavigateToNewEditor = actions::navigateToNewEditor,
             )
         }
 
         afternoteComposable<AfternoteRoute.DetailRoute> {
             AfternoteDetailNavigation(
                 backStackEntry = it,
-                onBack = actions::onPopBackStack,
+                onBack = actions::popBack,
                 onNavigateToEditor = { itemId ->
-                    actions.onNavigateToEditorForEdit(itemId, EditorCategory.SOCIAL)
+                    actions.navigateToEditorForEdit(itemId, EditorCategory.SOCIAL)
                 },
             )
         }
 
         afternoteComposable<AfternoteRoute.GalleryDetailRoute> { _ ->
             AfternoteGalleryDetailNavigation(
-                onBack = actions::onPopBackStack,
+                onBack = actions::popBack,
                 onNavigateToEditor = { itemId ->
-                    actions.onNavigateToEditorForEdit(itemId, EditorCategory.GALLERY)
+                    actions.navigateToEditorForEdit(itemId, EditorCategory.GALLERY)
                 },
             )
         }
@@ -72,19 +72,19 @@ fun NavGraphBuilder.afternoteNavGraph(
                     onReplaceSongs = hostViewModel::replaceSongs,
                     onClearSongs = hostViewModel::clearAllSongs,
                     onNavigateToSelectReceiver = {}, // TODO: 수신인 선택 화면 라우팅 연결
-                    onBottomNavTabSelected = actions::onBottomNavTabSelected,
-                    onPopBackStack = actions::onPopBackStack,
-                    onNavigateToMemorialPlaylist = actions::onNavigateToMemorialPlaylist,
-                    onSaveSuccessNavigateHome = actions::onEditorSaveSuccessNavigateHome,
+                    onBottomNavTabSelected = actions::navigateToBottomTab,
+                    onPopBackStack = actions::popBack,
+                    onNavigateToMemorialPlaylist = actions::navigateToMemorialPlaylist,
+                    onSaveSuccessNavigateHome = actions::popToAfternoteHome,
                 ),
             )
         }
 
         afternoteComposable<AfternoteRoute.MemorialGuidelineDetailRoute> { _ ->
             AfternoteMemorialGuidelineDetailNavigation(
-                onBack = actions::onPopBackStack,
+                onBack = actions::popBack,
                 onNavigateToEditor = { itemId ->
-                    actions.onNavigateToEditorForEdit(itemId, EditorCategory.MEMORIAL)
+                    actions.navigateToEditorForEdit(itemId, EditorCategory.MEMORIAL)
                 },
             )
         }
@@ -96,8 +96,8 @@ fun NavGraphBuilder.afternoteNavGraph(
                 songs = graphSongs,
                 actions =
                     MemorialPlaylistEntryActions(
-                        onBackClick = actions::onPopBackStack,
-                        onNavigateToAddSongScreen = actions::onNavigateToAddSong,
+                        onBackClick = actions::popBack,
+                        onNavigateToAddSongScreen = actions::navigateToAddSong,
                         onClearAllSongs = hostViewModel::clearAllSongs,
                         onRemoveSongs = hostViewModel::removeSongs,
                     ),
@@ -109,8 +109,8 @@ fun NavGraphBuilder.afternoteNavGraph(
             val isPasskeyRegistered by hostViewModel.isPasskeyRegistered.collectAsStateWithLifecycle()
             AfternoteFingerprintLoginNavigation(
                 isPasskeyRegistered = isPasskeyRegistered,
-                onAuthenticationSuccess = actions::onFingerprintAuthSuccess,
-                onShowError = actions::onFingerprintAuthError,
+                onAuthenticationSuccess = actions::replaceFingerprintLoginWithAfternoteHome,
+                onShowError = actions::onFingerprintAuthFailed,
             )
         }
 
@@ -118,7 +118,7 @@ fun NavGraphBuilder.afternoteNavGraph(
             val hostViewModel = graphScopedHostViewModel(graphScopedParentEntry)
             val addSongViewModel: AddSongViewModel = hiltViewModel()
             AfternoteAddSongNavigation(
-                onPopBackStack = actions::onPopBackStack,
+                onPopBackStack = actions::popBack,
                 onSongsAdded = hostViewModel::addSongs,
                 viewModel = addSongViewModel,
             )

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/navigation/ReceiverNavActions.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/navigation/ReceiverNavActions.kt
@@ -6,61 +6,52 @@ package com.afternote.feature.afternote.presentation.receiver.navigation
  * 다른 top-level Route(MindRecord/TimeLetter/Setting 등)로의 이동은 수신자 홈 측에서
  * 별도 `ReceiverHomeActions`로 받는다 — 본 인터페이스는 [com.afternote.core.ui.Route.Receiver]
  * 그래프 내부에서만 의미가 있는 이동만 다룬다.
+ *
+ * 작명 컨벤션 (#239): `navigateTo<Where>` / `popBack` / `popTo<Where>` /
+ * `replace<X>With<Y>` / `proceedTo<Next>`.
  */
 interface ReceiverNavActions {
-    fun onPopBackStack()
+    fun popBack()
 
-    fun onNavigateToAfternoteList()
+    fun navigateToAfternoteList()
 
-    fun onNavigateToReceivedAfternoteDetail(afternoteId: String)
+    fun navigateToReceivedAfternoteDetail(afternoteId: String)
 
-    /**
-     * 받은 기록함의 FAB → 발신자 등록 화면(이슈 #215, 디자인 15·16) 진입.
-     */
-    fun onNavigateToSenderRegistration()
+    /** 받은 기록함의 FAB → 발신자 등록 화면(이슈 #215, 디자인 15·16) 진입. */
+    fun navigateToSenderRegistration()
 
-    /**
-     * 받은 기록함 카드 클릭 → 발신자 상세(11·12) 진입.
-     */
-    fun onNavigateToSenderDetail(senderId: String)
+    /** 받은 기록함 카드 클릭 → 발신자 상세(11·12) 진입. */
+    fun navigateToSenderDetail(senderId: String)
 
     /**
-     * 발신자 상세의 "열람 신청하기" 진입 — nested 열람 신청 흐름 그래프
+     * 발신자 상세의 "열람 신청하기" → nested 열람 신청 흐름 그래프
      * ([com.afternote.feature.afternote.presentation.receiver.navigation.model.ReceiverRoute.DeliveryVerificationFlowRoute])
-     * 진입점. 본인 확인 캐시 분기는 흐름 내부(IntroRoute 의 LaunchedEffect) 에서 자동 처리되므로 호출자는
+     * 진입. 본인 확인 캐시 분기는 흐름 내부(IntroRoute 의 LaunchedEffect) 에서 자동 처리되므로 호출자는
      * senderId 만 전달.
      */
-    fun onRequestVerificationFlow(senderId: String)
+    fun navigateToDeliveryVerificationFlow(senderId: String)
 
-    /**
-     * 본인 확인 안내(2) 의 "인증 시작하기" → 이메일 인증 화면(3·4) 진입.
-     */
-    fun onNavigateIdentityIntroToEmail()
+    /** 본인 확인 안내(2) 의 "인증 시작하기" → 이메일 인증 화면(3·4) 진입. */
+    fun navigateToIdentityVerificationEmail()
 
     /**
      * 본인 확인 흐름 (Intro 의 캐시 hit jump 또는 Email 인증 성공) → 마스터 키(5) 진입.
      * Intro 까지의 본인 확인 화면들은 pop (사용자가 뒤로가기로 안내·인증을 다시 보지 않도록).
      */
-    fun onIdentityFlowToMasterKey()
+    fun proceedToMasterKey()
 
-    /**
-     * 마스터 키 검증 성공 → 증빙 서류 업로드(6·7·8) 진입. 마스터 키 화면은 pop 한다.
-     */
-    fun onNavigateMasterKeyToDocumentUpload()
+    /** 마스터 키 검증 성공 → 증빙 서류 업로드(6·7·8) 진입. 마스터 키 화면은 pop 한다. */
+    fun proceedToDocumentUpload()
 
-    /**
-     * 서류 업로드 + `submitDeliveryVerification` 성공 → 완료(9) 진입. 서류 화면은 pop 한다.
-     */
-    fun onNavigateDocumentUploadToComplete()
+    /** 서류 업로드 + `submitDeliveryVerification` 성공 → 완료(9) 진입. 서류 화면은 pop 한다. */
+    fun proceedToDeliveryVerificationComplete()
 
-    /**
-     * 완료(9)의 "받은 기록함으로 돌아가기" → 받은 기록함까지 pop.
-     */
-    fun onNavigateCompleteToReceivedRecords()
+    /** 완료(9)의 "받은 기록함으로 돌아가기" → 받은 기록함까지 pop. */
+    fun popToReceivedRecords()
 
     /**
      * 발신자 상세(12)의 "기록 열람하기" → 수신자 홈 진입. 발신자 컨텍스트(authCode) 복원은
      * `SenderDetailViewModel.openReceiverHome` 이 담당하므로 본 액션은 순수 네비게이션만 수행한다.
      */
-    fun onNavigateToReceiverHome()
+    fun navigateToReceiverHome()
 }

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/navigation/ReceiverNavGraph.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/navigation/ReceiverNavGraph.kt
@@ -57,26 +57,26 @@ fun NavGraphBuilder.receiverNavGraph(
     navigation<Route.Receiver>(startDestination = ReceiverRoute.ReceivedRecordsRoute) {
         receiverComposable<ReceiverRoute.ReceivedRecordsRoute> {
             ReceivedRecordsScreen(
-                onBackClick = actions::onPopBackStack,
-                onAddSenderClick = actions::onNavigateToSenderRegistration,
-                onSenderClick = { sender -> actions.onNavigateToSenderDetail(sender.id) },
+                onBackClick = actions::popBack,
+                onAddSenderClick = actions::navigateToSenderRegistration,
+                onSenderClick = { sender -> actions.navigateToSenderDetail(sender.id) },
             )
         }
 
         receiverComposable<ReceiverRoute.SenderRegistrationRoute> {
             SenderRegistrationScreen(
-                onBackClick = actions::onPopBackStack,
+                onBackClick = actions::popBack,
                 // 등록 완료 시 받은 기록함으로 pop. 카드는 자동으로 반영된다 (SenderRegistry StateFlow).
-                onRegistered = actions::onPopBackStack,
+                onRegistered = actions::popBack,
             )
         }
 
         receiverComposable<ReceiverRoute.SenderDetailRoute> { backStackEntry ->
             val senderId = backStackEntry.toRoute<ReceiverRoute.SenderDetailRoute>().senderId
             SenderDetailScreen(
-                onBackClick = actions::onPopBackStack,
-                onRequestVerification = { actions.onRequestVerificationFlow(senderId) },
-                onOpenReceiverHome = actions::onNavigateToReceiverHome,
+                onBackClick = actions::popBack,
+                onRequestVerification = { actions.navigateToDeliveryVerificationFlow(senderId) },
+                onOpenReceiverHome = actions::navigateToReceiverHome,
             )
         }
 
@@ -95,20 +95,20 @@ fun NavGraphBuilder.receiverNavGraph(
                 // popUpTo 들도 모두 inclusive 라 흐름 중 Intro 가 다시 등장하지 않는다.
                 if (isVerified) {
                     LaunchedEffect(Unit) {
-                        actions.onIdentityFlowToMasterKey()
+                        actions.proceedToMasterKey()
                     }
                 } else {
                     IdentityVerificationIntroScreen(
-                        onBackClick = actions::onPopBackStack,
-                        onStartClick = actions::onNavigateIdentityIntroToEmail,
+                        onBackClick = actions::popBack,
+                        onStartClick = actions::navigateToIdentityVerificationEmail,
                     )
                 }
             }
 
             receiverComposable<ReceiverRoute.IdentityVerificationEmailRoute> {
                 IdentityVerificationEmailScreen(
-                    onBackClick = actions::onPopBackStack,
-                    onVerified = actions::onIdentityFlowToMasterKey,
+                    onBackClick = actions::popBack,
+                    onVerified = actions::proceedToMasterKey,
                 )
             }
 
@@ -116,21 +116,21 @@ fun NavGraphBuilder.receiverNavGraph(
                 val flowVm = backStackEntry.deliveryFlowViewModel(deliveryFlowParentEntry)
                 MasterKeyScreen(
                     senderId = flowVm.senderId,
-                    onBackClick = actions::onPopBackStack,
-                    onVerified = actions::onNavigateMasterKeyToDocumentUpload,
+                    onBackClick = actions::popBack,
+                    onVerified = actions::proceedToDocumentUpload,
                 )
             }
 
             receiverComposable<ReceiverRoute.DocumentUploadRoute> {
                 DocumentUploadScreen(
-                    onBackClick = actions::onPopBackStack,
-                    onSubmitted = actions::onNavigateDocumentUploadToComplete,
+                    onBackClick = actions::popBack,
+                    onSubmitted = actions::proceedToDeliveryVerificationComplete,
                 )
             }
 
             receiverComposable<ReceiverRoute.DeliveryVerificationCompleteRoute> {
                 DeliveryVerificationCompleteScreen(
-                    onBackToRecords = actions::onNavigateCompleteToReceivedRecords,
+                    onBackToRecords = actions::popToReceivedRecords,
                 )
             }
         }
@@ -143,13 +143,13 @@ fun NavGraphBuilder.receiverNavGraph(
             ReceiverAfternoteHomeEntry(
                 actions =
                     ReceiverAfternoteHomeEntryActions(
-                        navigateToDetail = actions::onNavigateToReceivedAfternoteDetail,
+                        navigateToDetail = actions::navigateToReceivedAfternoteDetail,
                     ),
             )
         }
 
         receiverComposable<ReceiverRoute.AfternoteDetailRoute> {
-            ReceivedAfternoteDetailRoute(onBack = actions::onPopBackStack)
+            ReceivedAfternoteDetailRoute(onBack = actions::popBack)
         }
     }
 }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavActions.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavActions.kt
@@ -1,46 +1,40 @@
 package com.afternote.feature.onboarding.presentation.navigation
 
 /**
- * 온보딩 그래프로 전달되는 네비게이션 이벤트 묶음.
+ * 온보딩 그래프로 전달되는 네비게이션 명령 모음.
  *
- * [onboardingNavGraph]의 파라미터 비대화를 줄이고, 앱 루트에서 `remember`로 안정적으로 묶기 위함이다.
+ * 작명 컨벤션 (#239):
+ * - `navigateTo<Where>` — 단순 navigate
+ * - `popBack` / `popTo<Where>` — pop 동작
+ * - `replace<X>With<Y>` — popUpTo + navigate (replace)
+ * - `proceedTo<Next>` — 회원가입 같은 흐름 내부 stepping
+ *
+ * Screen 콜백 인자는 `on<도메인 이벤트>` 자리라 본 인터페이스와 별 책임. NavGraph 가 둘을 매핑한다.
  */
 interface OnboardingNavActions {
-    fun onOnboardingComplete()
+    /** 회원가입/로그인 성공 → Onboarding 그래프 전체 비우고 Home 진입 (replace). */
+    fun replaceOnboardingWithHome()
 
-    fun onNavigateWelcomeToSignUp()
+    fun navigateToSignUp()
 
-    fun onNavigateWelcomeToLogin()
+    fun navigateToLogin()
 
-    /**
-     * Welcome 의 "전달 받은 기록 확인하기" 누름 → 수신자 흐름 진입 (받은 기록함, 이슈 #215).
-     * 본인 확인 캐시 상태와 무관하게 받은 기록함으로 직행하며, 본인 확인은 발신자별 열람 신청 시점에 1회 수행.
-     */
-    fun onNavigateWelcomeToReceivedRecords()
+    /** Welcome 의 "전달 받은 기록 확인하기" → 수신자 흐름 (받은 기록함) 진입. */
+    fun navigateToReceivedRecords()
 
-    fun onReplaceLoginWithSignUp()
+    /** Login → SignUp 으로 화면 교체 (뒤로가기 시 Login 으로 돌아가지 않도록). */
+    fun replaceLoginWithSignUp()
 
-    fun onLoginBack()
+    /** 화면 단위 동작이 동일한 단순 뒤로가기 — 호출 화면별로 분기할 필요 없을 때 공통 사용. */
+    fun popBack()
 
-    fun onSignUpEmailNext()
+    fun proceedToSignUpResidentNumber()
 
-    fun onSignUpEmailBack()
+    fun proceedToSignUpPassword()
 
-    fun onSignUpResidentNext()
+    fun proceedToTerms()
 
-    fun onSignUpResidentBack()
+    fun proceedToProfile()
 
-    fun onSignUpPasswordNext()
-
-    fun onSignUpPasswordBack()
-
-    fun onTermsNext()
-
-    fun onTermsBack()
-
-    fun onViewTerms()
-
-    fun onTermsDetailBack()
-
-    fun onProfileBack()
+    fun navigateToTermsDetail()
 }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
@@ -40,18 +40,18 @@ fun NavGraphBuilder.onboardingNavGraph(
         // ── Welcome ──
         composable<OnboardingRoute.WelcomeRoute> {
             WelcomeScreen(
-                onStartClick = actions::onNavigateWelcomeToSignUp,
-                onCheckRecordsClick = actions::onNavigateWelcomeToReceivedRecords,
-                onLoginClick = actions::onNavigateWelcomeToLogin,
+                onStartClick = actions::navigateToSignUp,
+                onCheckRecordsClick = actions::navigateToReceivedRecords,
+                onLoginClick = actions::navigateToLogin,
             )
         }
 
         // ── Login ──
         composable<OnboardingRoute.LoginRoute> {
             LoginEntry(
-                onLoginSuccess = actions::onOnboardingComplete,
-                onSignUpClick = actions::onReplaceLoginWithSignUp,
-                onBackClick = actions::onLoginBack,
+                onLoginSuccess = actions::replaceOnboardingWithHome,
+                onSignUpClick = actions::replaceLoginWithSignUp,
+                onBackClick = actions::popBack,
             )
         }
 
@@ -61,7 +61,7 @@ fun NavGraphBuilder.onboardingNavGraph(
             val snackbarHostState =
                 rememberSignUpEventHost(
                     viewModel = signUpViewModel,
-                    onNavigateToResidentNumber = actions::onSignUpEmailNext,
+                    onNavigateToResidentNumber = actions::proceedToSignUpResidentNumber,
                 )
 
             SignUpScreen(
@@ -77,7 +77,7 @@ fun NavGraphBuilder.onboardingNavGraph(
                 onVerificationCodeChange = signUpViewModel::updateVerificationCode,
                 onRequestVerification = signUpViewModel::requestVerification,
                 onNextClick = signUpViewModel::verifyEmailAndProceed,
-                onBackClick = actions::onSignUpEmailBack,
+                onBackClick = actions::popBack,
             )
         }
 
@@ -93,8 +93,8 @@ fun NavGraphBuilder.onboardingNavGraph(
                 snackbarHostState = snackbarHostState,
                 onFrontNumberChange = signUpViewModel::updateResidentFrontNumber,
                 onBackNumberChange = signUpViewModel::updateResidentBackNumber,
-                onNextClick = actions::onSignUpResidentNext,
-                onBackClick = actions::onSignUpResidentBack,
+                onNextClick = actions::proceedToSignUpPassword,
+                onBackClick = actions::popBack,
             )
         }
 
@@ -111,8 +111,8 @@ fun NavGraphBuilder.onboardingNavGraph(
                 snackbarHostState = snackbarHostState,
                 onPasswordChange = signUpViewModel::updateSignUpPassword,
                 onPasswordConfirmChange = signUpViewModel::updateSignUpPasswordConfirm,
-                onNextClick = actions::onSignUpPasswordNext,
-                onBackClick = actions::onSignUpPasswordBack,
+                onNextClick = actions::proceedToTerms,
+                onBackClick = actions::popBack,
             )
         }
 
@@ -129,9 +129,9 @@ fun NavGraphBuilder.onboardingNavGraph(
                 onPrivacyToggle = signUpViewModel::togglePrivacyAgreed,
                 onMarketingToggle = signUpViewModel::toggleMarketingAgreed,
                 onToggleAll = signUpViewModel::toggleAllTerms,
-                onViewTermsClick = { _ -> actions.onViewTerms() },
-                onNextClick = actions::onTermsNext,
-                onBackClick = actions::onTermsBack,
+                onViewTermsClick = { _ -> actions.navigateToTermsDetail() },
+                onNextClick = actions::proceedToProfile,
+                onBackClick = actions::popBack,
             )
         }
 
@@ -139,8 +139,8 @@ fun NavGraphBuilder.onboardingNavGraph(
         composable<OnboardingRoute.TermsDetailRoute> {
             TermsDetailScreen(
                 title = "",
-                onBackClick = actions::onTermsDetailBack,
-                onNextClick = actions::onTermsDetailBack,
+                onBackClick = actions::popBack,
+                onNextClick = actions::popBack,
             )
         }
 
@@ -150,8 +150,8 @@ fun NavGraphBuilder.onboardingNavGraph(
 
             OnboardingProfileEntry(
                 viewModel = signUpViewModel,
-                onOnboardingComplete = actions::onOnboardingComplete,
-                onBackClick = actions::onProfileBack,
+                onOnboardingComplete = actions::replaceOnboardingWithHome,
+                onBackClick = actions::popBack,
             )
         }
     }

--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Afternote-FE: pre-push hook.
+# Install once: ./gradlew installGitHooks
+#
+# Push 직전에 :app:compileDebugKotlin 한 번 돌려서 CI 의 Android Lint job
+# (= 내부적으로 compileDebugKotlin → lint 순으로 돈다) 이 컴파일 단계에서
+# 깨지는 케이스를 사전 차단한다. Lint 본체는 비싸므로 CI 에 위임.
+#
+# Bypass: git push --no-verify
+
+set -e
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT" || exit 1
+
+# Delete-only push (e.g. git push origin --delete branch) 는 검증 스킵.
+# stdin 포맷: "<local_ref> <local_oid> <remote_ref> <remote_oid>" 줄들.
+# local_oid 가 zero 면 delete.
+ZERO="0000000000000000000000000000000000000000"
+has_real_push=0
+while read -r local_ref local_oid remote_ref remote_oid; do
+    [ -z "$local_oid" ] && continue
+    [ "$local_oid" = "$ZERO" ] && continue
+    has_real_push=1
+done
+[ "$has_real_push" = "0" ] && exit 0
+
+echo "[pre-push] :app:compileDebugKotlin 검증..."
+if ! ./gradlew --console=plain :app:compileDebugKotlin; then
+    echo
+    echo "[pre-push] 컴파일 실패 → push 차단."
+    echo "[pre-push] 우회가 꼭 필요하면: git push --no-verify"
+    exit 1
+fi


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #239

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `*NavActions` 인터페이스 작명 컨벤션 정립 + 본인 영역 전수 리네임. 각 NavActions KDoc 에 컨벤션 명시.
- **컨벤션**:
  - `navigateTo<Where>` — 단순 navigate
  - `popBack` / `popTo<Where>` — pop 동작
  - `replace<X>With<Y>` — popUpTo + navigate (replace)
  - `proceedTo<Next>` — 회원가입·열람 신청 같은 *흐름 내부 stepping*
  - `on<Result>Succeeded` / `on<Result>Failed` — 결과 알림 (navigate 와 분리)
- **본인 영역 3 인터페이스 리네임**:
  - `OnboardingNavActions` — 15→11 메서드. `onXxxBack` 들을 `popBack` 한 자리로 통합 (동작 동일). `onOnboardingComplete` → `replaceOnboardingWithHome`. `onSignUpEmailNext` 등 → `proceedToSignUpResidentNumber` 등.
  - `AfternoteNavActions` — 12 메서드. `onNavigateToXxx` → `navigateToXxx`. `onFingerprintAuthSuccess` → `replaceFingerprintLoginWithAfternoteHome`. `onEditorSaveSuccessNavigateHome` → `popToAfternoteHome`. `onFingerprintAuthError` → `onFingerprintAuthFailed`.
  - `ReceiverNavActions` — 12 메서드. `onIdentityFlowToMasterKey` → `proceedToMasterKey`. `onNavigateMasterKeyToDocumentUpload` → `proceedToDocumentUpload`. `onNavigateDocumentUploadToComplete` → `proceedToDeliveryVerificationComplete`. `onNavigateCompleteToReceivedRecords` → `popToReceivedRecords`. `onRequestVerificationFlow` → `navigateToDeliveryVerificationFlow`.
- `AppNavigationActions.kt` 의 본인 영역 구현체 (`rememberOnboardingNavActions`/`rememberAfternoteNavActions`/`rememberReceiverNavActions`) + 호출처 (3 NavGraph) reference 일괄 갱신.
- Dangling `ReceiverFlowEntryPoint` import (develop 머지 시점부터 남아있던 unused) 정리.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
동작 무변경 — 시그니처·이름만 정리.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- **다른 owner 영역 NavActions 미포함**: `MindRecordNavActions`(이준혁), `TimeLetterNavActions`(kyungmin), `SettingNavActions` 는 각 owner 영역이라 본 PR 손대지 않음. KDoc 에 컨벤션이 명시되어 있으니 각 owner 가 본인 영역 일관 적용 시 참고 가능.
- **Screen 콜백 Actions 미포함**: `HomeTabActions`, `ReceiverHomeActions` 등은 *Screen callback 인자* 자리라 NavActions 와 책임 분리 (이슈 본문 분석 결과). 콜백 자리 컨벤션 `on<도메인 이벤트>` 적용은 별 작업 (해당 화면 자연스러운 작업 시 점진).
- **`onFingerprintAuthFailed(message)`** 는 navigate 아닌 결과 알림이라 NavActions 자리에 두는 게 어색. 향후 ScreenCallback 으로 분리 후보 — 본 PR 범위 외.
- `popBack` 통합 — Onboarding 의 각 화면별 `onXxxBack` 들이 모두 `navController.popBackStack()` 동작 동일이라 한 메서드로 합침. 향후 특정 화면의 back 동작이 달라지면 (예: confirm dialog) 그때 별도 메서드 분기.