### PR TITLE
refactor(afternote+core): onPrefillApplied → onPrefillConsumed 어미 정렬 + @param:StringRes use-site target 명시 (#293)

### DIFF
--- a/core/ui/src/main/kotlin/com/afternote/core/ui/UiText.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/UiText.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.res.stringResource
  */
 sealed interface UiText {
     data class Resource(
-        @StringRes val resId: Int,
+        @param:StringRes val resId: Int,
         val args: List<Any> = emptyList(),
     ) : UiText
 
@@ -24,7 +24,7 @@ sealed interface UiText {
     /** 서버/예외가 메시지를 주면 그대로, 없으면 리소스 fallback. `e.message ?: getString(R.string.x)` 대응. */
     data class DynamicOrResource(
         val value: String?,
-        @StringRes val fallbackResId: Int,
+        @param:StringRes val fallbackResId: Int,
     ) : UiText
 
     companion object {

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/AfternoteEditorViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/AfternoteEditorViewModel.kt
@@ -172,8 +172,8 @@ private data class EditorFormSnapshot(
  *
  * **단일 UI 상태:** 폼·작성자 수신자·저장 진행/오류·일회성 신호 모두 단일 [AfternoteEditorUiState] 로 묶어 [uiState] 로만 노출한다
  * (Google 공식 가이드 — *"ViewModel events should always result in a UI state update"*).
- * 일회성(저장 성공·썸네일 업로드·프리필 적용)은 UiState 의 nullable 신호로 표현하고 UI 가 [LaunchedEffect] 로 소비 후
- * `on*Consumed` / [onPrefillApplied] 콜백으로 reset.
+ * 일회성(저장 성공·썸네일 업로드·프리필 적용)은 UiState 의 nullable 신호로 표현하고 UI 가 `LaunchedEffect` 로 소비 후
+ * `on*Consumed` 콜백으로 reset.
  *
  * **SSOT:** 비즈니스 폼 필드는 [EditorFormState] 로 [internalState] 안에 보관하며, 프로세스 종료 시
  * [SavedStateHandle] JSON 스냅샷으로 복원한다. 추모 플레이리스트 곡 목록은 폼의 [EditorFormState.memorialPlaylistSongs] 와
@@ -183,7 +183,7 @@ private data class EditorFormSnapshot(
  * **UI Layer 분리:** ViewModel은 Compose UI 객체(`TextFieldState`, `SnapshotStateList`, 파사드)를 들지 않는다.
  * UI 레이어는 `rememberAfternoteEditorState(getCurrentForm = ::currentForm, updateForm = ::updateForm)` 으로
  * 자체 파사드를 만들고, prefill 등 UI 상태 변경은 [AfternoteEditorUiState.pendingPrefill] 신호로 위임받아 적용 후
- * [onPrefillApplied] 로 통보한다.
+ * [onPrefillConsumed] 로 통보한다.
  *
  * 수정 모드(`itemId` 있음)의 상세 로드는 [com.afternote.feature.afternote.presentation.author.detail.AfternoteDetailViewModel]
  * 과 같이 `init`에서만 트리거한다 (`LaunchedEffect`로 네비게이션에 위임하지 않음).
@@ -443,7 +443,7 @@ class AfternoteEditorViewModel
                         val prefill = AfternoteEditorFormMapper.buildEditorFormPrefill(detail)
                         savedStateHandle[EDITOR_ORIGINAL_CATEGORY_FOR_API_KEY] = prefill.category.name
                         // UI 레이어 파사드가 TextFieldState·SnapshotStateList 등 UI 상태를 갱신하도록 위임.
-                        // skeleton 종료는 UI 가 prefill 적용을 마친 뒤 [onPrefillApplied] 로 통보한다
+                        // skeleton 종료는 UI 가 prefill 적용을 마친 뒤 [onPrefillConsumed] 로 통보한다
                         // (uiState 갱신 시점에 prefill 도착했어도 UI 가 form·TextFieldState 에 반영하기 전이라
                         //  여기서 끄면 skeleton 사라짐 → 빈 폼 → prefill 깜빡임 발생).
                         internalState.update { it.copy(pendingPrefill = prefill) }
@@ -459,7 +459,7 @@ class AfternoteEditorViewModel
          * UI 가 [AfternoteEditorUiState.pendingPrefill] 신호를 받아 폼·TextFieldState 에 모두 반영한 직후 호출.
          * skeleton 종료([AfternoteEditorUiState.isPrefillLoading] = false) + 신호 reset (pendingPrefill = null) 동시 처리.
          */
-        fun onPrefillApplied() {
+        fun onPrefillConsumed() {
             internalState.update { it.copy(isPrefillLoading = false, pendingPrefill = null) }
         }
 

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/state/AfternoteSaveState.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/state/AfternoteSaveState.kt
@@ -68,6 +68,6 @@ data class AfternoteEditorUiState(
     val pendingSaveSuccessId: Long? = null,
     /** 추모 영상 썸네일 업로드 완료 신호 — UI 파사드가 form 에 url 적용 후 `onThumbnailUploadedConsumed` 로 reset. */
     val pendingThumbnailUrl: String? = null,
-    /** 수정 모드 prefill 데이터 — UI 파사드가 form 에 적용 후 `onPrefillApplied` 로 reset (skeleton 종료 동시). */
+    /** 수정 모드 prefill 데이터 — UI 파사드가 form 에 적용 후 `onPrefillConsumed` 로 reset (skeleton 종료 동시). */
     val pendingPrefill: EditorFormPrefill? = null,
 )

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/navigation/AfternoteNavGraphEditor.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/navigation/AfternoteNavGraphEditor.kt
@@ -207,7 +207,7 @@ internal fun AfternoteEditorNavigation(params: AfternoteEditorNavigationParams) 
         if (pendingPrefill != null) {
             params.onReplaceSongs(pendingPrefill.memorialPlaylistSongs)
             state.applyFormPrefill(pendingPrefill)
-            editViewModel.onPrefillApplied()
+            editViewModel.onPrefillConsumed()
         }
     }
 

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadUiState.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadUiState.kt
@@ -12,7 +12,7 @@ import androidx.compose.runtime.Immutable
 sealed interface ErrorPayload {
     /** 클라이언트가 미리 정의한 generic 문구 (i18n 가능). 서버 message 미제공 시 fallback. */
     data class Res(
-        @StringRes val id: Int,
+        @param:StringRes val id: Int,
     ) : ErrorPayload
 
     /** 백엔드가 런타임에 내려준 사용자 친화 message (예: 409 "이미 대기 중인 인증 요청이 존재합니다."). */


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #293

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `AfternoteEditorViewModel.onPrefillApplied()` → `onPrefillConsumed()` 어미 정렬 (#228 마이그레이션 후 단발성 신호 reset 콜백 컨벤션 = `on*Consumed`).
- B 느슨 통일 채택 — 공통 신호 `onErrorConsumed` 는 도메인 생략 유지 (4 화면 공유). 도메인 명사 + Consumed 9곳 + 본 어미 정렬 1곳으로 일관성 확보.
- 영향 위치: ViewModel 정의 1줄 + KDoc 참조 3곳 + UiState KDoc 1곳 + NavGraph 호출 1곳.
- 인접 KDoc dangling 정리 — `[LaunchedEffect]` 는 ViewModel 모듈에서 resolve 안 되므로 백틱 `LaunchedEffect` 로 (KT-73255 처럼 본인 영역만).
- KT-73255 deprecation warning 해소 — `core/ui/UiText.kt` `Resource.resId` · `DynamicOrResource.fallbackResId` + `afternote/.../DocumentUploadUiState.kt` `ErrorPayload.Res.id` 의 `@StringRes` → `@param:StringRes`. 본 repo 컨벤션 = param-only (PR #289 와 동일 방향).

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- 시각 변경 없음 (네이밍 + annotation use-site target).

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- `:feature:afternote:presentation:compileDebugKotlin` · `lintDebug` · `assembleDebug` 통과. 새 develop tip (PR #290 머지 후) QA 흐름 정상 (로그인/회원가입/받은 기록함/발신자 등록).
- `@StringRes` → `@param:StringRes` 는 [PR #289](https://github.com/Afternote/Afternote-FE/pull/289) 의 동일 fix 와 동일 파일 동일 의도 — feat/286 → develop 머지 cycle 와 충돌 없이 (같은 변경) 통합 가능.