### PR TITLE
feat(ci): PR 머지 시 base 무관 closes #N 자동 close 워크플로 도입 (#294)

### DIFF
--- a/.github/workflows/auto-close-issue.yml
+++ b/.github/workflows/auto-close-issue.yml
@@ -1,0 +1,83 @@
+name: Auto-close referenced issues on PR merge
+
+# GitHub 의 기본 자동 close 는 default branch 머지 시에만 발동.
+# 본 repo 의 stack PR 워크플로 (feat/A → feat/B → develop) 에서는 closes #N 키워드가 있어도
+# 자동 close 미발동 → 매 PR 머지마다 수동 close 부담.
+#
+# 본 워크플로는 base 무관하게 PR merged 시점에 close 키워드를 파싱해 referenced issue 를 close.
+# default branch 머지 시 GitHub 가 이미 close 처리한 경우 state 가드로 중복 회피.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-referenced:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues referenced by close keywords
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const text = `${pr.title}\n\n${pr.body || ''}`;
+
+            // GitHub 공식 close keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved.
+            // 형식: <keyword> [<owner>/<repo>]#<N>.
+            // https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
+            const regex = /\b(?:close[ds]?|fix(?:e[ds])?|resolve[ds]?)\s+(?:([\w.-]+\/[\w.-]+))?#(\d+)/gi;
+
+            const seen = new Set();
+            const closed = [];
+            const skipped = [];
+            let match;
+
+            while ((match = regex.exec(text)) !== null) {
+              const repoFull = match[1] || `${context.repo.owner}/${context.repo.repo}`;
+              const [owner, repo] = repoFull.split('/');
+              const num = parseInt(match[2], 10);
+              const key = `${owner}/${repo}#${num}`;
+              if (seen.has(key)) continue;
+              seen.add(key);
+
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner, repo, issue_number: num,
+                });
+
+                // PR 자기 자신 또는 다른 PR 참조 — close 대상 아님
+                if (issue.pull_request) {
+                  skipped.push(`${key} (is a PR)`);
+                  continue;
+                }
+                // 이미 close — default branch 머지로 GitHub 가 이미 처리한 경우 등
+                if (issue.state !== 'open') {
+                  skipped.push(`${key} (already ${issue.state})`);
+                  continue;
+                }
+
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: num,
+                  body: `Auto-closed by merge of #${pr.number} into \`${pr.base.ref}\`.`,
+                });
+                await github.rest.issues.update({
+                  owner, repo, issue_number: num,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+                closed.push(key);
+              } catch (err) {
+                core.warning(`Failed to close ${key}: ${err.message}`);
+              }
+            }
+
+            core.summary
+              .addHeading('Auto-close summary', 3)
+              .addRaw(`Closed: ${closed.length ? closed.join(', ') : '(none)'}`).addBreak()
+              .addRaw(`Skipped: ${skipped.length ? skipped.join(', ') : '(none)'}`)
+              .write();


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #294

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `.github/workflows/auto-close-issue.yml` 신설 — `pull_request.closed` + `merged == true` 트리거. base 무관
- GitHub 공식 close keyword 9종 (`close[ds]?` / `fix(e[ds])?` / `resolve[ds]?`) 정규식 파싱. PR title + body 모두 스캔
- cross-repo `owner/repo#N` 형식 지원
- state 가드 — 이미 `closed` 인 이슈는 skip (default branch 머지 시 GitHub 가 이미 처리한 경우 중복 회피)
- PR 자기 자신/다른 PR 참조 skip (`issue.pull_request` 가드)
- close 시 comment 에 트리거 PR 번호 + base ref 명시 (수동 close 와 구분)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- 시각 변경 없음 (CI 워크플로 신설)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 동기: [PR #289](https://github.com/Afternote/Afternote-FE/pull/289) (base=`feat/286`) merged 됐지만 default branch 미반영 → [이슈 #288](https://github.com/Afternote/Afternote-FE/issues/288) 자동 close 미발동 (수동 close 부담)
- 본 PR 자체도 본 워크플로의 첫 검증 대상 — develop 머지되면 GitHub 의 기본 동작과 본 워크플로 둘 다 발동, state 가드로 한 번만 close 됨
- 향후 stack PR (`feat/A → feat/B → develop`) 머지 cycle 시 매 단계마다 이슈 자동 close
- 권한: `GITHUB_TOKEN` 의 `issues: write` 사용 (workflow 내 명시)