### PR TITLE
refactor(receiver): feature:receiver 모듈 신설 및 수신자 인증 도메인 이전 (#275)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,6 +92,7 @@ dependencies {
     // Feature — domain (홈 요약 UseCase가 마인드레코드 도메인 Repository에, 수신자 홈이 애프터노트 도메인 Repository에 직접 의존)
     implementation(projects.feature.mindrecord.domain)
     implementation(projects.feature.afternote.domain)
+    implementation(projects.feature.receiver.domain)
 
     // Feature — data (Hilt @Module / 바인딩이 루트 그래프에 포함되도록 app이 classpath에 둔다)
     implementation(projects.feature.afternote.data)

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/di/AfternoteReceiverRepositoryModule.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/di/AfternoteReceiverRepositoryModule.kt
@@ -2,8 +2,8 @@ package com.afternote.feature.afternote.data.di
 
 import com.afternote.feature.afternote.data.repositoryimpl.receiver.IdentityVerificationRepositoryImpl
 import com.afternote.feature.afternote.data.repositoryimpl.receiver.ReceiverRepositoryImpl
-import com.afternote.feature.afternote.domain.repository.receiver.IdentityVerificationRepository
 import com.afternote.feature.afternote.domain.repository.receiver.ReceiverRepository
+import com.afternote.feature.receiver.domain.repository.IdentityVerificationRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/di/ReceiverAuthRepositoryModule.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/di/ReceiverAuthRepositoryModule.kt
@@ -1,7 +1,7 @@
 package com.afternote.feature.afternote.data.di
 
 import com.afternote.feature.afternote.data.repositoryimpl.receiver.ReceiverAuthRepositoryImpl
-import com.afternote.feature.afternote.domain.repository.receiver.ReceiverAuthRepository
+import com.afternote.feature.receiver.domain.repository.ReceiverAuthRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/di/ReceiverDeliveryDocumentUploadRepositoryModule.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/di/ReceiverDeliveryDocumentUploadRepositoryModule.kt
@@ -1,7 +1,7 @@
 package com.afternote.feature.afternote.data.di
 
 import com.afternote.feature.afternote.data.repositoryimpl.receiver.ReceiverDeliveryDocumentUploadRepositoryImpl
-import com.afternote.feature.afternote.domain.repository.receiver.ReceiverDeliveryDocumentUploadRepository
+import com.afternote.feature.receiver.domain.repository.ReceiverDeliveryDocumentUploadRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/ReceiverAuthDto.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/ReceiverAuthDto.kt
@@ -1,10 +1,10 @@
 package com.afternote.feature.afternote.data.dto
 
-import com.afternote.feature.afternote.domain.model.receiver.DeliveryVerification
-import com.afternote.feature.afternote.domain.model.receiver.DeliveryVerificationStatus
-import com.afternote.feature.afternote.domain.model.receiver.ReceiverAuthPresignedUrl
-import com.afternote.feature.afternote.domain.model.receiver.ReceiverIdentity
-import com.afternote.feature.afternote.domain.model.receiver.SenderMessageInfo
+import com.afternote.feature.receiver.domain.model.DeliveryVerification
+import com.afternote.feature.receiver.domain.model.DeliveryVerificationStatus
+import com.afternote.feature.receiver.domain.model.ReceiverAuthPresignedUrl
+import com.afternote.feature.receiver.domain.model.ReceiverIdentity
+import com.afternote.feature.receiver.domain.model.SenderMessageInfo
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/response/ReceivedAfternoteDetailResponseMapper.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/response/ReceivedAfternoteDetailResponseMapper.kt
@@ -6,10 +6,10 @@ import com.afternote.feature.afternote.data.dto.ReceivedPlaylistInfo
 import com.afternote.feature.afternote.data.dto.ReceivedSongInfo
 import com.afternote.feature.afternote.data.mapper.categoryToServiceType
 import com.afternote.feature.afternote.data.mapper.formatDateFromServer
+import com.afternote.feature.afternote.domain.model.receiver.ReceivedAccountCredentials
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedAfternoteDetail
-import com.afternote.feature.receiver.domain.model.ReceivedAccountCredentials
-import com.afternote.feature.receiver.domain.model.ReceivedPlaylistDetail
-import com.afternote.feature.receiver.domain.model.ReceivedPlaylistSong
+import com.afternote.feature.afternote.domain.model.receiver.ReceivedPlaylistDetail
+import com.afternote.feature.afternote.domain.model.receiver.ReceivedPlaylistSong
 
 fun ReceivedAfternoteDetailResponse.toDomain(): ReceivedAfternoteDetail =
     ReceivedAfternoteDetail(

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/response/ReceivedAfternoteDetailResponseMapper.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/response/ReceivedAfternoteDetailResponseMapper.kt
@@ -6,10 +6,10 @@ import com.afternote.feature.afternote.data.dto.ReceivedPlaylistInfo
 import com.afternote.feature.afternote.data.dto.ReceivedSongInfo
 import com.afternote.feature.afternote.data.mapper.categoryToServiceType
 import com.afternote.feature.afternote.data.mapper.formatDateFromServer
-import com.afternote.feature.afternote.domain.model.receiver.ReceivedAccountCredentials
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedAfternoteDetail
-import com.afternote.feature.afternote.domain.model.receiver.ReceivedPlaylistDetail
-import com.afternote.feature.afternote.domain.model.receiver.ReceivedPlaylistSong
+import com.afternote.feature.receiver.domain.model.ReceivedAccountCredentials
+import com.afternote.feature.receiver.domain.model.ReceivedPlaylistDetail
+import com.afternote.feature.receiver.domain.model.ReceivedPlaylistSong
 
 fun ReceivedAfternoteDetailResponse.toDomain(): ReceivedAfternoteDetail =
     ReceivedAfternoteDetail(

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/IdentityVerificationRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/IdentityVerificationRepositoryImpl.kt
@@ -6,7 +6,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import com.afternote.feature.afternote.data.di.IdentityVerificationDataStore
-import com.afternote.feature.afternote.domain.repository.receiver.IdentityVerificationRepository
+import com.afternote.feature.receiver.domain.repository.IdentityVerificationRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImpl.kt
@@ -8,11 +8,11 @@ import com.afternote.feature.afternote.data.dto.ReceiverAuthVerifyRequest
 import com.afternote.feature.afternote.data.dto.toDomain
 import com.afternote.feature.afternote.data.service.ReceiverAuthApiService
 import com.afternote.feature.afternote.domain.error.ReceiverDeliverySubmitException
-import com.afternote.feature.afternote.domain.model.receiver.DeliveryVerification
-import com.afternote.feature.afternote.domain.model.receiver.ReceiverAuthPresignedUrl
-import com.afternote.feature.afternote.domain.model.receiver.ReceiverIdentity
-import com.afternote.feature.afternote.domain.model.receiver.SenderMessageInfo
-import com.afternote.feature.afternote.domain.repository.receiver.ReceiverAuthRepository
+import com.afternote.feature.receiver.domain.model.DeliveryVerification
+import com.afternote.feature.receiver.domain.model.ReceiverAuthPresignedUrl
+import com.afternote.feature.receiver.domain.model.ReceiverIdentity
+import com.afternote.feature.receiver.domain.model.SenderMessageInfo
+import com.afternote.feature.receiver.domain.repository.ReceiverAuthRepository
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverDeliveryDocumentUploadRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverDeliveryDocumentUploadRepositoryImpl.kt
@@ -1,8 +1,8 @@
 package com.afternote.feature.afternote.data.repositoryimpl.receiver
 
 import com.afternote.core.common.di.IoDispatcher
-import com.afternote.feature.afternote.domain.repository.receiver.ReceiverAuthRepository
-import com.afternote.feature.afternote.domain.repository.receiver.ReceiverDeliveryDocumentUploadRepository
+import com.afternote.feature.receiver.domain.repository.ReceiverAuthRepository
+import com.afternote.feature.receiver.domain.repository.ReceiverDeliveryDocumentUploadRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverRepositoryImpl.kt
@@ -13,9 +13,9 @@ import com.afternote.feature.afternote.domain.model.receiver.AfterNotesListResul
 import com.afternote.feature.afternote.domain.model.receiver.LoadCountResult
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedAfternoteDetail
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedExportBundle
-import com.afternote.feature.afternote.domain.model.receiver.SenderMessageInfo
-import com.afternote.feature.afternote.domain.repository.receiver.ReceiverAuthRepository
 import com.afternote.feature.afternote.domain.repository.receiver.ReceiverRepository
+import com.afternote.feature.receiver.domain.model.SenderMessageInfo
+import com.afternote.feature.receiver.domain.repository.ReceiverAuthRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject

--- a/feature/afternote/domain/build.gradle.kts
+++ b/feature/afternote/domain/build.gradle.kts
@@ -7,6 +7,7 @@ android {
 }
 dependencies {
     implementation(projects.core.domain)
+    implementation(projects.feature.receiver.domain)
     implementation(libs.coroutines.core)
     implementation(libs.androidx.paging.common)
 }

--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/repository/receiver/ReceiverRepository.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/repository/receiver/ReceiverRepository.kt
@@ -6,7 +6,7 @@ import com.afternote.feature.afternote.domain.model.receiver.AfterNotesListResul
 import com.afternote.feature.afternote.domain.model.receiver.LoadCountResult
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedAfternoteDetail
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedExportBundle
-import com.afternote.feature.afternote.domain.model.receiver.SenderMessageInfo
+import com.afternote.feature.receiver.domain.model.SenderMessageInfo
 import kotlinx.coroutines.flow.Flow
 
 /**

--- a/feature/afternote/presentation/build.gradle.kts
+++ b/feature/afternote/presentation/build.gradle.kts
@@ -13,6 +13,7 @@ android {
 
 dependencies {
     implementation(projects.feature.afternote.domain)
+    implementation(projects.feature.receiver.domain)
     implementation(projects.core.datastore)
     implementation(projects.core.domain)
     implementation(projects.core.model)

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DeliveryVerificationFlowViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DeliveryVerificationFlowViewModel.kt
@@ -4,8 +4,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import com.afternote.feature.afternote.domain.repository.receiver.IdentityVerificationRepository
 import com.afternote.feature.afternote.presentation.receiver.navigation.model.ReceiverRoute
+import com.afternote.feature.receiver.domain.repository.IdentityVerificationRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadViewModel.kt
@@ -3,9 +3,9 @@ package com.afternote.feature.afternote.presentation.receiver.deliveryverificati
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.afternote.feature.afternote.domain.error.ReceiverDeliverySubmitException
-import com.afternote.feature.afternote.domain.repository.receiver.ReceiverAuthRepository
-import com.afternote.feature.afternote.domain.repository.receiver.ReceiverDeliveryDocumentUploadRepository
 import com.afternote.feature.afternote.presentation.R
+import com.afternote.feature.receiver.domain.repository.ReceiverAuthRepository
+import com.afternote.feature.receiver.domain.repository.ReceiverDeliveryDocumentUploadRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/IdentityVerificationViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/IdentityVerificationViewModel.kt
@@ -2,8 +2,8 @@ package com.afternote.feature.afternote.presentation.receiver.deliveryverificati
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.afternote.feature.afternote.domain.repository.receiver.IdentityVerificationRepository
 import com.afternote.feature.afternote.presentation.R
+import com.afternote.feature.receiver.domain.repository.IdentityVerificationRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/MasterKeyViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/MasterKeyViewModel.kt
@@ -2,10 +2,10 @@ package com.afternote.feature.afternote.presentation.receiver.deliveryverificati
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.afternote.feature.afternote.domain.repository.receiver.ReceiverAuthRepository
 import com.afternote.feature.afternote.domain.repository.receiver.ReceiverRepository
 import com.afternote.feature.afternote.presentation.R
 import com.afternote.feature.afternote.presentation.receiver.recordsbox.SenderRegistry
+import com.afternote.feature.receiver.domain.repository.ReceiverAuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/navigation/model/ReceiverRoute.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/navigation/model/ReceiverRoute.kt
@@ -66,7 +66,7 @@ sealed interface ReceiverRoute {
     /**
      * 본인 확인 이메일 인증 화면(designs 3·4). 인증 시작하기 → 진입.
      *
-     * 인증 성공 시 [com.afternote.feature.afternote.domain.repository.receiver.IdentityVerificationRepository]
+     * 인증 성공 시 [com.afternote.feature.receiver.domain.repository.IdentityVerificationRepository]
      * 캐시가 켜져 이후 동일 사용자(폰)에서는 마스터 키로 직진. DataStore 영구 저장이라 앱 재시작 후에도 유지.
      */
     @Serializable

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/recordsbox/SenderEntry.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/recordsbox/SenderEntry.kt
@@ -1,7 +1,7 @@
 package com.afternote.feature.afternote.presentation.receiver.recordsbox
 
 import androidx.compose.runtime.Immutable
-import com.afternote.feature.afternote.domain.model.receiver.DeliveryVerificationStatus
+import com.afternote.feature.receiver.domain.model.DeliveryVerificationStatus
 
 /**
  * 받은 기록함 카드 한 줄의 표시 데이터.
@@ -11,7 +11,7 @@ import com.afternote.feature.afternote.domain.model.receiver.DeliveryVerificatio
  *
  * `authCode` 는 마스터 키 검증 성공 후 채워지며, "기록 열람하기" 진입 시 [com.afternote.feature.afternote
  * .domain.repository.receiver.ReceiverRepository.saveAuthCode] 로 글로벌 헤더 컨텍스트에 복원한다.
- * `realSenderName`·`relation` 은 [com.afternote.feature.afternote.domain.model.receiver.ReceiverIdentity]
+ * `realSenderName`·`relation` 은 [com.afternote.feature.receiver.domain.model.ReceiverIdentity]
  * 응답에서 수신한 값으로 발신자 상세(11·12)의 인사말 및 관계 표기에 사용한다.
  *
  * `verificationStatus` 는 가장 최근에 조회한 열람 신청 상태 캐시. 발신자 상세 진입 시 서버 호출 결과로

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/recordsbox/SenderRegistry.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/recordsbox/SenderRegistry.kt
@@ -1,7 +1,7 @@
 package com.afternote.feature.afternote.presentation.receiver.recordsbox
 
-import com.afternote.feature.afternote.domain.model.receiver.DeliveryVerificationStatus
-import com.afternote.feature.afternote.domain.model.receiver.ReceiverIdentity
+import com.afternote.feature.receiver.domain.model.DeliveryVerificationStatus
+import com.afternote.feature.receiver.domain.model.ReceiverIdentity
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/senderdetail/SenderDetailViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/senderdetail/SenderDetailViewModel.kt
@@ -4,13 +4,13 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import com.afternote.feature.afternote.domain.model.receiver.DeliveryVerification
-import com.afternote.feature.afternote.domain.model.receiver.DeliveryVerificationStatus
-import com.afternote.feature.afternote.domain.repository.receiver.ReceiverAuthRepository
 import com.afternote.feature.afternote.domain.repository.receiver.ReceiverRepository
 import com.afternote.feature.afternote.presentation.receiver.navigation.model.ReceiverRoute
 import com.afternote.feature.afternote.presentation.receiver.recordsbox.SenderEntry
 import com.afternote.feature.afternote.presentation.receiver.recordsbox.SenderRegistry
+import com.afternote.feature.receiver.domain.model.DeliveryVerification
+import com.afternote.feature.receiver.domain.model.DeliveryVerificationStatus
+import com.afternote.feature.receiver.domain.repository.ReceiverAuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/feature/receiver/data/build.gradle.kts
+++ b/feature/receiver/data/build.gradle.kts
@@ -3,15 +3,13 @@ plugins {
 }
 
 android {
-    namespace = "com.afternote.feature.afternote.data"
+    namespace = "com.afternote.feature.receiver.data"
 }
 
 dependencies {
     implementation(libs.androidx.datastore.preferences)
-    implementation(libs.androidx.paging.runtime)
     implementation(projects.core.common)
     implementation(projects.core.domain)
     implementation(projects.core.model)
-    implementation(projects.feature.afternote.domain)
     implementation(projects.feature.receiver.domain)
 }

--- a/feature/receiver/data/src/main/AndroidManifest.xml
+++ b/feature/receiver/data/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest>
+
+</manifest>

--- a/feature/receiver/domain/build.gradle.kts
+++ b/feature/receiver/domain/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    id("afternote.android.domain")
+}
+
+android {
+    namespace = "com.afternote.feature.receiver.domain"
+}
+dependencies {
+    implementation(projects.core.domain)
+    implementation(libs.coroutines.core)
+}

--- a/feature/receiver/domain/src/main/java/com/afternote/feature/receiver/domain/model/ReceiverAuthModels.kt
+++ b/feature/receiver/domain/src/main/java/com/afternote/feature/receiver/domain/model/ReceiverAuthModels.kt
@@ -1,4 +1,4 @@
-package com.afternote.feature.afternote.domain.model.receiver
+package com.afternote.feature.receiver.domain.model
 
 data class ReceiverIdentity(
     val receiverId: Long,

--- a/feature/receiver/domain/src/main/java/com/afternote/feature/receiver/domain/repository/IdentityVerificationRepository.kt
+++ b/feature/receiver/domain/src/main/java/com/afternote/feature/receiver/domain/repository/IdentityVerificationRepository.kt
@@ -1,4 +1,4 @@
-package com.afternote.feature.afternote.domain.repository.receiver
+package com.afternote.feature.receiver.domain.repository
 
 import kotlinx.coroutines.flow.Flow
 

--- a/feature/receiver/domain/src/main/java/com/afternote/feature/receiver/domain/repository/ReceiverAuthRepository.kt
+++ b/feature/receiver/domain/src/main/java/com/afternote/feature/receiver/domain/repository/ReceiverAuthRepository.kt
@@ -1,9 +1,9 @@
-package com.afternote.feature.afternote.domain.repository.receiver
+package com.afternote.feature.receiver.domain.repository
 
-import com.afternote.feature.afternote.domain.model.receiver.DeliveryVerification
-import com.afternote.feature.afternote.domain.model.receiver.ReceiverAuthPresignedUrl
-import com.afternote.feature.afternote.domain.model.receiver.ReceiverIdentity
-import com.afternote.feature.afternote.domain.model.receiver.SenderMessageInfo
+import com.afternote.feature.receiver.domain.model.DeliveryVerification
+import com.afternote.feature.receiver.domain.model.ReceiverAuthPresignedUrl
+import com.afternote.feature.receiver.domain.model.ReceiverIdentity
+import com.afternote.feature.receiver.domain.model.SenderMessageInfo
 
 /**
  * 수신자 인증 흐름 전용 Repository (`receiver-auth/...` 경로).

--- a/feature/receiver/domain/src/main/java/com/afternote/feature/receiver/domain/repository/ReceiverDeliveryDocumentUploadRepository.kt
+++ b/feature/receiver/domain/src/main/java/com/afternote/feature/receiver/domain/repository/ReceiverDeliveryDocumentUploadRepository.kt
@@ -1,4 +1,4 @@
-package com.afternote.feature.afternote.domain.repository.receiver
+package com.afternote.feature.receiver.domain.repository
 
 /**
  * 수신자 열람 신청 흐름의 증빙 서류 업로드 전용 Repository (이슈 #215, 디자인 6·7·8).

--- a/feature/receiver/presentation/build.gradle.kts
+++ b/feature/receiver/presentation/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    id("afternote.android.library.compose")
+    id("afternote.android.hilt")
+}
+
+android {
+    namespace = "com.afternote.feature.receiver.presentation"
+}
+
+dependencies {
+    implementation(projects.feature.receiver.domain)
+    implementation(projects.core.domain)
+    implementation(projects.core.model)
+    implementation(projects.core.common)
+    implementation(projects.core.ui)
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.android.navigation.compose)
+    implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.hilt.navigation)
+    implementation(libs.androidx.lifecycle.viewmodel.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
+}

--- a/feature/receiver/presentation/src/main/AndroidManifest.xml
+++ b/feature/receiver/presentation/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest>
+
+</manifest>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -53,6 +53,10 @@ include(":feature:onboarding:data")
 include(":feature:onboarding:domain")
 include(":feature:onboarding:presentation")
 
+include(":feature:receiver:data")
+include(":feature:receiver:domain")
+include(":feature:receiver:presentation")
+
 include(":feature:setting:data")
 include(":feature:setting:domain")
 include(":feature:setting:presentation")


### PR DESCRIPTION
## 📌Issues
_Closes #275_

## 📎Work Description
_(a) `feature:receiver/{data,domain,presentation}` 3 모듈 신설 — `settings.gradle.kts` 등록 + 기초 `build.gradle.kts` / `AndroidManifest.xml`._
_(b) `receiver:domain` 으로 이전 — `ReceiverAuthModels` (`ReceiverIdentity` · `ReceiverAuthPresignedUrl` · `DeliveryVerification` · `DeliveryVerificationStatus` · `SenderMessageInfo`) + 3 인터페이스 (`ReceiverAuthRepository` · `IdentityVerificationRepository` · `ReceiverDeliveryDocumentUploadRepository`) 의 패키지 경로 변경 (`com.afternote.feature.afternote.domain.*` → `com.afternote.feature.receiver.domain.*`)._
_(c) afternote 측 정리 — `data` / `presentation` import 경로 수정, `data` · `domain` · `presentation` 가 `feature:receiver:domain` 참조하도록 의존 추가._
_(d) `:app` 에 `feature:receiver:domain` 직접 의존 추가 — `ReceiverHomeViewModel` 이 `ReceiverRepository.loadSenderMessage()` 의 반환형 `SenderMessageInfo` (receiver:domain) 를 직접 다루므로 classpath 노출 필요._
_(e) 매퍼 import 정정 — `ReceivedAccountCredentials` · `ReceivedPlaylistDetail` · `ReceivedPlaylistSong` 는 부모 `ReceivedAfternoteDetail` 과 함께 옮길 수 없어 `afternote:domain.model.receiver` 잔류. 직전 커밋에서 클래스 본체 이동 없이 import 만 새 경로로 바꿔놨던 오류 정정._

## 📷Screenshot
_시각 변경 없음. 모듈/패키지 구조 정리._

## 💬To Reviewers
_• 본 PR 은 이슈 #275 의 (d) "data/domain receiver 인프라 분리" + 모듈 skeleton 작업. presentation 측 실제 이동 ((a) `recordsbox/` + `senderdetail/`, (b) `deliveryverification/`, (c) `navigation/`) 은 별도 브랜치 3개로 단계 분할 예정._
_• `Received*` 자식 클래스 잔류 결정 사유: 부모 `ReceivedAfternoteDetail` 이 `AfternoteServiceType` (afternote:domain) 의존이라 함께 receiver:domain 으로 옮기면 역의존 발생. 자식만 분리하면 형제가 다른 모듈에 흩어져 가독성 악화. 부모/자식 한 묶음 `afternote:domain.model.receiver` 유지._
_• `ReceiverRepository` 인터페이스도 `ReceivedAfternoteDetail` 등 afternote:domain 모델을 반환하므로 afternote:domain 잔류 — 수신자 측 애프터노트 조회 API 모음이라 의미상 더 맞음. 반환형 중 `SenderMessageInfo` 한 곳만 receiver:domain 참조._
_• `afternote:domain` 의 `implementation(projects.feature.receiver.domain)` 를 `api(...)` 로 바꿔서 transitive 노출도 가능하나, 본 repo convention 은 `:app` 에 필요 도메인 직접 명시 (`app/build.gradle.kts` 의 mindrecord/afternote domain 주석 참조). 그쪽 따랐음._