### PR TITLE
ci(screenshot): validateScreenshotTest fail 시 PR comment 자동 알림 (#317)

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -37,3 +37,52 @@ jobs:
           name: screenshot-test-results
           path: core/ui/build/outputs/screenshotTest-results/
           retention-days: 7
+
+      # 실패 시 PR 에 artifact URL + 조치 가이드 자동 코멘트.
+      # 같은 PR 의 재실행에서는 기존 코멘트를 update (marker 로 중복 누적 방지).
+      - name: Comment artifact URL on PR (failure)
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- screenshot-fail-bot -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              marker,
+              '❌ **Screenshot test fail** — baseline 과 CI rendered PNG 차이.',
+              '',
+              `📦 **Artifact**: ${runUrl} (페이지 하단 Artifacts → \`screenshot-test-results\`)`,
+              '',
+              '🔍 **확인 위치** (artifact zip 내부):',
+              '- diff PNG: `preview/debug/diffs/...`',
+              '- rendered PNG: `preview/debug/rendered/...` (CI 환경에서 새로 그린 결과)',
+              '- baseline PNG: repo `core/ui/src/screenshotTestDebug/reference/...`',
+              '',
+              '📝 **조치 가이드**:',
+              '- diff 가 anti-aliasing/font 미세 차이 → rendered PNG 를 baseline 으로 교체 후 commit/push',
+              '- 의미 있는 시각 변경 → 의도 확인 후 `./gradlew :core:ui:updateScreenshotTest` 로 baseline 갱신 + commit/push',
+              '',
+              '근본 fix (docker 통일 baseline 환경) 는 별 epic.',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #317

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
`.github/workflows/screenshot.yml` 의 `if: failure()` block 에 `actions/github-script@v7` 기반 PR comment 자동 작성 step 추가.

### 변경 — `screenshot.yml`
- `Upload screenshot diff on failure` 다음에 새 step `Comment artifact URL on PR (failure)` 추가
- fail + `pull_request` 이벤트일 때만 발동 (`if: failure() && github.event_name == 'pull_request'`)
- comment 본문: artifact 다운로드 URL + 확인 위치 (diff/rendered/baseline 경로) + 조치 가이드 (baseline 교체 vs 코드 수정 결정 기준)
- marker (`<!-- screenshot-fail-bot -->`) 로 기존 comment 있으면 update, 없으면 create — 같은 PR 재실행 시 코멘트 누적 방지

### 효과
fail 발생 시 GitHub UI 의 Actions tab 안 가도 PR comment 만 봐도 다음 액션 명확. [PR #302](https://github.com/Afternote/Afternote-FE/pull/302) 의 `ProfileImagePicker` fail 처리 흐름 (artifact 다운로드 → diff 확인 → baseline 교체) 의 첫 안내 자동화.

### 범위 제외
**docker 통일 baseline 환경 (root fix)** — 별 epic. 작업 분량 크고 (Dockerfile + container workflow + 기존 31 baseline 재생성) 다른 OPEN PR baseline 충돌 위험.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
시각 변경 없음 (CI workflow 1 step 추가).

## 💬𝘛𝘠𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- **base = `develop`** — screenshot.yml 단독 변경, 다른 OPEN PR 영역과 무관
- comment 작성 권한 = `pull-requests: write` (이미 `screenshot.yml` permissions 명시됨)
- 본 PR 자체는 screenshot test fail 가능성 없음 (workflow yml 만 수정) — 본 step 의 실제 검증은 향후 fail 발생 PR 에서