### PR TITLE
chore(ci): 모든 모듈 Android Lint 결과를 Reviewdog 인라인에 노출 (#279)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,6 +61,27 @@ jobs:
           KAKAO_NATIVE_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
           GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
 
+      # 모듈별 lint XML 을 한 파일로 합쳐 Reviewdog 가 :feature/* · :core/* 위반도
+      # PR 인라인 코멘트로 띄우도록 한다. 이전엔 :app XML 한 개만 전달돼 다른 모듈 위반이
+      # Actions step 로그(수만 줄)에 묻혔다.
+      - name: Merge module lint XMLs into one
+        if: always()
+        run: |
+          set -e
+          out=app/build/reports/lint-results-merged.xml
+          mkdir -p app/build/reports
+          {
+            echo '<?xml version="1.0" encoding="UTF-8"?>'
+            echo '<issues format="6" by="lint" client="gradle" type="baseline" name="merged">'
+            find . -path '*/build/reports/lint-results-debug.xml' -print | while read -r xml; do
+              xmllint --xpath '//issue' "$xml" 2>/dev/null || true
+            done
+            echo '</issues>'
+          } > "$out"
+          modules=$(find . -path '*/build/reports/lint-results-debug.xml' | wc -l)
+          issues=$(grep -c '<issue ' "$out" || echo 0)
+          echo "merged $issues issues from $modules modules → $out"
+
       - name: Report Android Lint (Reviewdog)
         if: always()
         uses: dvdandroid/action-android-lint@master
@@ -68,4 +89,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           level: warning
-          lint_xml_file: app/build/reports/lint-results-debug.xml
+          lint_xml_file: app/build/reports/lint-results-merged.xml

--- a/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
 import com.afternote.afternote_fe.screen.HomeTabActions
 import com.afternote.afternote_fe.screen.receiver.ReceiverHomeActions
@@ -14,7 +13,6 @@ import com.afternote.core.ui.bottombar.BottomNavTab
 import com.afternote.feature.afternote.presentation.author.editor.model.EditorCategory
 import com.afternote.feature.afternote.presentation.author.navigation.AfternoteNavActions
 import com.afternote.feature.afternote.presentation.author.navigation.model.AfternoteRoute
-import com.afternote.feature.afternote.presentation.receiver.navigation.ReceiverFlowEntryPoint
 import com.afternote.feature.afternote.presentation.receiver.navigation.ReceiverNavActions
 import com.afternote.feature.afternote.presentation.receiver.navigation.model.ReceiverRoute
 import com.afternote.feature.mindrecord.presentation.navigation.MindRecordNavActions
@@ -25,7 +23,6 @@ import com.afternote.feature.setting.presentation.navigation.SettingNavActions
 import com.afternote.feature.setting.presentation.navigation.SettingRoute
 import com.afternote.feature.timeletter.presentation.navigation.TimeLetterNavActions
 import com.afternote.feature.timeletter.presentation.navigation.TimeLetterRoute
-import dagger.hilt.android.EntryPointAccessors
 
 @Composable
 fun rememberOnboardingNavActions(navController: NavController): OnboardingNavActions =


### PR DESCRIPTION
*📌Issues*

- Closes #279

*📎Work Description*

- `.github/workflows/lint.yml` 의 `Run Android Lint` step 직후에 **모듈 lint XML merge step** 추가. `find . -path '*/build/reports/lint-results-debug.xml'` + `xmllint --xpath '//issue'` 로 모든 모듈 issue 를 단일 `app/build/reports/lint-results-merged.xml` 로 모음
- `Report Android Lint (Reviewdog)` step 의 `lint_xml_file` 을 `app/build/reports/lint-results-debug.xml` (→ `:app` 단일) 에서 `app/build/reports/lint-results-merged.xml` (→ 전 모듈) 로 교체

*📷Screenshot*

- 시각 변경 없음 — CI 워크플로우만 변경

*💬To Reviewers*

- **변경 전 한계**: Reviewdog 가 `:app` lint XML 만 인라인 코멘트로 띄움 → `:feature/*` · `:core/*` 모듈 lint 위반은 Actions step 로그 (수만 줄) 에 묻혀 PR Files / Conversation 탭에 안 보였음. 사용자가 `Run Android Lint` step 로그를 직접 Ctrl+F 해야 위치 추적 가능
- **변경 후 기대**: 모든 모듈 위반이 PR Files 탭 인라인 + Actions Annotations 에 노출됨
- **검증 방법**: 본 PR push 시 CI Reviewdog 가 develop 의 기존 `:feature/*` lint warning (예: `feature/mindrecord/.../WriteTextField.kt:72:63 Elvis operator always returns the left operand`, `feature/setting/.../DeviceAlarmOffSection.kt:28:9 Divider deprecated → HorizontalDivider`, `feature/setting/.../viewmodel/*.kt annotation target` 등) 을 인라인 코멘트로 띄우면 동작 OK
- **fallback 가능성**: `dvdandroid/action-android-lint@master` 가 합친 XML 받아 정상 파싱하는지가 핵심. 만약 `OSError: Invalid file specified` 또는 `reviewdog: parse error: EOF` 같은 실패가 뜨면 옵션 B (reviewdog 바이너리 직접 + `-efm` 수동 errorformat) 로 follow-up 필요. 이슈 #279 에 두 옵션 비교 있음
- 옵션 A 채택 사유: yaml 변경 최소(~12줄), 기존 `dvdandroid` action 재사용
- chore(ci) 영역, `:app:compileDebugKotlin` 빌드 영향 없음
