### PR TITLE
feat(onboarding): 회원가입 이메일 인증번호 만료 카운트다운 UI (#154)

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
 import com.afternote.afternote_fe.screen.HomeTabActions
 import com.afternote.afternote_fe.screen.receiver.ReceiverHomeActions
@@ -14,7 +13,6 @@ import com.afternote.core.ui.bottombar.BottomNavTab
 import com.afternote.feature.afternote.presentation.author.editor.model.EditorCategory
 import com.afternote.feature.afternote.presentation.author.navigation.AfternoteNavActions
 import com.afternote.feature.afternote.presentation.author.navigation.model.AfternoteRoute
-import com.afternote.feature.afternote.presentation.receiver.navigation.ReceiverFlowEntryPoint
 import com.afternote.feature.afternote.presentation.receiver.navigation.ReceiverNavActions
 import com.afternote.feature.afternote.presentation.receiver.navigation.model.ReceiverRoute
 import com.afternote.feature.mindrecord.presentation.navigation.MindRecordNavActions
@@ -25,7 +23,6 @@ import com.afternote.feature.setting.presentation.navigation.SettingNavActions
 import com.afternote.feature.setting.presentation.navigation.SettingRoute
 import com.afternote.feature.timeletter.presentation.navigation.TimeLetterNavActions
 import com.afternote.feature.timeletter.presentation.navigation.TimeLetterRoute
-import dagger.hilt.android.EntryPointAccessors
 
 @Composable
 fun rememberOnboardingNavActions(navController: NavController): OnboardingNavActions =

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
@@ -71,6 +71,7 @@ fun NavGraphBuilder.onboardingNavGraph(
                 isSendingCode = signUpViewModel.isSendingCode,
                 isEmailFormatValid = signUpViewModel.isEmailFormatValid,
                 resendCooldownSeconds = signUpViewModel.resendCooldownSeconds,
+                verificationRemainingSeconds = signUpViewModel.verificationRemainingSeconds,
                 isNextEnabled = signUpViewModel.isStep1NextEnabled,
                 snackbarHostState = snackbarHostState,
                 onEmailChange = signUpViewModel::updateEmail,

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpScreen.kt
@@ -26,6 +26,8 @@ import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.onboarding.presentation.R
 
+private const val SECONDS_PER_MINUTE = 60
+
 @Composable
 fun SignUpScreen(
     initialEmail: String,
@@ -34,6 +36,7 @@ fun SignUpScreen(
     isSendingCode: Boolean,
     isEmailFormatValid: Boolean,
     resendCooldownSeconds: Int,
+    verificationRemainingSeconds: Int,
     isNextEnabled: Boolean,
     snackbarHostState: SnackbarHostState,
     onEmailChange: (String) -> Unit,
@@ -119,10 +122,21 @@ fun SignUpScreen(
                     },
                 )
 
-                // 인증번호 전송 안내 메시지
+                // 인증번호 전송 안내 — 발송 직후 남은 시간 카운트다운, 만료 시 다시 받기 안내.
                 if (isVerificationSent) {
+                    val isExpired = verificationRemainingSeconds == 0
+                    val message =
+                        if (isExpired) {
+                            stringResource(R.string.signup_verification_expired)
+                        } else {
+                            stringResource(
+                                R.string.signup_verification_sent_with_timer,
+                                verificationRemainingSeconds / SECONDS_PER_MINUTE,
+                                verificationRemainingSeconds % SECONDS_PER_MINUTE,
+                            )
+                        }
                     Text(
-                        text = stringResource(R.string.signup_verification_sent),
+                        text = message,
                         style = AfternoteDesign.typography.captionLargeB,
                         color = AfternoteDesign.colors.b1,
                     )
@@ -143,6 +157,30 @@ private fun SignUpScreenPreview() {
             isSendingCode = false,
             isEmailFormatValid = false,
             resendCooldownSeconds = 0,
+            verificationRemainingSeconds = 172,
+            isNextEnabled = false,
+            snackbarHostState = remember { SnackbarHostState() },
+            onEmailChange = {},
+            onVerificationCodeChange = {},
+            onRequestVerification = {},
+            onNextClick = {},
+            onBackClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "인증번호 만료")
+@Composable
+private fun SignUpScreenExpiredPreview() {
+    AfternoteTheme {
+        SignUpScreen(
+            initialEmail = "user@example.com",
+            initialVerificationCode = "",
+            isVerificationSent = true,
+            isSendingCode = false,
+            isEmailFormatValid = true,
+            resendCooldownSeconds = 0,
+            verificationRemainingSeconds = 0,
             isNextEnabled = false,
             snackbarHostState = remember { SnackbarHostState() },
             onEmailChange = {},

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
@@ -13,6 +13,7 @@ import com.afternote.core.domain.repository.account.AccountRepository
 import com.afternote.core.domain.usecase.auth.LoginType
 import com.afternote.core.domain.usecase.auth.LoginUseCase
 import com.afternote.feature.onboarding.presentation.signup.SignUpViewModel.Companion.RESEND_COOLDOWN_SECONDS
+import com.afternote.feature.onboarding.presentation.signup.SignUpViewModel.Companion.VERIFICATION_CODE_TTL_SECONDS
 import com.afternote.feature.onboarding.presentation.terms.TermsState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -54,6 +55,12 @@ class SignUpViewModel
 
             /** "재전송" 클릭 후 다음 요청까지 강제 대기 초. 서버 비용·SMS 발송량 보호. */
             private const val RESEND_COOLDOWN_SECONDS = 30
+
+            /**
+             * 인증번호 만료까지 남은 초. 백엔드 [EmailService.java](https://github.com/Afternote/Afternote-BE/blob/main/src/main/java/com/afternote/domain/auth/service/EmailService.java)
+             * 의 Redis TTL 과 일치 (`set(..., 3, TimeUnit.MINUTES)`). 메일 본문도 "3분 안에 입력해주세요" 안내.
+             */
+            private const val VERIFICATION_CODE_TTL_SECONDS = 180
 
             /** 8~16자, 영문 대소문자 + 숫자 + 특수문자 각 1개 이상. */
             private val PASSWORD_REGEX =
@@ -132,6 +139,15 @@ class SignUpViewModel
 
         private var cooldownJob: Job? = null
 
+        /**
+         * 발송된 인증번호의 만료까지 남은 초. 발송 직후 [VERIFICATION_CODE_TTL_SECONDS] 부터 1초 틱으로
+         * 감소. 0 이면 만료 — 백엔드 Redis TTL 만료로 verify 호출도 거절된다.
+         */
+        var verificationRemainingSeconds by mutableIntStateOf(0)
+            private set
+
+        private var expiryJob: Job? = null
+
         // Step 4: 약관 동의
         var termsState by mutableStateOf(TermsState())
             private set
@@ -192,6 +208,7 @@ class SignUpViewModel
                     .onSuccess {
                         isVerificationSent = true
                         startResendCooldown()
+                        startExpiryCountdown()
                     }.onFailure { error ->
                         eventChannel.send(
                             SignUpEvent.ShowError(error.message),
@@ -210,6 +227,22 @@ class SignUpViewModel
                     while (resendCooldownSeconds > 0) {
                         delay(1000)
                         resendCooldownSeconds -= 1
+                    }
+                }
+        }
+
+        /**
+         * 인증번호 발송 성공 직후 호출. [VERIFICATION_CODE_TTL_SECONDS] 부터 1초 틱으로 감소.
+         * 재전송 시 이전 카운트다운은 취소되고 새로 시작 — 마지막 발송 시점 기준 TTL.
+         */
+        private fun startExpiryCountdown() {
+            expiryJob?.cancel()
+            expiryJob =
+                viewModelScope.launch {
+                    verificationRemainingSeconds = VERIFICATION_CODE_TTL_SECONDS
+                    while (verificationRemainingSeconds > 0) {
+                        delay(1000)
+                        verificationRemainingSeconds -= 1
                     }
                 }
         }

--- a/feature/onboarding/presentation/src/main/res/values/strings.xml
+++ b/feature/onboarding/presentation/src/main/res/values/strings.xml
@@ -32,6 +32,8 @@
     <string name="signup_password_placeholder">비밀번호</string>
     <string name="signup_verification_code_placeholder">인증번호</string>
     <string name="signup_verification_sent">인증번호가 전송되었습니다.\n수신 된 인증번호를 입력해 주세요.</string>
+    <string name="signup_verification_sent_with_timer">인증번호가 전송되었습니다. 남은 시간 %1$d:%2$02d</string>
+    <string name="signup_verification_expired">인증번호가 만료되었어요. 다시 받기를 눌러주세요.</string>
     <string name="signup_verification_request">인증번호 받기</string>
     <string name="signup_verification_requesting">전송 중…</string>
     <string name="signup_verification_resend">재전송</string>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #154

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `SignUpViewModel` 에 인증번호 만료 카운트다운 추가:
  - `VERIFICATION_CODE_TTL_SECONDS = 180` 상수 — 백엔드 [EmailService.java:69](https://github.com/Afternote/Afternote-BE/blob/main/src/main/java/com/afternote/domain/auth/service/EmailService.java#L69) 의 Redis TTL `set(..., 3, TimeUnit.MINUTES)` 과 일치
  - `verificationRemainingSeconds` 1초 틱 코루틴 (`startExpiryCountdown`) — `requestVerification().onSuccess` 시점에 시작, 재요청 시 이전 job 취소 후 새로 시작
- `SignUpScreen` 의 안내 메시지 분기:
  - 발송 직후 ~ 만료 전 : `"인증번호가 전송되었습니다. 남은 시간 m:ss"`
  - 만료 (`remainingSeconds == 0`) : `"인증번호가 만료되었어요. 다시 받기를 눌러주세요."`
  - "인증번호 받기" 버튼은 재전송 쿨다운 종료 후 active — 사용자가 만료 안내 보고 다시 받기 가능
- Preview 2개 추가 (카운트다운 / 만료)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
Preview 로 확인 가능 (만료 시점 시각 안내 + 다시 받기 유도).

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- **백엔드 정책 검증 결과 (Afternote-BE EmailService.java 직접 확인)**:
  | 항목 | 값 | 출처 |
  |---|---|---|
  | TTL | **3분** (Redis SET, `TimeUnit.MINUTES`) | `EmailService.java:69` |
  | 만료 응답 | HTTP 400, code **1207** `INVALID_EMAIL_VERIFICATION` | `ErrorCode.java:75` |
  | 만료 vs 오답 구분 | **구분 X** — 둘 다 동일 에러 (Redis TTL 자동 삭제 = key null + 코드 mismatch 같은 false) | `EmailService.java:78-83` |
  | 재전송 쿨다운 | 백엔드 **10초** | `EmailService.java:23` |
  | 시간당 한도 | **5회/1시간** | `EmailService.java:25` |
- **만료 vs 오답 구분 없음** → 클라가 *남은 시간으로 만료 추정*. UX 상 자연 (만료된 코드 vs 오타 모두 "다시 받기" 안내가 답).
- **클라 `RESEND_COOLDOWN_SECONDS = 30` vs 백엔드 10초 불일치 — 본 PR 유지**. 클라 UX 보호 의도 (재전송 연타 방지 + SMS 발송량). 통일 결정은 별 작업.

### 본 PR 범위 외 (To Reviewers 누적 — 다음 자연스러운 SignUp 작업 PR 에 묻기)
- `android.util.Patterns.EMAIL_ADDRESS` → pure Kotlin Regex (ViewModel 안티패턴, JVM 단위 테스트 가능성 회복)
- `android.net.Uri` 보유 → `String?` 또는 도메인 모델 (ViewModel 안티패턴)
- `mutableStateOf` 노출 → `StateFlow` (CLAUDE.md 표준 — 이미 #228 점진 정리 우산)
- `Channel<SignUpEvent>` → UI state 흡수 (#228 점진 정리 우산)
- `verifyEmailAndProceed` 에서 만료 상태 가드 (현재는 백엔드 400 응답 받고 에러 메시지 표시 — 카운트다운 0 일 때 호출 자체 차단 고려)

### 컴파일 위해 본 PR 에 포함된 변경
- `AppNavigationActions.kt` 의 dangling `ReceiverFlowEntryPoint` import 제거 — [PR #270](https://github.com/Afternote/Afternote-FE/pull/270) 에 동일 변경 있음. develop 머지 안 된 상태라 본 PR 컴파일 위해 같이 포함. 둘 중 먼저 머지되는 쪽이 develop 정리, 다른 PR 자동 머지.