### PR TITLE
fix(onboarding): 소셜 신규 유저(newUser:true) 로그인 시 Welcome 온보딩 진입 (#357)

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
@@ -35,6 +35,14 @@ fun rememberOnboardingNavActions(navController: NavController): OnboardingNavAct
                 }
             }
 
+            override fun replaceLoginWithWelcome() {
+                navController.navigate(OnboardingRoute.WelcomeRoute) {
+                    // 소셜 신규 가입자 — Login(과 그 아래 Welcome)을 비우고 새 Welcome 진입. 뒤로가기로 Login 에 못 돌아가게.
+                    popUpTo<OnboardingRoute.WelcomeRoute> { inclusive = true }
+                    launchSingleTop = true
+                }
+            }
+
             override fun navigateToSignUp() {
                 navController.navigate(OnboardingRoute.SignUpRoute)
             }

--- a/core/domain/src/main/java/com/afternote/core/domain/usecase/auth/LoginUseCase.kt
+++ b/core/domain/src/main/java/com/afternote/core/domain/usecase/auth/LoginUseCase.kt
@@ -24,7 +24,11 @@ class LoginUseCase
     constructor(
         private val authRepository: AuthRepository,
     ) {
-        suspend operator fun invoke(loginType: LoginType): Result<Unit> {
+        /**
+         * 로그인 후 세션을 저장한다. 반환 [Boolean] 은 "온보딩이 필요한 소셜 신규 가입자"인지 —
+         * 소셜 로그인 `newUser == true` 만 `true`, 이메일·기존 유저는 `false` (`newUser` 가 null 이어도 false).
+         */
+        suspend operator fun invoke(loginType: LoginType): Result<Boolean> {
             val sessionResult: Result<Session> =
                 when (loginType) {
                     is LoginType.Email -> {
@@ -48,9 +52,13 @@ class LoginUseCase
                     return Result.failure(exception)
                 }
 
-            return authRepository.saveSession(
-                accessToken = session.accessToken,
-                refreshToken = session.refreshToken,
-            )
+            return authRepository
+                .saveSession(
+                    accessToken = session.accessToken,
+                    refreshToken = session.refreshToken,
+                ).map {
+                    // 소셜 로그인이고 서버가 newUser=true 를 준 경우만 신규. 이메일(cast→null)·false·null 은 `== true` 로 모두 false.
+                    (session as? Session.SocialSession)?.isNewUser == true
+                }
         }
     }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginEntry.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginEntry.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun LoginEntry(
     onLoginSuccess: () -> Unit,
+    onNewUserOnboarding: () -> Unit,
     onSignUpClick: () -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -71,6 +72,12 @@ fun LoginEntry(
         if (uiState.isLoggedIn) {
             onLoginSuccess()
             viewModel.onLoggedInConsumed()
+        }
+    }
+    LaunchedEffect(uiState.shouldStartOnboarding) {
+        if (uiState.shouldStartOnboarding) {
+            onNewUserOnboarding()
+            viewModel.onOnboardingStartConsumed()
         }
     }
     val pendingErrorMessage = uiState.errorMessage

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginUiState.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginUiState.kt
@@ -3,18 +3,20 @@ package com.afternote.feature.onboarding.presentation.login
 /**
  * 로그인 화면 단일 UI 상태.
  *
- * 입력값(email/password) · 진행 플래그(isLoading) · 단발성 신호(isLoggedIn · errorMessage)
+ * 입력값(email/password) · 진행 플래그(isLoading) · 단발성 신호(isLoggedIn · shouldStartOnboarding · errorMessage)
  * 를 한 인스턴스로 묶어 reducer (`_uiState.update { copy(...) }`) 로 갱신한다.
  *
- * 단발성 신호는 UI 가 소비 후 [LoginViewModel.onLoggedInConsumed] /
+ * 단발성 신호는 UI 가 소비 후 [LoginViewModel.onLoggedInConsumed] / [LoginViewModel.onOnboardingStartConsumed] /
  * [LoginViewModel.onErrorConsumed] 호출로 reset.
  */
 data class LoginUiState(
     val email: String = "",
     val password: String = "",
     val isLoading: Boolean = false,
-    /** 로그인 성공 신호 — UI 가 LaunchedEffect 로 nav 후 [LoginViewModel.onLoggedInConsumed] 로 reset. */
+    /** 기존 유저 로그인 성공 신호 — UI 가 LaunchedEffect 로 홈 nav 후 [LoginViewModel.onLoggedInConsumed] 로 reset. */
     val isLoggedIn: Boolean = false,
+    /** 소셜 신규 가입자 신호 — UI 가 온보딩(Welcome) nav 후 [LoginViewModel.onOnboardingStartConsumed] 로 reset. */
+    val shouldStartOnboarding: Boolean = false,
     /** 서버/UseCase 가 내려준 사용자 친화 message. UI 가 snackbar 표시 후 [LoginViewModel.onErrorConsumed] 로 reset. */
     val errorMessage: String? = null,
 )

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginViewModel.kt
@@ -51,6 +51,11 @@ class LoginViewModel
             _uiState.update { it.copy(isLoggedIn = false) }
         }
 
+        /** UI 가 [LoginUiState.shouldStartOnboarding] 소비 후 reset. */
+        fun onOnboardingStartConsumed() {
+            _uiState.update { it.copy(shouldStartOnboarding = false) }
+        }
+
         /** UI 가 [LoginUiState.errorMessage] 소비 (snackbar 표시) 후 reset. */
         fun onErrorConsumed() {
             _uiState.update { it.copy(errorMessage = null) }
@@ -62,8 +67,14 @@ class LoginViewModel
                 _uiState.update { it.copy(isLoading = true) }
                 val result = loginUseCase(loginType = loginType)
                 result
-                    .onSuccess {
-                        _uiState.update { it.copy(isLoading = false, isLoggedIn = true) }
+                    .onSuccess { isNewUser ->
+                        _uiState.update {
+                            if (isNewUser) {
+                                it.copy(isLoading = false, shouldStartOnboarding = true)
+                            } else {
+                                it.copy(isLoading = false, isLoggedIn = true)
+                            }
+                        }
                     }.onFailure { exception ->
                         _uiState.update {
                             it.copy(isLoading = false, errorMessage = exception.message)

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavActions.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavActions.kt
@@ -15,6 +15,9 @@ interface OnboardingNavActions {
     /** 회원가입/로그인 성공 → Onboarding 그래프 전체 비우고 Home 진입 (replace). */
     fun replaceOnboardingWithHome()
 
+    /** 소셜 신규 가입자 로그인 성공 → Login 비우고 Welcome 진입 (온보딩 시작). */
+    fun replaceLoginWithWelcome()
+
     fun navigateToSignUp()
 
     fun navigateToLogin()

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
@@ -50,6 +50,7 @@ fun NavGraphBuilder.onboardingNavGraph(
         composable<OnboardingRoute.LoginRoute> {
             LoginEntry(
                 onLoginSuccess = actions::replaceOnboardingWithHome,
+                onNewUserOnboarding = actions::replaceLoginWithWelcome,
                 onSignUpClick = actions::replaceLoginWithSignUp,
                 onBackClick = actions::popBack,
             )


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #357

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 소셜 로그인 신규 가입자(`newUser:true`)가 온보딩을 건너뛰고 홈으로 직행하던 문제 수정 — 신규는 Welcome 으로, 기존·이메일은 현행대로 홈
- `LoginUseCase` 반환 `Result<Unit>` → `Result<Boolean>`(신규 여부): `saveSession` 성공 시 `(session as? SocialSession)?.isNewUser == true` 를 얹음 (이메일·`null` = false, 저장 실패는 그대로 전파)
- `LoginViewModel`·`LoginUiState` — 성공 시 신규면 `shouldStartOnboarding`, 기존이면 `isLoggedIn` (상호배타 one-shot 신호 + `onOnboardingStartConsumed`)
- `LoginEntry` `onNewUserOnboarding` 콜백 + `OnboardingNavActions.replaceLoginWithWelcome()` 추가·배선 (Login 비우고 Welcome 진입)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- 해당 없음 (네비게이션 분기, 신규 화면 無)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- **런타임 미검증**: `newUser:true` 는 서버가 진짜 첫 소셜 가입자에게만 줘서 에뮬레이터로 강제하기 어렵습니다(mock fixture 도 `newUser:false`). 컴파일만 확인 — 실기기에서 "신규 소셜 → Welcome" 플로우 확인 필요.
- **#349 와 충돌 주의**: `LoginUseCase` 시그니처를 바꿨습니다. #349(LoginUseCase 단위 테스트)가 `Result<Unit>` 기준으로 나중에 들어오면 새 시그니처(`Result<Boolean>`)에 맞춰야 합니다.
- 진입 화면은 Welcome 으로 합의 — 소셜은 OAuth 인증이라 이메일 인증·비밀번호 단계는 건너뜀. `null`/`false` 는 기존 유저로 안전 fallback.
- 검증: `:feature:onboarding:presentation:compileDebugKotlin :app:compileDebugKotlin` → BUILD SUCCESSFUL.
