### PR TITLE
refactor(core-ui): Red top-level val → AfternoteColors.errorStrong 토큰 흡수 (#305)

### DIFF
--- a/core/ui/src/main/kotlin/com/afternote/core/ui/theme/Color.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/theme/Color.kt
@@ -48,6 +48,14 @@ private val Accent10 = Color(0xFF3A4A8A)
 /** 시맨틱 에러/필수표시 색. 필수 입력 마커·검증 실패 등에 사용. */
 private val Error = Color(0xFFFF3647)
 
+/**
+ * 강한 에러 빨강. 본문 텍스트 강조 (예: 다이어리 작성 화면 글자 수 초과 경고) 에 사용.
+ *
+ * [Error] (`#FF3647`) 와 다른 색 — 디자인 시안에 두 토큰의 사용 컨텍스트 명확화 도착 시
+ * `error` / `errorStrong` 통합 또는 의미 재정의 가능.
+ */
+private val ErrorStrong = Color(0xFFFF0C0C)
+
 internal fun lightColors() =
     AfternoteColors(
         white = White,
@@ -74,6 +82,7 @@ internal fun lightColors() =
         accent9 = Accent9,
         accent10 = Accent10,
         error = Error,
+        errorStrong = ErrorStrong,
         isLightMode = true,
     )
 
@@ -103,6 +112,7 @@ internal fun darkColors() =
         accent9 = Accent9,
         accent10 = Accent10,
         error = Error,
+        errorStrong = ErrorStrong,
         isLightMode = false,
     )
 
