### PR TITLE
feat(ci) + refactor(afternote): Firebase App Distribution 자동 배포 워크플로 + 영상 URL 영구성 분기 단순화 (#292, #297)

### DIFF
--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -1,0 +1,103 @@
+name: Release Distribution (Firebase App Distribution)
+
+# main 브랜치 push 시점에만 실행. PR / 다른 브랜치에서는 트리거되지 않음 —
+# "main 머지된 상태만 배포" 운영 정책에 맞춤. 수동 트리거 (1hyok 머신) 는 fallback 으로 유지.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  distribute:
+    name: Build Release and Upload to Firebase App Distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'gradle'
+
+      # fail-fast — secret 누락 시 Gradle 까지 가지 않고 즉시 실패.
+      # secret 값은 echo 하지 않음 (env 로만 받아서 길이 검사). 누락 키 이름은 안전.
+      - name: Verify required secrets are set
+        env:
+          KAKAO_NATIVE_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
+          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
+          GOOGLE_SERVICES_JSON_B64: ${{ secrets.GOOGLE_SERVICES_JSON_B64 }}
+          RELEASE_STORE_FILE_B64: ${{ secrets.RELEASE_STORE_FILE_B64 }}
+          RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          missing=""
+          [ -z "$KAKAO_NATIVE_APP_KEY" ] && missing="$missing KAKAO_NATIVE_APP_KEY"
+          [ -z "$GOOGLE_WEB_CLIENT_ID" ] && missing="$missing GOOGLE_WEB_CLIENT_ID"
+          [ -z "$GOOGLE_SERVICES_JSON_B64" ] && missing="$missing GOOGLE_SERVICES_JSON_B64"
+          [ -z "$RELEASE_STORE_FILE_B64" ] && missing="$missing RELEASE_STORE_FILE_B64"
+          [ -z "$RELEASE_STORE_PASSWORD" ] && missing="$missing RELEASE_STORE_PASSWORD"
+          [ -z "$RELEASE_KEY_ALIAS" ] && missing="$missing RELEASE_KEY_ALIAS"
+          [ -z "$RELEASE_KEY_PASSWORD" ] && missing="$missing RELEASE_KEY_PASSWORD"
+          [ -z "$FIREBASE_SERVICE_ACCOUNT_JSON" ] && missing="$missing FIREBASE_SERVICE_ACCOUNT_JSON"
+          if [ -n "$missing" ]; then
+            echo "::error::필수 secret 누락:$missing — Settings → Secrets and variables → Actions 에 등록"
+            exit 1
+          fi
+
+      # google-services plugin 이 app/google-services.json 을 요구. 파일은 .gitignore 라
+      # CI 환경엔 없음. base64 인코딩된 secret 으로 받아서 decode.
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES_JSON_B64: ${{ secrets.GOOGLE_SERVICES_JSON_B64 }}
+        run: |
+          echo "$GOOGLE_SERVICES_JSON_B64" | base64 -d > app/google-services.json
+
+      - name: Decode release keystore
+        env:
+          RELEASE_STORE_FILE_B64: ${{ secrets.RELEASE_STORE_FILE_B64 }}
+        run: |
+          echo "$RELEASE_STORE_FILE_B64" | base64 -d > "$HOME/afternote-release.jks"
+
+      # Firebase App Distribution Gradle plugin 이 GOOGLE_APPLICATION_CREDENTIALS 환경변수로
+      # service account JSON 경로를 인식. plugin DSL 의 serviceCredentialsFile 미지정 시 fallback.
+      # 참고: https://firebase.google.com/docs/app-distribution/android/distribute-gradle
+      - name: Decode Firebase service account credentials
+        env:
+          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT_JSON" > "$HOME/firebase-service-account.json"
+
+      # app/build.gradle.kts 의 signingConfigs.release 가 local.properties 의 RELEASE_* 4개 키를
+      # 읽음. CI 환경에서는 local.properties 가 없으므로 secret 으로부터 작성.
+      - name: Compose local.properties
+        env:
+          KAKAO_NATIVE_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
+          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
+          RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          {
+            echo "KAKAO_NATIVE_APP_KEY=$KAKAO_NATIVE_APP_KEY"
+            echo "GOOGLE_WEB_CLIENT_ID=$GOOGLE_WEB_CLIENT_ID"
+            echo "RELEASE_STORE_FILE=$HOME/afternote-release.jks"
+            echo "RELEASE_STORE_PASSWORD=$RELEASE_STORE_PASSWORD"
+            echo "RELEASE_KEY_ALIAS=$RELEASE_KEY_ALIAS"
+            echo "RELEASE_KEY_PASSWORD=$RELEASE_KEY_PASSWORD"
+          } > local.properties
+
+      - name: Build release APK and upload to Firebase App Distribution
+        env:
+          KAKAO_NATIVE_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
+          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
+        run: |
+          export GOOGLE_APPLICATION_CREDENTIALS="$HOME/firebase-service-account.json"
+          ./gradlew assembleRelease appDistributionUploadRelease --no-daemon

--- a/README.md
+++ b/README.md
@@ -73,11 +73,30 @@ GOOGLE_WEB_CLIENT_ID=<구글 OAuth web client id>.apps.googleusercontent.com
 
 ## 배포 (매 회)
 
+### 자동 — `main` push 시 (기본 경로)
+
+`develop` → `main` 머지가 push 되면 GitHub Actions 워크플로 [`release-distribution.yml`](.github/workflows/release-distribution.yml) 가 자동 실행 → APK 빌드 → Firebase App Distribution 업로드 → 테스터 그룹 `afternote` 전원에게 자동 이메일 발송. 운영 정책 *"main 머지된 상태만 배포"* 와 일치.
+
+CI 가 사용하는 GitHub Secrets (Settings → Secrets and variables → Actions):
+
+| 키 | 용도 |
+|---|---|
+| `RELEASE_STORE_FILE_B64` | release keystore 파일 (`~/afternote-release.jks`) 의 base64 인코딩 |
+| `RELEASE_STORE_PASSWORD` | keystore 비밀번호 |
+| `RELEASE_KEY_ALIAS` | key alias (`afternote-release`) |
+| `RELEASE_KEY_PASSWORD` | key 비밀번호 |
+| `FIREBASE_SERVICE_ACCOUNT_JSON` | App Distribution Admin 권한 부여된 service account JSON 원문 |
+| `KAKAO_NATIVE_APP_KEY` · `GOOGLE_WEB_CLIENT_ID` · `GOOGLE_SERVICES_JSON_B64` | `local.properties` 키 (`lint.yml` 과 공유) |
+
+> base64 인코딩: `base64 -i ~/afternote-release.jks | pbcopy` (macOS)
+
+### 수동 — 1hyok 머신 (fallback / 긴급 시)
+
 ```bash
 ./gradlew assembleRelease appDistributionUploadRelease
 ```
 
-→ APK 빌드 + Firebase 업로드 + 테스터 그룹 `afternote` 전원에게 자동 이메일 발송.
+→ 동일하게 APK 빌드 + Firebase 업로드. CI 장애 시 또는 main 머지 없이 임시 배포 필요할 때 사용.
 
 > 같은 `versionCode` 로 재업로드하면 기존 release 갱신. 새 release 만들려면 `app/build.gradle.kts` 의 `versionCode` 증가.
 

--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/usecase/editor/ResolveMemorialMediaForSaveUseCase.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/usecase/editor/ResolveMemorialMediaForSaveUseCase.kt
@@ -13,7 +13,11 @@ class MemorialPhotoSaveException(
 ) : Exception("영정 사진 업로드에 실패했습니다.", cause)
 
 /**
- * 추모 영상·영정 사진 로컬 URI 업로드 및 PATCH 시 presigned URL 생략 규칙 적용.
+ * 추모 영상·영정 사진 로컬 URI 업로드 후 저장 페이로드에 들어갈 URL 묶음을 해석한다.
+ *
+ * POST/PATCH 동일 규칙 — 백엔드가 `S3Service.resolvePublicUrl(key)` 로 영구 public URL 을 발급하므로
+ * 클라이언트가 GET 응답에서 받은 URL 을 그대로 PATCH 페이로드에 다시 보낼 수 있다. 즉 PATCH 전용 분기
+ * (`isUpdate`, presigned 마커 검사) 없이 단일 해석 결과 사용.
  */
 class ResolveMemorialMediaForSaveUseCase
     @Inject
@@ -25,8 +29,6 @@ class ResolveMemorialMediaForSaveUseCase
             funeralVideoUrl: String?,
             memorialPhotoUrl: String?,
             pickedMemorialPhotoUri: String?,
-            funeralThumbnailUrl: String?,
-            isUpdate: Boolean,
         ): Result<ResolvedMemorialMediaForSave> {
             val resolvedVideoUrl = resolveVideoUrlForSave(funeralVideoUrl).getOrElse { return Result.failure(it) }
             val resolvedMemorialPhotoUrl =
@@ -34,15 +36,10 @@ class ResolveMemorialMediaForSaveUseCase
                     memorialPhotoUrl = memorialPhotoUrl,
                     pickedMemorialPhotoUri = pickedMemorialPhotoUri,
                 ).getOrElse { return Result.failure(it) }
