### PR TITLE
build: 공용 debug keystore 도입 (신규 팀원 OAuth 동작 단순화) (#288)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🚀 신규 팀원 빌드 셋업
 
-`local.properties` 는 `.gitignore` 에 등록되어 있어 **git 으로 받아지지 않는다**. clone 직후 다음 두 키를 루트 `local.properties` 에 직접 채워야 카카오·구글 로그인이 정상 동작한다.
+`local.properties` 는 `.gitignore` 에 등록되어 있어 **git 으로 받아지지 않는다**. clone 직후 아래 키들을 루트 `local.properties` 에 직접 채우고 공용 debug keystore 파일을 받아야 카카오·구글 로그인이 정상 동작한다.
 
 ## 필요 키
 
@@ -10,6 +10,7 @@
 |---|---|---|
 | `KAKAO_NATIVE_APP_KEY` | 카카오 SDK 초기화 (`KakaoSdk.init`) + 카카오 로그인 콜백 intent-filter 의 `kakao{NATIVE_APP_KEY}` scheme | [Kakao Developers](https://developers.kakao.com) → 내 애플리케이션 → 앱 키 → **네이티브 앱 키** |
 | `GOOGLE_WEB_CLIENT_ID` | Google 로그인 시 `CredentialManager.requestGoogleIdToken(serverClientId = ...)` 의 server client id (백엔드가 ID Token 의 `aud` 를 검증할 수 있도록 *Web* client ID 사용) | [Google Cloud Console](https://console.cloud.google.com) → APIs & Services → Credentials → OAuth 2.0 Client IDs → **Web application** 타입 |
+| `DEBUG_STORE_FILE` 외 3개 | 공용 debug keystore 경로/비밀번호/alias. 머신별 `~/.android/debug.keystore` 대신 팀 공용 keystore 로 통일해서 카카오·구글 콘솔에 SHA-1 / 키 해시 1번만 등록하면 모든 팀원의 debug 빌드에서 OAuth 동작 | Slack DM 으로 1hyok 에게 수령 |
 
 ## `local.properties` 양식
 
@@ -18,19 +19,29 @@
 ```properties
 KAKAO_NATIVE_APP_KEY=<카카오 네이티브 앱 키>
 GOOGLE_WEB_CLIENT_ID=<구글 OAuth web client id>.apps.googleusercontent.com
+
+# 공용 debug keystore (Slack DM 으로 .jks 파일 + 비밀번호 수령 후 채움)
+DEBUG_STORE_FILE=/Users/<you>/afternote-debug-shared.jks
+DEBUG_STORE_PASSWORD=<수령한 비밀번호>
+DEBUG_KEY_ALIAS=afternote-debug-shared
+DEBUG_KEY_PASSWORD=<수령한 비밀번호>
 ```
 
-## 키 수령 채널
+## 키·keystore 수령 채널
 
-신규 팀원은 위 두 키를 **Slack DM 으로 1hyok 에게 요청**. (직접 발급 권한이 있는 경우 위 콘솔에서 직접 조회 가능.)
+신규 팀원은 다음 셋을 **Slack DM 으로 1hyok 에게 요청**:
+
+1. `KAKAO_NATIVE_APP_KEY` + `GOOGLE_WEB_CLIENT_ID` (텍스트)
+2. `DEBUG_*` 4개 키 값 (텍스트)
+3. **`afternote-debug-shared.jks` 파일** (바이너리 첨부) — 로컬 어디에든 두고 `DEBUG_STORE_FILE` 에 절대 경로 명시
+
+> public repo 라 keystore 자체는 git 에 commit 하지 않는다. `.gitignore` 의 `*.keystore`, `*.jks` 패턴이 이중으로 차단.
 
 ## 누락 시 증상
 
-두 키가 비어 있으면 빌드는 통과하지만 다음이 깨진다:
-
-- `KakaoSdk.init("")` → SDK 초기화 실패 (앱 내 안내: `KAKAO_NATIVE_APP_KEY를 확인해주세요.`)
-- `AndroidManifest.xml` 의 `android:scheme="kakao${KAKAO_NATIVE_APP_KEY}"` 가 빈 scheme 으로 등록 → 카카오 로그인 콜백 intent-filter 매칭 안 됨
-- `requestGoogleIdToken(serverClientId = "")` → Credential Manager 가 invalid request 로 실패
+- `KAKAO_NATIVE_APP_KEY` 빈 값 → `KakaoSdk.init("")` 초기화 실패 + 콜백 intent-filter 매칭 불가
+- `GOOGLE_WEB_CLIENT_ID` 빈 값 → Credential Manager 가 invalid request 로 실패
+- `DEBUG_STORE_FILE` 빈 값 → Android plugin 의 default `~/.android/debug.keystore` (머신별 자동 생성) 로 fallback → 카카오·구글 콘솔에 등록된 공용 SHA-1 / 키 해시와 불일치 → 빌드는 통과하지만 로그인 시점에 실패
 
 # 📦 비개발자 APK 배포 (Firebase App Distribution)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,18 @@ android {
     }
 
     signingConfigs {
+        // 공용 debug keystore — 신규 팀원 OAuth 동작 단순화 (#288).
+        // 머신별 ~/.android/debug.keystore 대신 팀 공용 keystore 로 통일.
+        // keystore 파일은 public repo 라 git commit 금지 — Slack DM 으로 신규 인계자에게 전달.
+        getByName("debug") {
+            val debugStoreFile = localProperties.getProperty("DEBUG_STORE_FILE")
+            if (debugStoreFile != null) {
+                storeFile = file(debugStoreFile)
+                storePassword = localProperties.getProperty("DEBUG_STORE_PASSWORD")
+                keyAlias = localProperties.getProperty("DEBUG_KEY_ALIAS")
+                keyPassword = localProperties.getProperty("DEBUG_KEY_PASSWORD")
+            }
+        }
         create("release") {
             val releaseStoreFile = localProperties.getProperty("RELEASE_STORE_FILE")
             if (releaseStoreFile != null) {

--- a/core/ui/src/main/kotlin/com/afternote/core/ui/UiText.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/UiText.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.res.stringResource
  */
 sealed interface UiText {
     data class Resource(
-        @StringRes val resId: Int,
+        @param:StringRes val resId: Int,
         val args: List<Any> = emptyList(),
     ) : UiText
 
@@ -24,7 +24,7 @@ sealed interface UiText {
     /** 서버/예외가 메시지를 주면 그대로, 없으면 리소스 fallback. `e.message ?: getString(R.string.x)` 대응. */
     data class DynamicOrResource(
         val value: String?,
-        @StringRes val fallbackResId: Int,
+        @param:StringRes val fallbackResId: Int,
     ) : UiText
 
     companion object {

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadUiState.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadUiState.kt
@@ -12,7 +12,7 @@ import androidx.compose.runtime.Immutable
 sealed interface ErrorPayload {
     /** 클라이언트가 미리 정의한 generic 문구 (i18n 가능). 서버 message 미제공 시 fallback. */
     data class Res(
-        @StringRes val id: Int,
+        @param:StringRes val id: Int,
     ) : ErrorPayload
 
     /** 백엔드가 런타임에 내려준 사용자 친화 message (예: 409 "이미 대기 중인 인증 요청이 존재합니다."). */


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #288

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `app/build.gradle.kts` 의 `signingConfigs.getByName("debug")` 가 `local.properties` 의 `DEBUG_STORE_FILE`/`DEBUG_STORE_PASSWORD`/`DEBUG_KEY_ALIAS`/`DEBUG_KEY_PASSWORD` 4개 키를 읽어 공용 debug keystore 로 서명. 4개 키 없으면 Android plugin 의 default `~/.android/debug.keystore` 로 fallback (기존 동작 유지)
- 공용 debug keystore (`afternote-debug-shared.jks`) 의 SHA-1 / 카카오 키 해시는 GCP `afternote-android` Android OAuth client + 카카오 Developers + Firebase Console 에 등록 완료
- README 의 "🚀 신규 팀원 빌드 셋업" 갱신 — `DEBUG_*` 4개 키 양식 + Slack DM 으로 keystore 파일 수령 step + 누락 시 fallback 동작 명시
- `core/ui/UiText.kt`, `feature/afternote/.../DocumentUploadUiState.kt` 의 `@StringRes` → `@param:StringRes` 로 KT-73255 deprecation warning 해소 (본인 책임 영역만, 컴파일 결과 동일)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- 시각 변경 없음 (빌드 / 서명 변경)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- PR #287 (release signing + Firebase App Distribution) 위에 stack — base = `feat/286`. PR #287 머지 시 base 가 develop 로 자동 re-target
- 공용 keystore 파일 (`afternote-debug-shared.jks`) 은 public repo 라 레포에 포함하지 않음 — Slack DM 으로 신규 인계자에게 전달 (`DEBUG_*` 4개 키 값과 함께)
- 본 PR 머지 후 신규 팀원이 git pull 받고 README 따라 셋업하면 본인 머신에서 카카오/구글 로그인 즉시 동작 — 각자 머신의 debug SHA-1 / 키 해시를 콘솔에 등록하는 marginal cost 사라짐
- 검증: 에뮬레이터에 새 debug APK 설치 후 카카오 로그인 정상 동작 확인 (SHA-1 매칭 `1eb0437f90b600010776f81882910ace432358d0`)