@@ -136,6 +146,7 @@ class AfternoteColors(
     accent9: Color,
     accent10: Color,
     error: Color,
+    errorStrong: Color,
     isLightMode: Boolean,
 ) {
     var white by mutableStateOf(white)
@@ -186,6 +197,8 @@ class AfternoteColors(
         private set
     var error by mutableStateOf(error)
         private set
+    var errorStrong by mutableStateOf(errorStrong)
+        private set
     var isLightMode by mutableStateOf(isLightMode)
         private set
 
@@ -214,6 +227,7 @@ class AfternoteColors(
         accent9: Color = this.accent9,
         accent10: Color = this.accent10,
         error: Color = this.error,
+        errorStrong: Color = this.errorStrong,
         isLightMode: Boolean = this.isLightMode,
     ) = AfternoteColors(
         white = white,
@@ -240,6 +254,7 @@ class AfternoteColors(
         accent9 = accent9,
         accent10 = accent10,
         error = error,
+        errorStrong = errorStrong,
         isLightMode = isLightMode,
     )
 
@@ -268,8 +283,7 @@ class AfternoteColors(
         this.accent9 = other.accent9
         this.accent10 = other.accent10
         this.error = other.error
+        this.errorStrong = other.errorStrong
         this.isLightMode = other.isLightMode
     }
 }
-
-val Red = Color(0xFFFF0C0C) // 에러 메시지용 빨간색

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionWriteScreen.kt
@@ -26,7 +26,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.asString
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
-import com.afternote.core.ui.theme.Red
 import com.afternote.core.ui.topbar.DetailTopBar
 import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.component.DailyQuestionWriteHeaderCard
@@ -109,7 +108,7 @@ fun DailyQuestionWriteScreen(
                 if (errorMessage != null) {
                     Text(
                         text = errorMessage,
-                        color = Red,
+                        color = AfternoteDesign.colors.errorStrong,
                         style = AfternoteDesign.typography.captionLargeR,
                     )
                 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtWriteScreen.kt
@@ -35,7 +35,6 @@ import com.afternote.core.ui.R
 import com.afternote.core.ui.asString
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
-import com.afternote.core.ui.theme.Red
 import com.afternote.core.ui.topbar.DetailTopBar
 import com.afternote.feature.mindrecord.presentation.component.CategorySettingBottomSheet
 import com.afternote.feature.mindrecord.presentation.component.DailyDeepThoughtCard
@@ -162,7 +161,7 @@ fun DeepThoughtWriteScreen(
             if (errorMessage != null) {
                 Text(
                     text = errorMessage,
-                    color = Red,
+                    color = AfternoteDesign.colors.errorStrong,
                     style = AfternoteDesign.typography.captionLargeR,
                 )
             }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
@@ -44,7 +44,6 @@ import com.afternote.core.ui.R
 import com.afternote.core.ui.asString
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
-import com.afternote.core.ui.theme.Red
 import com.afternote.core.ui.topbar.DetailTopBar
 import com.afternote.feature.mindrecord.domain.model.TodayMood
 import com.afternote.feature.mindrecord.presentation.component.BottomSheetCalendar
@@ -217,7 +216,7 @@ fun DiaryWriteScreen(
             if (errorMessage != null) {
                 Text(
                     text = errorMessage,
-                    color = Red,
+                    color = AfternoteDesign.colors.errorStrong,
                     style = AfternoteDesign.typography.captionLargeR,
                 )
             }

--- a/feature/setting/presentation/src/main/kotlin/com/afternote/feature/setting/presentation/screen/WithdrawConfirmScreen.kt
+++ b/feature/setting/presentation/src/main/kotlin/com/afternote/feature/setting/presentation/screen/WithdrawConfirmScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.AfternoteTextField
@@ -33,7 +32,6 @@ import com.afternote.core.ui.button.AfternoteButtonType
 import com.afternote.core.ui.popup.Popup
 import com.afternote.core.ui.popup.PopupType
 import com.afternote.core.ui.theme.AfternoteDesign
-import com.afternote.core.ui.theme.Red
 import com.afternote.core.ui.topbar.DetailTopBar
 import com.afternote.feature.setting.presentation.R
 import com.afternote.feature.setting.presentation.viewmodel.SettingUiState
@@ -107,7 +105,7 @@ fun WithdrawConfirmScreen(
                 Text(
                     text = stringResource(R.string.withdraw_confirm_error),
                     style = AfternoteDesign.typography.captionLargeR,
-                    color = Red,
+                    color = AfternoteDesign.colors.errorStrong,
                 )
             }
             Spacer(Modifier.weight(1f))


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #305

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
[PR #304](https://github.com/Afternote/Afternote-FE/pull/304) 후속 — `feedback_color_hardcode_followup` 메모리의 마지막 잔여 (`core/ui/theme/Color.kt:264` 의 top-level `val Red`) 흡수.

### `core/ui/theme/Color.kt` — `errorStrong` 토큰 신설 + `Red` top-level 제거
- top-level `val Red = Color(0xFFFF0C0C)` 제거 (`feedback_use_theme_colors` 룰 위반 잔여)
- `private val ErrorStrong = Color(0xFFFF0C0C)` 신설 (KDoc: 강한 에러 빨강, PR #304 의 `error` (`#FF3647`) 와 다른 색이라 별 토큰 — 디자인 시안 확정 시 통합 또는 의미 재정의 여지)
- `AfternoteColors` 에 `errorStrong: Color` 추가 (light/dark · constructor · var · `copy()` · `update()` 7군데)

### 외부 호출처 4곳 — `Red` → `AfternoteDesign.colors.errorStrong`
- `feature:mindrecord` × 3
  - `DailyQuestionWriteScreen.kt`
  - `DeepThoughtWriteScreen.kt`
  - `DiaryWriteScreen.kt`
- `feature:setting` × 1 — `WithdrawConfirmScreen.kt` (이슈 본문은 mindrecord 3곳만 명시했으나 정찰 누락 — 빌드 단계에서 발견 후 동일 패턴 적용)

색 변경 zero (`#FF0C0C` 그대로) — 시각 회귀 없음.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
시각 변경 없음 — 단지 위치 이동 + 이름 부여. [PR #302](https://github.com/Afternote/Afternote-FE/pull/302) screenshot baseline (`AfternoteSectionHeader`/`AfternoteOutlinedCard`/`ProfileImage`/`ProfileImagePicker`) `:core:ui:validateScreenshotTest` 통과.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- **base = `feat/303` (PR #304) stack** — `Color.kt` 변경 영역이 PR #304 와 겹쳐 stack. PR #304 머지 시 base 자동 develop 으로 갱신
- **`errorStrong` 이름은 보수적** — 디자인 시안에 `#FF0C0C` vs `#FF3647` 의 사용 컨텍스트가 명확화 되면 토큰 통합 (`error` 단일) 또는 의미 재정의 가능. 본 PR 단계는 framework 의존 (top-level val) 제거 + 디자인 시스템 단일 진입점 (`AfternoteDesign.colors`) 통일까지
- **본 PR 머지 후 `feedback_color_hardcode_followup` 메모리 삭제 가능** — 4개 파일 + Red top-level + WithdrawConfirmScreen 누락분 모두 처리 완료
- 검증: `:app:assembleDebug` + `:core:ui:ktlintCheck` + `:feature:mindrecord:presentation:ktlintCheck` + `:feature:setting:presentation:ktlintCheck` + `:core:ui:validateScreenshotTest` 모두 BUILD SUCCESSFUL