-            val videoUrlForUpdate = videoUrlForUpdateRequest(isUpdate, resolvedVideoUrl)
-            val thumbnailForUpdate =
-                if (videoUrlForUpdate == null) null else funeralThumbnailUrl
             return Result.success(
                 ResolvedMemorialMediaForSave(
                     resolvedVideoUrl = resolvedVideoUrl,
                     resolvedMemorialPhotoUrl = resolvedMemorialPhotoUrl,
-                    videoUrlForUpdate = videoUrlForUpdate,
-                    funeralThumbnailUrlForUpdate = thumbnailForUpdate,
                 ),
             )
         }
@@ -71,17 +68,7 @@ class ResolveMemorialMediaForSaveUseCase
             return Result.success(memorialPhotoUrl?.takeIf { it.isNotBlank() })
         }
 
-        private fun videoUrlForUpdateRequest(
-            isUpdate: Boolean,
-            resolvedVideoUrl: String?,
-        ): String? {
-            if (!isUpdate || resolvedVideoUrl == null) return resolvedVideoUrl
-            if (resolvedVideoUrl.contains(PRESIGNED_URL_MARKER)) return null
-            return resolvedVideoUrl
-        }
-
         private companion object {
-            const val PRESIGNED_URL_MARKER = "X-Amz-"
             const val CONTENT_SCHEME = "content://"
         }
     }

