### PR TITLE
build(core-ui, app): 미사용 material.icons.extended dead dependency 제거 (#348)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,7 +69,6 @@ android {
 
 dependencies {
     implementation(libs.coil.compose)
-    implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.core.splashscreen)
 

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
     implementation(libs.androidx.compose.material.icons.core)
-    implementation(libs.androidx.compose.material.icons.extended)
 
     // Compose Preview Screenshot Testing (#241)
     screenshotTestImplementation(libs.screenshot.validation.api)


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #348

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `core/ui/build.gradle.kts` · `app/build.gradle.kts` 에서 `libs.androidx.compose.material.icons.extended` 의존성 제거
- 두 모듈 모두 `androidx.compose.material.icons.*` 실사용 0건 확인 → 코드 변경 없이 의존성 줄만 삭제 (`icons.core` 는 유지)
- `:core:ui:compileDebugKotlin` + `:app:compileDebugKotlin` 회귀 없음 확인

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- 해당 없음 (의존성 정리, 시각 변경 無)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- #337([PR #347](https://github.com/Afternote/Afternote-FE/pull/347)) 의 본인 영역(코어·홈) 잔여 정리입니다. `feature/timeletter` 의 동일 의존성은 kyungmin 영역이라 별도로 둡니다.
- 팀 가이드상 `material.icons.extended` 는 비권장(필요 아이콘은 vector image asset)이라, 이걸로 본인 영역 `icons.extended` 위반 0이 됩니다.