### PR TITLE
docs(afternote): ResolveMemorialMediaForSaveUseCase KDoc 정정 — 백엔드 URL 형식 (presigned + normalizeKey) 명시 (#258)

### DIFF
--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/usecase/editor/ResolveMemorialMediaForSaveUseCase.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/usecase/editor/ResolveMemorialMediaForSaveUseCase.kt
@@ -21,10 +21,16 @@ class MemorialPhotoSaveException(
  * 결과를 주고, 본 UseCase 는 그 sealed 분기를 *생성(POST) vs 수정(PATCH)* 페이로드 규칙에 매핑한다.
  * 도메인 본문이 `"content://"`, `"X-Amz-"` 같은 인프라 형식 디테일 문자열을 직접 비교하지 않는다.
  *
+ * **백엔드 URL 형식 (`Afternote-BE` 코드 확인됨)**:
+ * 사진·영상 모두 *GET 응답 시점에* 백엔드가 S3 storage key 를 presigned GET URL 로 변환해 응답
+ * (`AfternoteService` 의 `s3Service.generateGetPresignedUrl(...)`). 영구 URL 아님.
+ * 단, 백엔드 `PlaylistRelationStrategy.normalizeKey(...)` 가 POST/PATCH 시점에 어떤 형태 URL 도
+ * S3 key 로 정규화하므로 클라이언트가 받은 presigned URL 을 그대로 다시 보내도 데이터 손상 없음.
+ *
  * **PATCH 페이로드 규칙**:
  * - [VideoUploadOutcome.Existing] → 페이로드에서 *제거* (`null`).
- *   영상 URL 은 presigned 일 가능성이 있어 그대로 보내면 만료 후 깨지거나 서버가 *새 자원* 으로 오해.
- *   사진은 백엔드 `fileUrl` 이 영구 URL 이라 Existing 도 동일 URL 재전송 — POST 와 같은 값.
+ *   영상은 URL + 썸네일 쌍이라 부분 갱신 비일관 위험 → 변경 없음 신호로 null 처리.
+ * - [PhotoUploadOutcome.Existing] → URL 그대로 재전송 (단일 URL 이라 비일관 위험 없음, POST 와 같은 값).
  * - [VideoUploadOutcome.FreshlyUploaded] / [PhotoUploadOutcome.FreshlyUploaded] → URL 그대로 전송.
  *   서버가 *새 자원* 으로 등록.
  * - [VideoUploadOutcome.Empty] / [PhotoUploadOutcome.Empty] → null.

--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/usecase/editor/ResolvedMemorialMediaForSave.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/usecase/editor/ResolvedMemorialMediaForSave.kt
@@ -10,7 +10,9 @@ data class ResolvedMemorialMediaForSave(
     /** 생성·수정 공통: 영정 사진 URL. */
     val resolvedMemorialPhotoUrl: String?,
     /**
-     * 수정(PATCH) 전용: 본문에 넣을 videoUrl. Presigned URL이면 null로 생략.
+     * 수정(PATCH) 전용: 본문에 넣을 videoUrl.
+     * `VideoUploadOutcome.Existing` (기존 영상 그대로 두기) → null (변경 없음 신호로 페이로드에서 제거).
+     * `VideoUploadOutcome.FreshlyUploaded` (새 영상 업로드 직후) → 업로드 결과 URL.
      * 생성 시에는 무시하고 [resolvedVideoUrl]을 쓴다.
      */
     val videoUrlForUpdate: String?,


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #258

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- backend repo (`Afternote-BE`) 코드 직접 확인 결과 — 사진/영상 모두 *GET 응답 시 백엔드가 S3 storage key 를 presigned GET URL 로 변환해 응답* (영구 URL 아님). 단 `PlaylistRelationStrategy.normalizeKey(...)` 가 POST/PATCH 시점에 어떤 URL 도 S3 key 로 정규화하므로 클라이언트가 받은 그대로 다시 보내도 데이터 손상 없음.
- `ResolveMemorialMediaForSaveUseCase.kt` KDoc 갱신 — 백엔드 URL 형식 (presigned + normalizeKey 보장) 명시 + #247 의 KDoc 부정확한 부분 (*사진은 영구 `fileUrl`*) 정정.
- `ResolvedMemorialMediaForSave.kt` 의 `videoUrlForUpdate` KDoc 도 sealed outcome 분기 명시로 보강.
- 코드 변경 없음 — KDoc only.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- 시각 변경 없음 (KDoc 정정).

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- base = `feat/247` stack on PR #263. PR #263 머지 시 base 가 develop 으로 자동 re-target.
- 백엔드 코드 근거: `AfternoteService.java:140-153` (`s3Service.generateGetPresignedUrl(...)`) + `PlaylistRelationStrategy.java:99-100, 133-141` (`normalizeKey()` 가 S3 key 추출).
- 클라이언트 동작 변경 없음 — `videoUrlForUpdate` 분리 유지 (영상은 URL + 썸네일 쌍이라 부분 갱신 비일관 위험 회피). 사진은 단일 URL 이라 Existing 도 그대로 재전송 (POST 와 같은 값).