--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/usecase/editor/ResolvedMemorialMediaForSave.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/usecase/editor/ResolvedMemorialMediaForSave.kt
@@ -1,19 +1,13 @@
 package com.afternote.feature.afternote.domain.usecase.editor
 
 /**
- * 저장 직전까지 해석·업로드된 추모 미디어 URL 묶음.
- * 생성(Post)과 수정(Patch)에서 각각 다른 필드로 쓰인다.
+ * 저장 직전까지 해석·업로드된 추모 미디어 URL 묶음. POST/PATCH 동일 규칙 — 백엔드가
+ * `S3Service.resolvePublicUrl(key)` 로 영구 public URL 을 발급하므로 클라이언트가 받은 URL 을
+ * 그대로 다시 보낼 수 있다 (presigned 변환 없음).
  */
 data class ResolvedMemorialMediaForSave(
-    /** 생성·수정 공통: 업로드 반영 후 영상 URL (로컬 content면 업로드 결과). */
+    /** 업로드 반영 후 영상 URL (로컬 content 이면 업로드 결과). null 이면 영상 미첨부. */
     val resolvedVideoUrl: String?,
-    /** 생성·수정 공통: 영정 사진 URL. */
+    /** 영정 사진 URL (로컬 content 이면 업로드 결과). null 이면 사진 미첨부. */
     val resolvedMemorialPhotoUrl: String?,
-    /**
-     * 수정(PATCH) 전용: 본문에 넣을 videoUrl. Presigned URL이면 null로 생략.
-     * 생성 시에는 무시하고 [resolvedVideoUrl]을 쓴다.
-     */
-    val videoUrlForUpdate: String?,
-    /** 수정(PATCH) 시 썸네일: [videoUrlForUpdate]가 null이면 null. */
-    val funeralThumbnailUrlForUpdate: String?,
 )

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/AfternoteEditorViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/AfternoteEditorViewModel.kt
@@ -397,8 +397,6 @@ class AfternoteEditorViewModel
                     funeralVideoUrl = memorialMedia.funeralVideoUrl,
                     memorialPhotoUrl = memorialMedia.memorialPhotoUrl,
                     pickedMemorialPhotoUri = memorialMedia.pickedMemorialPhotoUri,
-                    funeralThumbnailUrl = memorialMedia.funeralThumbnailUrl,
-                    isUpdate = editingId != null,
                 ).getOrElse { return Result.failure(it) }
 
             val command =
