### PR TITLE
build: release signing + Firebase App Distribution 도입 (#286)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,14 +46,24 @@ jobs:
         env:
           KAKAO_NATIVE_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
           GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
+          GOOGLE_SERVICES_JSON_B64: ${{ secrets.GOOGLE_SERVICES_JSON_B64 }}
         run: |
           missing=""
           [ -z "$KAKAO_NATIVE_APP_KEY" ] && missing="$missing KAKAO_NATIVE_APP_KEY"
           [ -z "$GOOGLE_WEB_CLIENT_ID" ] && missing="$missing GOOGLE_WEB_CLIENT_ID"
+          [ -z "$GOOGLE_SERVICES_JSON_B64" ] && missing="$missing GOOGLE_SERVICES_JSON_B64"
           if [ -n "$missing" ]; then
             echo "::error::필수 secret 누락:$missing — Settings → Secrets and variables → Actions 에 등록"
             exit 1
           fi
+
+      # google-services plugin 이 app/google-services.json 을 요구. 파일은 .gitignore 라
+      # CI 환경엔 없음. base64 인코딩된 secret 으로 받아서 decode.
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES_JSON_B64: ${{ secrets.GOOGLE_SERVICES_JSON_B64 }}
+        run: |
+          echo "$GOOGLE_SERVICES_JSON_B64" | base64 -d > app/google-services.json
 
       - name: Run Android Lint
         run: ./gradlew lintDebug --continue --parallel

--- a/README.md
+++ b/README.md
@@ -32,6 +32,60 @@ GOOGLE_WEB_CLIENT_ID=<구글 OAuth web client id>.apps.googleusercontent.com
 - `AndroidManifest.xml` 의 `android:scheme="kakao${KAKAO_NATIVE_APP_KEY}"` 가 빈 scheme 으로 등록 → 카카오 로그인 콜백 intent-filter 매칭 안 됨
 - `requestGoogleIdToken(serverClientId = "")` → Credential Manager 가 invalid request 로 실패
 
+# 📦 비개발자 APK 배포 (Firebase App Distribution)
+
+디자이너·PM·QA·외부 베타테스터에게 release APK 를 자동 배포하는 흐름. Firebase 프로젝트 `afternote-b4d3c` + 테스터 그룹 `afternote` 사용.
+
+## 셋업 (1hyok 만 1회 — 신규 인계자도 동일)
+
+1. **Release keystore 생성** (분실 시 앱 업데이트 영구 불가 → 1Password / iCloud 등 2곳 이상 백업 필수)
+
+    ```bash
+    keytool -genkeypair -v \
+      -keystore ~/afternote-release.jks \
+      -keyalg RSA -keysize 4096 -validity 10000 \
+      -alias afternote-release
+    ```
+
+2. **`local.properties` 끝에 4개 키 추가** (signing config 가 읽음)
+
+    ```properties
+    RELEASE_STORE_FILE=/Users/<you>/afternote-release.jks
+    RELEASE_STORE_PASSWORD=<keystore 비밀번호>
+    RELEASE_KEY_ALIAS=afternote-release
+    RELEASE_KEY_PASSWORD=<key 비밀번호>
+    ```
+
+3. **`google-services.json` 배치** — Firebase Console → 프로젝트 설정 → 일반 → Android 앱 `com.afternote.afternote_fe` 카드에서 다운로드 → `app/google-services.json`
+
+4. **Firebase CLI 설치 + 인증** (자동 업로드용)
+
+    ```bash
+    npm install -g firebase-tools
+    firebase login
+    ```
+
+5. **콘솔에 신규 keystore SHA 등록** (배포 받은 사람의 카카오/구글 로그인 동작 위해)
+   - Release SHA-1 추출: `keytool -list -v -keystore ~/afternote-release.jks -alias afternote-release | grep SHA1`
+   - 카카오 키 해시 추출: `keytool -exportcert -alias afternote-release -keystore ~/afternote-release.jks | openssl sha1 -binary | openssl base64`
+   - **Kakao Developers** → 앱 → 플랫폼 키 → Android → 키 해시 추가
+   - **Firebase Console** → 프로젝트 설정 → Android 앱 → SHA 인증서 지문 추가
+
+## 배포 (매 회)
+
+```bash
+./gradlew assembleRelease appDistributionUploadRelease
+```
+
+→ APK 빌드 + Firebase 업로드 + 테스터 그룹 `afternote` 전원에게 자동 이메일 발송.
+
+> 같은 `versionCode` 로 재업로드하면 기존 release 갱신. 새 release 만들려면 `app/build.gradle.kts` 의 `versionCode` 증가.
+
+## 테스터 관리
+
+- 추가/제거: Firebase Console → App Distribution → 테스터 및 그룹 → `afternote` 그룹 편집
+- 신규 테스터는 첫 초대 이메일에서 **App Tester** 앱 설치 안내를 받음 → 이후 빌드는 자동 알림
+
 # 💻 코딩 컨벤션
 
 > **네이밍 컨벤션**

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,11 @@
+import com.google.firebase.appdistribution.gradle.firebaseAppDistribution
 import java.util.Properties
 
 plugins {
     id("afternote.android.application")
     id("afternote.android.navigation")
+    alias(libs.plugins.google.services)
+    alias(libs.plugins.firebase.app.distribution)
 }
 
 val localProperties = Properties()
@@ -32,6 +35,18 @@ android {
         manifestPlaceholders["KAKAO_NATIVE_APP_KEY"] = kakaoKey
     }
 
+    signingConfigs {
+        create("release") {
+            val releaseStoreFile = localProperties.getProperty("RELEASE_STORE_FILE")
+            if (releaseStoreFile != null) {
+                storeFile = file(releaseStoreFile)
+                storePassword = localProperties.getProperty("RELEASE_STORE_PASSWORD")
+                keyAlias = localProperties.getProperty("RELEASE_KEY_ALIAS")
+                keyPassword = localProperties.getProperty("RELEASE_KEY_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = true
@@ -40,6 +55,11 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+            signingConfig = signingConfigs.getByName("release")
+            firebaseAppDistribution {
+                groups = "afternote"
+                releaseNotes = "Release build for internal distribution"
+            }
         }
     }
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,26 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Room — RoomDatabase 서브클래스가 reflection 으로 인스턴스화될 때
+# Class.canonicalName 매칭이 필요해서 obfuscate 되면 안 됨.
+-keep class * extends androidx.room.RoomDatabase
+-keep class * extends androidx.room.RoomDatabase { *; }
+-keep @androidx.room.Database class *
+-keep @androidx.room.Entity class *
+-keep @androidx.room.Dao interface *
+
+# androidx.work — WorkDatabase 가 Room 기반이고 InitializationProvider 가 부팅 시 인스턴스화.
+-keep class androidx.work.impl.WorkDatabase
+-keep class androidx.work.impl.WorkDatabase_Impl
+-keep class androidx.work.impl.** { *; }
+
+# androidx.startup — Initializer reflection 기반 호출.
+-keep class androidx.startup.InitializationProvider { *; }
+-keep class * extends androidx.startup.Initializer
+
+# Kakao SDK — AccessTokenInterceptor 가 ClientErrorCause.TokenNotFound 등
+# enum entry 를 Class.getField 로 접근. SDK 의 consumer-rules 가 enum 까지
+# 보호하지 않아 NoSuchFieldException 발생.
+-keep class com.kakao.sdk.**.model.** { *; }
+-keep enum com.kakao.sdk.** { *; }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
     alias(libs.plugins.hilt.android) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.firebase.app.distribution) apply false
 }
 
 tasks.register<Exec>("installGitHooks") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,8 @@ navigationCommonKtx = "2.9.7"
 runtime = "1.10.6"
 composeRichEditor = "1.0.0-rc13"
 paging = "3.5.0"
+googleServices = "4.4.4"
+firebaseAppDistribution = "5.2.1"
 
 [libraries]
 androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "biometric" }
