### PR TITLE
refactor(afternote): MasterKey sealed Event → UI state 흡수 (#228 분할 1/9) (#277)

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
 import com.afternote.afternote_fe.screen.HomeTabActions
 import com.afternote.afternote_fe.screen.receiver.ReceiverHomeActions
@@ -14,7 +13,6 @@ import com.afternote.core.ui.bottombar.BottomNavTab
 import com.afternote.feature.afternote.presentation.author.editor.model.EditorCategory
 import com.afternote.feature.afternote.presentation.author.navigation.AfternoteNavActions
 import com.afternote.feature.afternote.presentation.author.navigation.model.AfternoteRoute
-import com.afternote.feature.afternote.presentation.receiver.navigation.ReceiverFlowEntryPoint
 import com.afternote.feature.afternote.presentation.receiver.navigation.ReceiverNavActions
 import com.afternote.feature.afternote.presentation.receiver.navigation.model.ReceiverRoute
 import com.afternote.feature.mindrecord.presentation.navigation.MindRecordNavActions
@@ -25,7 +23,6 @@ import com.afternote.feature.setting.presentation.navigation.SettingNavActions
 import com.afternote.feature.setting.presentation.navigation.SettingRoute
 import com.afternote.feature.timeletter.presentation.navigation.TimeLetterNavActions
 import com.afternote.feature.timeletter.presentation.navigation.TimeLetterRoute
-import dagger.hilt.android.EntryPointAccessors
 
 @Composable
 fun rememberOnboardingNavActions(navController: NavController): OnboardingNavActions =

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/MasterKeyScreen.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/MasterKeyScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.AfternoteTextField
-import com.afternote.core.ui.ObserveAsEvents
 import com.afternote.core.ui.scaffold.FlowStepScaffold
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
@@ -47,9 +46,10 @@ fun MasterKeyScreen(
     val authCodeState = rememberTextFieldState()
     val snackbarHostState = remember { SnackbarHostState() }
 
-    ObserveAsEvents(viewModel.events) { event ->
-        when (event) {
-            MasterKeyEvent.Verified -> onVerified()
+    LaunchedEffect(uiState.isVerified) {
+        if (uiState.isVerified) {
+            onVerified()
+            viewModel.onVerifiedConsumed()
         }
     }
 

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/MasterKeyUiState.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/MasterKeyUiState.kt
@@ -6,8 +6,5 @@ import androidx.compose.runtime.Immutable
 data class MasterKeyUiState(
     val isSubmitting: Boolean = false,
     val errorMessageRes: Int? = null,
+    val isVerified: Boolean = false,
 )
-
-sealed interface MasterKeyEvent {
-    data object Verified : MasterKeyEvent
-}

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/MasterKeyViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/MasterKeyViewModel.kt
@@ -7,12 +7,9 @@ import com.afternote.feature.afternote.domain.repository.receiver.ReceiverReposi
 import com.afternote.feature.afternote.presentation.R
 import com.afternote.feature.afternote.presentation.receiver.recordsbox.SenderRegistry
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -24,9 +21,10 @@ import javax.inject.Inject
  * 1) [ReceiverRepository.saveAuthCode] 로 글로벌 헤더 컨텍스트에 저장 (이후 서류 업로드·신청 제출 API 가
  *    동일 발신자 컨텍스트로 호출되도록).
  * 2) [SenderRegistry.attachIdentity] 로 카드에 authCode + ReceiverIdentity 결합.
- * 3) [MasterKeyEvent.Verified] 이벤트 발행 → UI 가 다음 단계(서류 업로드) 로 이동.
+ * 3) [MasterKeyUiState.isVerified] 를 true 로 갱신 → UI 가 다음 단계(서류 업로드) 로 이동 후
+ *    [onVerifiedConsumed] 로 소비 처리.
  *
