### PR TITLE
fix(data): PhotoUploadRepositoryImpl OkHttp Response leak + 디버그 로그 정리 (#335)

### DIFF
--- a/core/data/src/main/java/com/afternote/core/data/repoimpl/PhotoUploadRepositoryImpl.kt
+++ b/core/data/src/main/java/com/afternote/core/data/repoimpl/PhotoUploadRepositoryImpl.kt
@@ -102,23 +102,23 @@ class PhotoUploadRepositoryImpl
                     val contentType = presigned.contentType.ifBlank { DEFAULT_CONTENT_TYPE }
                     val requestBody = tempFile.asRequestBody(contentType.toMediaType())
 
-                    val response =
-                        withContext(ioDispatcher) {
-                            s3Client
-                                .newCall(
-                                    Request
-                                        .Builder()
-                                        .url(presigned.presignedUrl)
-                                        .put(requestBody)
-                                        .header("Content-Type", contentType)
-                                        .build(),
-                                ).execute()
-                        }
-                    check(response.isSuccessful) {
-                        "S3 upload failed: ${response.code} ${response.message}"
+                    withContext(ioDispatcher) {
+                        s3Client
+                            .newCall(
+                                Request
+                                    .Builder()
+                                    .url(presigned.presignedUrl)
+                                    .put(requestBody)
+                                    .header("Content-Type", contentType)
+                                    .build(),
+                            ).execute()
+                            .use { response ->
+                                check(response.isSuccessful) {
+                                    "S3 upload failed: ${response.code} ${response.message}"
+                                }
+                            }
                     }
 
-                    android.util.Log.d("PhotoUpload", "S3 upload success → ${presigned.fileUrl}")
                     Result.success(presigned.fileUrl)
                 } finally {
                     tempFile.delete()
@@ -126,7 +126,6 @@ class PhotoUploadRepositoryImpl
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                android.util.Log.e("PhotoUpload", "upload failed", e)
                 Result.failure(e)
             }
     }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closes #335

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
[PR #263](https://github.com/Afternote/Afternote-FE/pull/263) (`VideoUploadRepositoryImpl` 회귀 fix) 진행 중 발견한 **pre-existing 같은 버그** — `PhotoUploadRepositoryImpl` 도 OkHttp `Response` 를 `.use { }` 없이 사용 → connection pool leak.

### 변경
- [PhotoUploadRepositoryImpl.kt#L115](core/data/src/main/java/com/afternote/core/data/repoimpl/PhotoUploadRepositoryImpl.kt#L115) — `.execute()` 결과를 `.use { response -> check(...) }` 블록으로 감쌈 → upload 성공/실패 모두 response.body close 보장.
- 디버그 로그 `android.util.Log.d/e("PhotoUpload", ...)` 3건 제거 — 부산물 (`#335` 본문 명시).

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
N/A (Repository 구현 변경).

## 💬𝘛𝘠𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 사진 업로드는 영상보다 사용자 진입 빈도 높음 → 누적 leak 영향 ↑
- fix 패턴은 PR #263 의 `VideoUploadRepositoryImpl` 와 동일 (그 PR 머지 시 자연스럽게 같은 컨벤션 정착)
- base = `develop`