@@ -113,3 +115,5 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ktlint-gradle = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradle" }
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+firebase-app-distribution = { id = "com.google.firebase.appdistribution", version.ref = "firebaseAppDistribution" }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #286

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `signingConfigs.release` 추가, keystore 비밀번호는 `local.properties` 의 `RELEASE_*` 4개 키로 분리 (gitignored)
- `com.google.gms.google-services` 4.4.4 + `com.google.firebase.appdistribution` 5.2.1 plugin 도입
- `firebaseAppDistribution { groups = "afternote", releaseNotes = ... }` 설정 — `./gradlew appDistributionUploadRelease` 한 줄로 자동 빌드+업로드+테스터 메일 발송
- R8 minify 의 obfuscation 으로 release 빌드가 깨지는 케이스 두 가지 해결:
  - Room/WorkManager: `WorkDatabase.canonicalName` reflection 보호
  - Kakao SDK: `ClientErrorCause.TokenNotFound` 등 enum entry 보호 (`AccessTokenInterceptor` 가 `Class.getField` 로 접근)
- README 의 "🚀 신규 팀원 빌드 셋업" 다음에 "📦 비개발자 APK 배포" 섹션 신설 — release keystore 생성, local.properties 키 4개, Firebase CLI 셋업, 배포 명령, 테스터 관리

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
| 검증 항목 | 결과 |
|---|---|
| `./gradlew assembleDebug` | ✅ |
| `./gradlew assembleRelease` (서명 SHA-1 매칭) | ✅ |
| 에뮬레이터에 release APK 직접 설치 후 카카오 로그인 | ✅ |
| 에뮬레이터에 release APK 직접 설치 후 구글 로그인 | ✅ |
| `./gradlew appDistributionUploadRelease` 자동 업로드 | ✅ |
| 테스터 3명 (`afternote` 그룹) 자동 메일 발송 | ✅ |

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 콘솔 작업 (Kakao Developers, Google Cloud Console, Firebase Console) 은 1hyok 가 본 PR 작업 중 직접 처리. release SHA-1 / 키 해시 등록, 옛 동아리 시절 패키지명 (`com.kuit.afternote`) → `com.afternote.afternote_fe` 정정 포함
- release keystore 자체는 1hyok 머신에 보관 + 별도 백업 (분실 시 앱 업데이트 영구 불가). 신규 인계자는 README 의 "📦 비개발자 APK 배포 > 셋업" 따라 본인 keystore 새로 발급 후 콘솔에 SHA 추가
- *팀원 git pull 후 debug 빌드로 카카오/구글 로그인* 흐름은 본 PR 범위 밖. 별도 후속 이슈에서 공용 debug keystore 도입으로 처리 예정 (현재는 각자 머신의 debug SHA-1 / 키 해시를 콘솔에 일일이 등록해야 동작)