### PR TITLE
refactor(core-ui): AfternoteFieldContainer modifier default 표준화 + fillMaxWidth 호출부 위임 (#341)

### DIFF
--- a/core/ui/src/main/kotlin/com/afternote/core/ui/AfternoteFieldContainer.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/AfternoteFieldContainer.kt
@@ -8,12 +8,15 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
+import com.afternote.core.ui.theme.AfternoteTheme
 
 /**
  * 입력 필드 / 슬롯 카드 등 디자인 시스템의 시각 컨테이너 단위.
@@ -23,6 +26,10 @@ import com.afternote.core.ui.theme.AfternoteDesign
  * 을 별도로 박아두던 것을 한 곳으로 모은다.
  *
  * [onClick] 을 주면 ripple 이 둥근 코너 안쪽으로 잘리도록 `clip` 뒤에 `clickable` 이 걸린다.
+ *
+ * 폭 / 크기 정책은 호출부가 [modifier] 로 결정 (Compose API 가이드라인: element function 의 modifier
+ * default 는 빈 `Modifier`). 부모 폭 차지가 필요하면 `Modifier.fillMaxWidth()`, Row 안에서
+ * 가변 비율이면 `Modifier.weight(...)` 등을 명시적으로 넘긴다.
  */
 @Composable
 fun AfternoteFieldContainer(
@@ -35,7 +42,6 @@ fun AfternoteFieldContainer(
     Row(
         modifier =
             modifier
-                .fillMaxWidth()
                 .clip(RoundedCornerShape(8.dp))
                 .background(AfternoteDesign.colors.white)
                 .border(1.dp, AfternoteDesign.colors.gray2, RoundedCornerShape(8.dp))
@@ -49,4 +55,22 @@ fun AfternoteFieldContainer(
         verticalAlignment = verticalAlignment,
         content = content,
     )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AfternoteFieldContainerPreview() {
+    AfternoteTheme {
+        AfternoteFieldContainer(
+            modifier =
+                Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth(),
+        ) {
+            Text(
+                text = "Sample Field Container Content",
+                style = AfternoteDesign.typography.bodyLargeR,
+            )
+        }
+    }
 }

--- a/core/ui/src/main/kotlin/com/afternote/core/ui/TextFieldShort.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/TextFieldShort.kt
@@ -96,7 +96,7 @@ private fun TextFieldShort(
         textStyle = AfternoteDesign.typography.textField.copy(color = AfternoteDesign.colors.gray9), // 👈 무조건 textField 스타일 고정!
         cursorBrush = SolidColor(AfternoteDesign.colors.black),
         decorator = { innerTextField ->
-            AfternoteFieldContainer {
+            AfternoteFieldContainer(modifier = Modifier.fillMaxWidth()) {
                 Row(
                     modifier = Modifier.weight(1f),
                     verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
## 📌 *Issues*

- Closes #341
- PR #250 (#222) stack — base = `feat/222`

## 📎 *Work Description*

- `AfternoteFieldContainer.kt`
  - `modifier: Modifier = Modifier.fillMaxWidth()` → `modifier: Modifier = Modifier` (Compose API 가이드라인 준수)
  - Row 내부 `.fillMaxWidth()` 제거 — 폭/크기 정책을 호출부가 결정
  - `fillMaxWidth` import 제거, KDoc 보강 + Preview 추가
- `TextFieldShort.kt:99` — decorator 의 `AfternoteFieldContainer { ... }` 를 `AfternoteFieldContainer(modifier = Modifier.fillMaxWidth()) { ... }` 로 명시
- `DocumentSlotCard.kt:61` — 호출부가 이미 `modifier = Modifier.weight(1f)` 명시 → 영향 없음

## 📷 *Screenshot*

시각 결과 동일 (Row 가 호출부의 `Modifier.fillMaxWidth()` 받아 동일 폭). screenshot test baseline 변화 없음.

## 💬 *To Reviewers*

- base = `feat/222` stack. PR #250 머지 후 develop 위로 자동 정렬됨
- 가이드라인 근거: element function 의 modifier default 는 **MUST** `Modifier` (빈 companion object). https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md
- #341 issue body 의 첫 번째 우려 ("modifier 노드 위치 분리 — 호출부에서 .background/.size 등 시각 modifier 를 넘기면 시각 박스와 분리된 위치 적용") 는 현 호출처 모두 padding 만 넘기고 있어 무해. 향후 시각 modifier 를 넘기는 호출 케이스 발생 시 `outerModifier`/`contentModifier` 분리 API 별 follow-up 예정 — Non-blocking