- * `MasterKeyEvent.Verified` 직후 본 ViewModel 인스턴스는 화면 pop 과 함께 사라지므로, 후속 화면은
+ * 검증 성공 직후 본 ViewModel 인스턴스는 화면 pop 과 함께 사라지므로, 후속 화면은
  * SenderRegistry 의 갱신된 SenderEntry 를 참조해 컨텍스트를 잇는다.
  *
  * `senderId` 는 자체 SavedStateHandle 이 아니라 parent backStackEntry 의
@@ -46,9 +44,6 @@ class MasterKeyViewModel
         private val _uiState = MutableStateFlow(MasterKeyUiState())
         val uiState: StateFlow<MasterKeyUiState> = _uiState.asStateFlow()
 
-        private val _events = Channel<MasterKeyEvent>(Channel.BUFFERED)
-        val events: Flow<MasterKeyEvent> = _events.receiveAsFlow()
-
         fun submit(
             senderId: String,
             authCode: String,
@@ -63,8 +58,7 @@ class MasterKeyViewModel
                     .onSuccess { identity ->
                         receiverRepository.saveAuthCode(trimmed)
                         senderRegistry.attachIdentity(senderId, trimmed, identity)
-                        _uiState.update { it.copy(isSubmitting = false) }
-                        _events.send(MasterKeyEvent.Verified)
+                        _uiState.update { it.copy(isSubmitting = false, isVerified = true) }
                     }.onFailure {
                         _uiState.update {
                             it.copy(
@@ -78,5 +72,9 @@ class MasterKeyViewModel
 
         fun consumeError() {
             _uiState.update { it.copy(errorMessageRes = null) }
+        }
+
+        fun onVerifiedConsumed() {
+            _uiState.update { it.copy(isVerified = false) }
         }
     }


### PR DESCRIPTION
*📌Issues*

- Closes #277
- Part of #228 (전수 9개 VM `sealed *Event` → UI state 흡수 마이그레이션 중 1/9)

*📎Work Description*

- `MasterKeyUiState.kt`: `MasterKeyEvent` sealed interface 제거, `isVerified: Boolean = false` 필드 추가
- `MasterKeyViewModel.kt`: `Channel<MasterKeyEvent>` + `receiveAsFlow()` + `_events` 멤버 및 관련 import (`kotlinx.coroutines.channels.Channel`, `flow.Flow`, `flow.receiveAsFlow`) 제거. `verify(authCode)` 성공 분기를 `_uiState.update { it.copy(isSubmitting = false, isVerified = true) }` 로 통합. `onVerifiedConsumed()` 콜백 신설
- `MasterKeyScreen.kt`: `ObserveAsEvents(viewModel.events)` 블록 + `com.afternote.core.ui.ObserveAsEvents` import 제거. `LaunchedEffect(uiState.isVerified) { if (uiState.isVerified) { onVerified(); viewModel.onVerifiedConsumed() } }` 로 대체
- (부수) `AppNavigationActions.kt`: 미사용 import 3건 (`LocalContext`, `ReceiverFlowEntryPoint`, `EntryPointAccessors`) 제거

*📷Screenshot*

- 시각 변경 없음 — 검증 성공 후 네비게이션 흐름 동일, 내부 신호 전달 메커니즘만 Channel → State 흡수로 전환

*💬To Reviewers*

- Google 공식 가이드 ["ViewModel events should always result in a UI state update"](https://developer.android.com/topic/architecture/ui-layer/events#handle-viewmodel-events) 적용. `Channel` 은 producer(VM) 가 consumer(UI) 보다 오래 살 때 delivery 보장 X → configuration change · process death · 분할 화면 일관성 결함을 회피
- 본 PR 의 패턴 (sealed Event 제거 + `UiState.isXxx` 흡수 + `onXxxConsumed()` 콜백) 이 #228 후속 8개 VM 분할의 **표준 템플릿**. `MasterKeyEvent` 가 단일 케이스(`Verified`) 라 9개 중 가장 단순해서 첫 분할 대상으로 선정
- `MasterKeyViewModel.consumeError()` 는 본 분할 범위 외라 그대로 유지 — 후속 작업에서 `onErrorConsumed()` 류로 네이밍 통일 검토 가능
