### PR TITLE
refactor(core-ui): 색 하드코드 정리 — AfternoteColors.error 신설 + Shimmer 매직넘버 추출 + Hero 그라데이션 정당화 (#303)

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/screen/receiver/component/SenderMessageHeroCard.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/receiver/component/SenderMessageHeroCard.kt
@@ -66,6 +66,13 @@ fun SenderMessageHeroCard(
     }
 }
 
+/**
+ * SenderMessageHeroCard 전용 파스텔 그라데이션 (그린 → 크림 → 피치).
+ *
+ * 본 화면 1회용 + 다른 화면 (예: [HeroCard]) 의 그라데이션과 색 조합이 달라 디자인 시스템
+ * 토큰으로 추상화하면 재사용성보다 SSOT 위반 비용이 큼.
+ * 디자인 시스템 룰 (`feedback_use_theme_colors`) 의 예외로 본 한 곳에 고정.
+ */
 private fun heroGradient(): Brush =
     Brush.linearGradient(
         colors =

--- a/core/ui/src/main/kotlin/com/afternote/core/ui/modifierextention/ShimmerModifier.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/modifierextention/ShimmerModifier.kt
@@ -16,6 +16,15 @@ import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.launch
 
 /**
+ * Shimmer 그라데이션의 두 색 — 본 Modifier 가 `Modifier.Node` 라 Composable 컨텍스트 밖이라
+ * `AfternoteDesign.colors` 직접 접근 불가. 디자인 시스템 토큰화 + 다크 모드 대응은
+ * `shimmerLoadingPlaceholder(highlight, base)` 시그니처 변경 + 호출처 전수 갱신을 동반하는
+ * 별 PR. 본 const 는 매직 넘버 → 이름 부여까지의 중간 단계.
+ */
+private val ShimmerBase = Color(0xFFE8E8E8)
+private val ShimmerHighlight = Color(0xFFF6F6F6)
+
+/**
  * 이미지·썸네일 로딩 구간에 쓰는 가벼운 shimmer 배경.
  * [Modifier.composed] 대신 [Modifier.Node]로 그리기만 갱신해 리컴포지션·할당을 줄인다.
  */
@@ -65,10 +74,10 @@ private class ShimmerLoadingPlaceholderNode :
             Brush.linearGradient(
                 colorStops =
                     arrayOf(
-                        0f to Color(0xFFE8E8E8),
-                        0.4f to Color(0xFFF6F6F6),
-                        0.6f to Color(0xFFF6F6F6),
-                        1f to Color(0xFFE8E8E8),
+                        0f to ShimmerBase,
+                        0.4f to ShimmerHighlight,
+                        0.6f to ShimmerHighlight,
+                        1f to ShimmerBase,
                     ),
                 start = Offset(startX, 0f),
                 end = Offset(startX + widthPx, widthPx),

--- a/core/ui/src/main/kotlin/com/afternote/core/ui/theme/Color.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/theme/Color.kt
@@ -45,6 +45,9 @@ private val Accent8 = Color(0xFF6E5A7F)
 private val Accent9 = Color(0xFF24324A)
 private val Accent10 = Color(0xFF3A4A8A)
 
+/** 시맨틱 에러/필수표시 색. 필수 입력 마커·검증 실패 등에 사용. */
+private val Error = Color(0xFFFF3647)
+
 internal fun lightColors() =
     AfternoteColors(
         white = White,
@@ -70,6 +73,7 @@ internal fun lightColors() =
         accent8 = Accent8,
         accent9 = Accent9,
         accent10 = Accent10,
+        error = Error,
         isLightMode = true,
     )
 
@@ -98,6 +102,7 @@ internal fun darkColors() =
         accent8 = Accent8,
         accent9 = Accent9,
         accent10 = Accent10,
+        error = Error,
         isLightMode = false,
     )
 
@@ -130,6 +135,7 @@ class AfternoteColors(
     accent8: Color,
     accent9: Color,
     accent10: Color,
+    error: Color,
     isLightMode: Boolean,
 ) {
     var white by mutableStateOf(white)
@@ -178,6 +184,8 @@ class AfternoteColors(
         private set
     var accent10 by mutableStateOf(accent10)
         private set
+    var error by mutableStateOf(error)
+        private set
     var isLightMode by mutableStateOf(isLightMode)
         private set
 
@@ -205,6 +213,7 @@ class AfternoteColors(
         accent8: Color = this.accent8,
         accent9: Color = this.accent9,
         accent10: Color = this.accent10,
+        error: Color = this.error,
         isLightMode: Boolean = this.isLightMode,
     ) = AfternoteColors(
         white = white,
@@ -230,6 +239,7 @@ class AfternoteColors(
         accent8 = accent8,
         accent9 = accent9,
         accent10 = accent10,
+        error = error,
         isLightMode = isLightMode,
     )
 
@@ -257,6 +267,7 @@ class AfternoteColors(
         this.accent8 = other.accent8
         this.accent9 = other.accent9
         this.accent10 = other.accent10
+        this.error = other.error
         this.isLightMode = other.isLightMode
     }
 }

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/EditorSectionLabel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/EditorSectionLabel.kt
@@ -71,9 +71,8 @@ fun EditorSectionLabel(
                 modifier =
                     Modifier
                         .size(4.dp)
-                        // TODO: 디자인 시스템에 error/required 시맨틱 컬러 추가 후 교체
                         .background(
-                            color = Color(0xFFFF3647),
+                            color = AfternoteDesign.colors.error,
                             shape = CircleShape,
                         ).align(Alignment.Top),
             )

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/summary/HeroCard.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/summary/HeroCard.kt
@@ -26,6 +26,23 @@ import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.feature.afternote.presentation.R
 
+/**
+ * HeroCard 전용 파스텔 그라데이션 (라이트 블루 → 화이트-ish → 라이트 피치).
+ *
+ * 본 화면 1회용 + 다른 화면 (예: SenderMessageHeroCard) 의 그라데이션과 색 조합이 달라
+ * 디자인 시스템 토큰으로 추상화하면 재사용성보다 SSOT 위반 비용이 큼.
+ * 디자인 시스템 룰 (`feedback_use_theme_colors`) 의 예외로 본 한 곳에 고정.
+ */
+private val HeroGradient: Brush =
+    Brush.linearGradient(
+        colors =
+            listOf(
+                Color(0xFFD0E4FF),
+                Color(0xFFF0F4F8),
+                Color(0xFFFFE0CC),
+            ),
+    )
+
 @Composable
 fun HeroCard(
     modifier: Modifier = Modifier,
@@ -37,17 +54,7 @@ fun HeroCard(
                 .fillMaxWidth()
                 .height(140.dp)
                 .clip(RoundedCornerShape(16.dp))
-                .background(
-                    brush =
-                        Brush.linearGradient(
-                            colors =
-                                listOf(
-                                    Color(0xFFD0E4FF), // Light Blue
-                                    Color(0xFFF0F4F8), // White-ish
-                                    Color(0xFFFFE0CC), // Light Peach
-                                ),
-                        ),
-                ),
+                .background(brush = HeroGradient),
     ) {
         Image(
             painter = painterResource(R.drawable.feature_afternote_img_hero_background),


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #303

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
[`feedback_color_hardcode_followup`](memory) 메모의 4개 파일 (1hyok 본인 작성) `Color(0xFF...)` 하드코드를 메모리 케이스별 판단대로 정리.

### `core/ui/theme/Color.kt` — `error` 토큰 신설
- top-level `private val Error = Color(0xFFFF3647)` (KDoc: 시맨틱 에러/필수표시 색)
- `lightColors()` / `darkColors()` 양쪽 `error = Error`
- `AfternoteColors` constructor / `var error` / `copy()` / `update()` 모두 추가
- 다크 모드 색은 동일 — 디자인 시스템 룰 확정 시 별 PR

### `EditorSectionLabel.kt:76` — error 토큰 적용
- 필수 표시 `Color(0xFFFF3647)` → `AfternoteDesign.colors.error`
- `// TODO: 디자인 시스템에 error/required 시맨틱 컬러 추가 후 교체` 주석 제거

### `ShimmerModifier.kt` — file-level 매직넘버 추출
- `private val ShimmerBase = Color(0xFFE8E8E8)`, `ShimmerHighlight = Color(0xFFF6F6F6)` 추출
- KDoc 에 Theme 토큰화 미흡 사유 명시 — `Modifier.Node` 가 Composable 컨텍스트 X 라 `AfternoteDesign.colors` 직접 접근 불가
- 후속 PR 가이드 명시: `shimmerLoadingPlaceholder(highlight, base)` 시그니처 변경 + 호출처 5곳 갱신 + 다크 모드 동반

### `SenderMessageHeroCard.kt` + `HeroCard.kt` — 그라데이션 정당화 KDoc
- 한 화면 1회용 + 서로 다른 색 조합 (그린계 vs 블루-피치) — 디자인 시스템 토큰 추상화하면 SSOT 위반 비용이 재사용성보다 큼
- `feedback_use_theme_colors` 룰의 예외로 본 한 곳에 고정
- `HeroCard` 의 인라인 `Brush.linearGradient(...)` 는 file-level `private val HeroGradient` 로 추출 (`SenderMessageHeroCard.heroGradient()` 패턴과 통일)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
시각 변경 없음 — 모든 색은 동일, 단지 토큰화/이름 부여/주석 보강.
[PR #302](https://github.com/Afternote/Afternote-FE/pull/302) screenshot baseline (`AfternoteSectionHeader`/`AfternoteOutlinedCard`/`ProfileImage`/`ProfileImagePicker`) `:core:ui:validateScreenshotTest` 통과 확인.

## 💬𝘛𝘠𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- **`Red = Color(0xFFFF0C0C)`** top-level val 통일은 mindrecord 영역 사용처 3곳 (`DailyQuestionWriteScreen` / `DeepThoughtWriteScreen` / `DiaryWriteScreen`) — owner (이준혁) 결정 영역이라 본 PR 범위 외
- **`ShimmerHighlight/Base` Theme 토큰화** 는 다크 모드 적용 시점에 별 PR — 호출처 5곳 (1hyok 1 + mindrecord 4) 시그니처 변경 동반
- 검증: `:app:assembleDebug` + `:core:ui:ktlintCheck` + `:feature:afternote:presentation:ktlintCheck` + `:core:ui:validateScreenshotTest` 모두 BUILD SUCCESSFUL
- 본 PR 머지 후 `feedback_color_hardcode_followup` 메모리 삭제 가능