### PR TITLE
refactor(core, onboarding): 이메일 인증 phantom isVerified 모델 제거 — 검증 게이트 HTTP status 단일화 (#355)

### DIFF
--- a/core/data/src/main/java/com/afternote/core/data/mapper/auth/AuthMapper.kt
+++ b/core/data/src/main/java/com/afternote/core/data/mapper/auth/AuthMapper.kt
@@ -1,21 +1,16 @@
 package com.afternote.core.data.mapper.auth
 
 import com.afternote.core.model.AccountRegistration
-import com.afternote.core.model.EmailVerification
 import com.afternote.core.model.Session
 import com.afternote.core.model.TokenBundle
 import com.afternote.core.network.dto.LoginData
 import com.afternote.core.network.dto.ReissueData
 import com.afternote.core.network.dto.SignUpData
-import com.afternote.core.network.dto.VerifyEmailData
 
 /**
  * Auth DTO를 Domain 모델로 변환. (스웨거 기준)
- * TODO:리팩토링 점검 필요
  */
 object AuthMapper {
-    fun toEmailVerifyResult(dto: VerifyEmailData): EmailVerification = EmailVerification(isVerified = dto.isVerified ?: true)
-
     fun toSignUpResult(dto: SignUpData): AccountRegistration = AccountRegistration(userId = dto.userId, email = dto.email)
 
     fun toDefaultLoginResult(dto: LoginData.DefaultLoginData): Session.DefaultSession =

--- a/core/data/src/main/java/com/afternote/core/data/repoimpl/account/AccountRepositoryImpl.kt
+++ b/core/data/src/main/java/com/afternote/core/data/repoimpl/account/AccountRepositoryImpl.kt
@@ -3,11 +3,9 @@ package com.afternote.core.data.repoimpl.account
 import com.afternote.core.data.mapper.auth.AuthMapper
 import com.afternote.core.domain.repository.account.AccountRepository
 import com.afternote.core.model.AccountRegistration
-import com.afternote.core.model.EmailVerification
 import com.afternote.core.network.dto.PasswordChangeRequest
 import com.afternote.core.network.dto.SendEmailCodeRequest
 import com.afternote.core.network.dto.SignUpRequest
-import com.afternote.core.network.dto.VerifyEmailData
 import com.afternote.core.network.dto.VerifyEmailRequest
 import com.afternote.core.network.model.requireData
 import com.afternote.core.network.model.requireStatus
@@ -28,18 +26,15 @@ class AccountRepositoryImpl
         override suspend fun verifyEmail(
             email: String,
             certificateCode: String,
-        ): Result<EmailVerification> =
+        ): Result<Unit> =
             runCatching {
-                val response =
-                    accountApiService.verifyEmail(
+                accountApiService
+                    .verifyEmail(
                         VerifyEmailRequest(
                             email,
                             certificateCode,
                         ),
-                    )
-                response.requireStatus()
-
-                AuthMapper.toEmailVerifyResult(response.data ?: VerifyEmailData(isVerified = null))
+                    ).requireStatus()
             }
 
         override suspend fun signUp(

--- a/core/data/src/test/java/com/afternote/core/data/mapper/auth/AuthMapperTest.kt
+++ b/core/data/src/test/java/com/afternote/core/data/mapper/auth/AuthMapperTest.kt
@@ -1,0 +1,58 @@
+package com.afternote.core.data.mapper.auth
+
+import com.afternote.core.model.Session
+import com.afternote.core.network.dto.LoginData
+import com.afternote.core.network.dto.ReissueData
+import com.afternote.core.network.dto.SignUpData
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * [AuthMapper] DTO→Domain 변환 회귀 가드. 토큰/식별자 필드의 누락·뒤바뀜을 막는다.
+ */
+class AuthMapperTest {
+    @Test
+    fun `toSignUpResult - userId·email 전달`() {
+        val result = AuthMapper.toSignUpResult(SignUpData(userId = 42L, email = "a@b.com"))
+        assertEquals(42L, result.userId)
+        assertEquals("a@b.com", result.email)
+    }
+
+    @Test
+    fun `toDefaultLoginResult - 토큰 전달 + DefaultSession 매핑`() {
+        val result =
+            AuthMapper.toDefaultLoginResult(
+                LoginData.DefaultLoginData(accessToken = "at", refreshToken = "rt"),
+            )
+        assertEquals(Session.DefaultSession(accessToken = "at", refreshToken = "rt"), result)
+    }
+
+    @Test
+    fun `toSocialLoginResult - 토큰·isNewUser 전달`() {
+        val result =
+            AuthMapper.toSocialLoginResult(
+                LoginData.SocialLoginData(accessToken = "at", refreshToken = "rt", isNewUser = true),
+            )
+        assertEquals(
+            Session.SocialSession(accessToken = "at", refreshToken = "rt", isNewUser = true),
+            result,
+        )
+    }
+
+    @Test
+    fun `toSocialLoginResult - isNewUser null 보존`() {
+        val result =
+            AuthMapper.toSocialLoginResult(
+                LoginData.SocialLoginData(accessToken = "at", refreshToken = "rt", isNewUser = null),
+            )
+        assertNull(result.isNewUser)
+    }
+
+    @Test
+    fun `toRotateTokenResult - 토큰 전달`() {
+        val result = AuthMapper.toRotateTokenResult(ReissueData(accessToken = "at", refreshToken = "rt"))
+        assertEquals("at", result.accessToken)
+        assertEquals("rt", result.refreshToken)
+    }
+}

--- a/core/domain/src/main/java/com/afternote/core/domain/repository/account/AccountRepository.kt
+++ b/core/domain/src/main/java/com/afternote/core/domain/repository/account/AccountRepository.kt
@@ -1,7 +1,6 @@
 package com.afternote.core.domain.repository.account
 
 import com.afternote.core.model.AccountRegistration
-import com.afternote.core.model.EmailVerification
 
 interface AccountRepository {
     suspend fun sendEmailCode(email: String): Result<Unit>
@@ -9,7 +8,7 @@ interface AccountRepository {
     suspend fun verifyEmail(
         email: String,
         certificateCode: String,
-    ): Result<EmailVerification>
+    ): Result<Unit>
 
     suspend fun signUp(
         email: String,

--- a/core/model/src/main/kotlin/com/afternote/core/model/AuthResult.kt
+++ b/core/model/src/main/kotlin/com/afternote/core/model/AuthResult.kt
@@ -1,13 +1,6 @@
 package com.afternote.core.model
 
 /**
- * 이메일 인증번호 확인 성공 결과.
- */
-data class EmailVerification(
-    val isVerified: Boolean,
-)
-
-/**
  * 회원가입 성공 결과. (스웨거: userId)
  */
 data class AccountRegistration(

--- a/core/network/src/main/kotlin/com/afternote/core/network/dto/AuthDto.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/dto/AuthDto.kt
@@ -15,11 +15,6 @@ data class VerifyEmailRequest(
 )
 
 @Serializable
-data class VerifyEmailData(
-    val isVerified: Boolean? = null,
-)
-
-@Serializable
 data class SignUpRequest(
     val email: String,
     val password: String,

--- a/core/network/src/main/kotlin/com/afternote/core/network/model/BaseResponse.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/model/BaseResponse.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.io.IOException
 
+/** 서버 공통 응답 봉투. 제네릭 [T] 는 `data` 필드의 페이로드 타입 — `data` 없는 엔드포인트는 `BaseResponse<Unit>`. */
 @Serializable
 data class BaseResponse<T>(
     @SerialName("status")

--- a/core/network/src/main/kotlin/com/afternote/core/network/service/AccountApiService.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/service/AccountApiService.kt
@@ -4,7 +4,6 @@ import com.afternote.core.network.dto.PasswordChangeRequest
 import com.afternote.core.network.dto.SendEmailCodeRequest
 import com.afternote.core.network.dto.SignUpData
 import com.afternote.core.network.dto.SignUpRequest
-import com.afternote.core.network.dto.VerifyEmailData
 import com.afternote.core.network.dto.VerifyEmailRequest
 import com.afternote.core.network.model.BaseResponse
 import retrofit2.http.Body
@@ -19,7 +18,7 @@ interface AccountApiService {
     @POST("auth/email/verify")
     suspend fun verifyEmail(
         @Body body: VerifyEmailRequest,
-    ): BaseResponse<VerifyEmailData>
+    ): BaseResponse<Unit>
 
     @POST("auth/sign-up")
     suspend fun signUp(

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
@@ -170,12 +170,8 @@ class SignUpViewModel
                     .verifyEmail(
                         email = state.email,
                         certificateCode = state.verificationCode,
-                    ).onSuccess { result ->
-                        if (result.isVerified) {
-                            _uiState.update { it.copy(shouldNavigateToResidentNumber = true) }
-                        } else {
-                            _uiState.update { it.copy(errorMessage = "인증번호가 일치하지 않습니다") }
-                        }
+                    ).onSuccess {
+                        _uiState.update { it.copy(shouldNavigateToResidentNumber = true) }
                     }.onFailure { error ->
                         _uiState.update { it.copy(errorMessage = error.message ?: "이메일 인증 실패") }
                     }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #355

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 서버가 주지 않는 `isVerified` phantom 필드 모델 제거 — 이메일 인증 검증 게이트를 HTTP status(= `Result` 성공/실패)로 단일화
- `VerifyEmailData` · `EmailVerification` · `AuthMapper.toEmailVerifyResult` 삭제 → `AccountApiService.verifyEmail`·`AccountRepository.verifyEmail` 을 `BaseResponse<Unit>`·`Result<Unit>` 로 (`sendEmailCode`·`passwordChange` 와 동일 패턴)
- `SignUpViewModel.verifyEmailAndProceed` 의 도달 불가능한 `else`(서버가 200+false 를 보내지 않음) 제거 → `onSuccess { 진행 } onFailure { 에러 }`
- `BaseResponse` 에 data 없는 엔드포인트용 가이드 주석 1줄 추가
- 근거: Afternote-BE `AuthController`/`AuthService` 의 `emailVerify` — 코드 정답 시 `data: null`(응답에 `isVerified` 필드 없음), 오답은 비-200 예외로 응답 → 검증 결과는 HTTP status 로만 표현

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- 해당 없음 (네트워크·도메인 정리, 시각 변경 無)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- `AuthMapperTest`(회원가입·로그인·토큰 재발급 매핑 회귀 테스트)는 원래 #351 작업물인데, phantom `toEmailVerifyResult` 케이스만 제외하고 이 커밋에 함께 넣었습니다. #351 은 이 PR 로 흡수됩니다.
- 검증: `:feature:onboarding:presentation:compileDebugKotlin :core:data:testDebugUnitTest` → BUILD SUCCESSFUL.