@@ -411,8 +409,8 @@ class AfternoteEditorViewModel
                             playlistSongs = playlistSongs,
                             memorialMedia =
                                 MemorialMediaUrls(
-                                    funeralVideoUrl = resolved.videoUrlForUpdate,
-                                    funeralThumbnailUrl = resolved.funeralThumbnailUrlForUpdate,
+                                    funeralVideoUrl = resolved.resolvedVideoUrl,
+                                    funeralThumbnailUrl = memorialMedia.funeralThumbnailUrl,
                                     memorialPhotoUrl = resolved.resolvedMemorialPhotoUrl,
                                 ),
                         )


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #292
- closed #297

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

### #292 — Firebase App Distribution 자동 배포 워크플로
- `.github/workflows/release-distribution.yml` 신설 — `main` push 시점 트리거. release keystore + `google-services.json` + Firebase service account credentials base64/원문 secret decode → `./gradlew assembleRelease appDistributionUploadRelease` 실행. service account 는 `GOOGLE_APPLICATION_CREDENTIALS` 환경변수 주입 ([공식 문서](https://firebase.google.com/docs/app-distribution/android/distribute-gradle)).
- README "📦 비개발자 APK 배포" 섹션에 자동/수동 두 경로 + GitHub Secrets 표 명시.
- 1hyok 수동 실행 (`./gradlew assembleRelease appDistributionUploadRelease`) 은 CI 장애 시 fallback 으로 유지.

### #297 — 영상 URL 영구성 분기 단순화 (#258 후속)
- backend repo (`Afternote-BE`) 직접 조사 결과 — `S3Service.generateGetPresignedUrl(...)` 구현이 `extractStorageKey → resolvePublicUrl(key)` 만 호출 (X-Amz-Signature 없음, 사실상 no-op). 사진과 동일하게 영상 URL 도 영구 public URL → 클라이언트 비대칭 정리 가능.
- `ResolvedMemorialMediaForSave` 의 `videoUrlForUpdate` / `funeralThumbnailUrlForUpdate` 제거 (4 → 2 필드).
- `ResolveMemorialMediaForSaveUseCase` 의 `urlForUpdateRequest()` private extension + `PRESIGNED_URL_MARKER` 제거. `invoke` 파라미터에서 `isUpdate` / `funeralThumbnailUrl` 삭제.
- `AfternoteEditorViewModel` PATCH 분기에서 `resolved.resolvedVideoUrl` + `memorialMedia.funeralThumbnailUrl` 직접 사용 (POST 와 동일 미디어 페이로드).
- [PR #291](https://github.com/Afternote/Afternote-FE/pull/291) (이슈 #258 의 KDoc 정정) 가 BE 구현 미확인으로 "presigned" 결론 — 본 PR 의 BE 코드 조사로 정정.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- 시각 변경 없음 (CI 워크플로 신설 + 도메인 로직 단순화).

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- **base 갱신 필요** — 본 PR 의 base 가 옛 develop tip (`4518d201`) 이라 [PR #290](https://github.com/Afternote/Afternote-FE/pull/290) 머지 변경분 미반영. 머지 전 develop merge / rebase 필요. 머지 시 `AfternoteEditorViewModel.kt` KDoc 영역에서 conflict 발생 가능 — develop tip 의 새 KDoc (events/Channel/AfternoteEditorEvent 제거 후 UiState nullable 신호 표현) 가 winner.
- 본 PR 도 자체 검증 대상 — [PR #295](https://github.com/Afternote/Afternote-FE/pull/295) (auto-close workflow) 가 먼저 머지되면 `closes #292 / #297` 키워드로 base 무관 자동 close. 본 PR 가 먼저 머지되면 default branch (develop) 머지라 GitHub 기본 자동 close 발동.
- #292 Secrets 등록 (`RELEASE_STORE_FILE_B64`, `RELEASE_STORE_PASSWORD`, `RELEASE_KEY_ALIAS`, `RELEASE_KEY_PASSWORD`, `FIREBASE_SERVICE_ACCOUNT_JSON`) 은 1hyok 분담. 본 PR 머지 후 main push 시점에 워크플로 첫 발동.
- #297 영상 첨부 PATCH 회귀 검증 — 본 PR 머지 후 release 빌드에서 영상 첨부 작성 + 수정 시나리오 확인 권장.