### PR TITLE
test(afternote): data DTO→domain mapper + 에러 핸들러 단위 테스트 6종 (#350)

### DIFF
--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverAuthDtoMapperTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverAuthDtoMapperTest.kt
@@ -1,0 +1,83 @@
+package com.afternote.feature.afternote.data.dto
+
+import com.afternote.feature.afternote.domain.model.receiver.DeliveryVerificationStatus
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * `ReceiverAuthDto` 의 toDomain 확장 회귀 가드.
+ * 단순 전달 매핑(SenderMessageInfo·ReceiverIdentity·ReceiverAuthPresignedUrl)과,
+ * 핵심 로직인 [DeliveryVerificationStatus.fromRaw] 의 대소문자 무시 + UNKNOWN fallback 을 검증.
+ */
+class ReceiverAuthDtoMapperTest {
+    @Test
+    fun `ReceiverMessageResponse toDomain - SenderMessageInfo 매핑`() {
+        val result = ReceiverMessageResponse(senderName = "홍길동", message = "보고싶다").toDomain()
+        assertEquals("홍길동", result.senderName)
+        assertEquals("보고싶다", result.message)
+    }
+
+    @Test
+    fun `ReceiverAuthVerifyResponse toDomain - ReceiverIdentity 매핑`() {
+        val result =
+            ReceiverAuthVerifyResponse(
+                receiverId = 3L,
+                receiverName = "김수신",
+                senderName = "홍발신",
+                relation = "자녀",
+            ).toDomain()
+
+        assertEquals(3L, result.receiverId)
+        assertEquals("김수신", result.receiverName)
+        assertEquals("홍발신", result.senderName)
+        assertEquals("자녀", result.relation)
+    }
+
+    @Test
+    fun `ReceiverAuthPresignedUrlResponse toDomain - 매핑`() {
+        val result =
+            ReceiverAuthPresignedUrlResponse(
+                presignedUrl = "url",
+                fileKey = "key",
+                fileUrl = "file",
+                contentType = "image/jpeg",
+            ).toDomain()
+
+        assertEquals("url", result.presignedUrl)
+        assertEquals("key", result.fileKey)
+        assertEquals("file", result.fileUrl)
+        assertEquals("image/jpeg", result.contentType)
+    }
+
+    @Test
+    fun `DeliveryVerificationResponse toDomain - status fromRaw 대소문자 무시`() {
+        assertEquals(DeliveryVerificationStatus.APPROVED, response(status = "approved").toDomain().status)
+        assertEquals(DeliveryVerificationStatus.PENDING, response(status = "PENDING").toDomain().status)
+    }
+
+    @Test
+    fun `DeliveryVerificationResponse toDomain - 알 수 없는 status는 UNKNOWN`() {
+        assertEquals(DeliveryVerificationStatus.UNKNOWN, response(status = "WeIrD").toDomain().status)
+    }
+
+    @Test
+    fun `DeliveryVerificationResponse toDomain - 나머지 필드 전달`() {
+        val result = response(status = "REJECTED").toDomain()
+        assertEquals(11L, result.id)
+        assertEquals(DeliveryVerificationStatus.REJECTED, result.status)
+        assertEquals("death", result.deathCertificateUrl)
+        assertEquals("family", result.familyRelationCertificateUrl)
+        assertEquals("note", result.adminNote)
+        assertEquals("2025-11-26", result.createdAt)
+    }
+
+    private fun response(status: String) =
+        DeliveryVerificationResponse(
+            id = 11L,
+            status = status,
+            deathCertificateUrl = "death",
+            familyRelationCertificateUrl = "family",
+            adminNote = "note",
+            createdAt = "2025-11-26",
+        )
+}

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/AfternoteListItemDtoToDomainTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/AfternoteListItemDtoToDomainTest.kt
@@ -1,0 +1,69 @@
+package com.afternote.feature.afternote.data.mapper
+
+import com.afternote.feature.afternote.data.dto.AfternoteListItem
+import com.afternote.feature.afternote.domain.AfternoteServiceType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * [AfternoteListItem.toDomain] / [toDomainList] 회귀 가드.
+ * 작성자 목록 DTO→[com.afternote.feature.afternote.domain.model.author.ListItem] 매핑 +
+ * 공유 헬퍼([formatDateFromServer]·[categoryToServiceType])의 경계 동작을 toDomain 경유로 검증.
+ */
+class AfternoteListItemDtoToDomainTest {
+    @Test
+    fun `toDomain - 필드 매핑 + id Long을 String으로`() {
+        val result =
+            AfternoteListItem(
+                afternoteId = 7L,
+                title = "은행 계정",
+                category = "SOCIAL",
+                createdAt = "2025-11-26T14:30:00",
+            ).toDomain()
+
+        assertEquals("7", result.id)
+        assertEquals("은행 계정", result.serviceName)
+        assertEquals("2025.11.26", result.date)
+        assertEquals(AfternoteServiceType.SOCIAL_NETWORK, result.type)
+    }
+
+    @Test
+    fun `toDomain - category 매핑은 대소문자 무시 + MUSIC PLAYLIST는 MEMORIAL`() {
+        assertEquals(AfternoteServiceType.MEMORIAL, item(category = "music").toDomain().type)
+        assertEquals(AfternoteServiceType.MEMORIAL, item(category = "PLAYLIST").toDomain().type)
+        assertEquals(AfternoteServiceType.GALLERY_AND_FILES, item(category = "gallery").toDomain().type)
+    }
+
+    @Test
+    fun `toDomain - 알 수 없는 category는 SOCIAL_NETWORK 기본값`() {
+        assertEquals(AfternoteServiceType.SOCIAL_NETWORK, item(category = "???").toDomain().type)
+    }
+
+    @Test
+    fun `toDomain - createdAt에 T가 없어도 dash를 dot으로 치환`() {
+        assertEquals("2025.11.26", item(createdAt = "2025-11-26").toDomain().date)
+    }
+
+    @Test
+    fun `toDomainList - 빈 리스트는 빈 리스트`() {
+        assertEquals(emptyList<Any>(), emptyList<AfternoteListItem>().toDomainList())
+    }
+
+    @Test
+    fun `toDomainList - 각 항목을 순서대로 매핑`() {
+        val list = listOf(item(afternoteId = 1L), item(afternoteId = 2L)).toDomainList()
+        assertEquals(listOf("1", "2"), list.map { it.id })
+    }
+
+    private fun item(
+        afternoteId: Long = 1L,
+        title: String = "t",
+        category: String = "SOCIAL",
+        createdAt: String = "2025-01-01T00:00:00",
+    ) = AfternoteListItem(
+        afternoteId = afternoteId,
+        title = title,
+        category = category,
+        createdAt = createdAt,
+    )
+}

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/ReceiverAfternoteListItemDtoToDomainTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/ReceiverAfternoteListItemDtoToDomainTest.kt
@@ -1,0 +1,70 @@
+package com.afternote.feature.afternote.data.mapper
+
+import com.afternote.feature.afternote.data.dto.ReceivedAfternoteResponse
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * [ReceivedAfternoteResponse.toDomain] / [toReceiverDomainList] 회귀 가드.
+ * 수신자 목록 DTO→[com.afternote.feature.afternote.domain.model.receiver.AfterNoteListItemDto] 매핑.
+ * 서버 카테고리(SOCIAL/GALLERY/PLAYLIST/MUSIC)를 presentation typeKey로 정규화하는 규칙과
+ * null 가드(category·createdAt)를 검증한다.
+ */
+class ReceiverAfternoteListItemDtoToDomainTest {
+    @Test
+    fun `toDomain - 필드 매핑 + category 정규화 + 날짜 포맷`() {
+        val result =
+            ReceivedAfternoteResponse(
+                id = 9L,
+                title = "사진첩",
+                category = "GALLERY",
+                createdAt = "2025-11-26T14:30:00",
+            ).toDomain()
+
+        assertEquals(9L, result.id)
+        assertEquals("사진첩", result.title)
+        assertEquals("GALLERY_AND_FILES", result.sourceType)
+        assertEquals("2025.11.26", result.lastUpdatedAt)
+    }
+
+    @Test
+    fun `toDomain - category 정규화는 대소문자 무시 + MUSIC PLAYLIST는 MEMORIAL`() {
+        assertEquals("SOCIAL_NETWORK", resp(category = "social").toDomain().sourceType)
+        assertEquals("MEMORIAL", resp(category = "PLAYLIST").toDomain().sourceType)
+        assertEquals("MEMORIAL", resp(category = "music").toDomain().sourceType)
+    }
+
+    @Test
+    fun `toDomain - 정규화 규칙에 없는 category는 원본 유지`() {
+        assertEquals("ESTATE", resp(category = "ESTATE").toDomain().sourceType)
+    }
+
+    @Test
+    fun `toDomain - category null이면 sourceType null`() {
+        assertNull(resp(category = null).toDomain().sourceType)
+    }
+
+    @Test
+    fun `toDomain - createdAt null이면 lastUpdatedAt null`() {
+        assertNull(resp(createdAt = null).toDomain().lastUpdatedAt)
+    }
+
+    @Test
+    fun `toReceiverDomainList - 각 항목을 순서대로 매핑`() {
+        val list = listOf(resp(id = 1L), resp(id = 2L)).toReceiverDomainList()
+        assertEquals(listOf(1L, 2L), list.map { it.id })
+    }
+
+    private fun resp(
+        id: Long = 1L,
+        title: String? = "t",
+        category: String? = "SOCIAL",
+        createdAt: String? = "2025-01-01T00:00:00",
+    ) = ReceivedAfternoteResponse(
+        id = id,
+        title = title,
+        category = category,
+        createdAt = createdAt,
+    )
+}

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/response/AfternoteDetailResponseMapperTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/response/AfternoteDetailResponseMapperTest.kt
@@ -1,0 +1,142 @@
+package com.afternote.feature.afternote.data.mapper.response
+
+import com.afternote.feature.afternote.data.dto.AfternoteCredentials
+import com.afternote.feature.afternote.data.dto.AfternoteDetailReceiver
+import com.afternote.feature.afternote.data.dto.AfternoteDetailResponse
+import com.afternote.feature.afternote.data.dto.AfternoteMemorialVideo
+import com.afternote.feature.afternote.data.dto.AfternotePlaylist
+import com.afternote.feature.afternote.data.dto.AfternoteSong
+import com.afternote.feature.afternote.domain.AfternoteServiceType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [AfternoteDetailResponse.toDetailDomain] 회귀 가드 (작성자 상세).
+ * 핵심 경계: receivers null→emptyList, receiver 필드 null→"", actions null→emptyList,
+ * memorialPhotoUrl 없으면 profilePhoto로 대체, memorialVideo null→video/thumbnail null,
+ * credentials·playlist nullable 매핑.
+ */
+class AfternoteDetailResponseMapperTest {
+    @Test
+    fun `toDetailDomain - 최소 응답은 nullable이 비거나 null`() {
+        val result =
+            AfternoteDetailResponse(
+                afternoteId = 1L,
+                category = "SOCIAL",
+                title = "t",
+            ).toDetailDomain()
+
+        assertEquals(1L, result.id)
+        assertEquals(AfternoteServiceType.SOCIAL_NETWORK, result.type)
+        assertTrue(result.receivers.isEmpty())
+        assertNull(result.credentials)
+        assertNull(result.playlist)
+        assertTrue(result.processing!!.actions.isEmpty())
+    }
+
+    @Test
+    fun `toDetailDomain - timestamps 포맷`() {
+        val result =
+            AfternoteDetailResponse(
+                afternoteId = 1L,
+                category = "SOCIAL",
+                title = "t",
+                createdAt = "2025-11-26T14:30:00",
+                updatedAt = "2025-12-01T09:00:00",
+            ).toDetailDomain()
+
+        assertEquals("2025.11.26", result.timestamps.createdAt)
+        assertEquals("2025.12.01", result.timestamps.updatedAt)
+    }
+
+    @Test
+    fun `toDetailDomain - receiver의 null 필드는 빈 문자열`() {
+        val result =
+            AfternoteDetailResponse(
+                afternoteId = 1L,
+                category = "GALLERY",
+                title = "t",
+                receivers = listOf(AfternoteDetailReceiver(receiverId = 5L)),
+            ).toDetailDomain()
+
+        val receiver = result.receivers.single()
+        assertEquals(5L, receiver.receiverId)
+        assertEquals("", receiver.name)
+        assertEquals("", receiver.relation)
+        assertEquals("", receiver.phone)
+    }
+
+    @Test
+    fun `toDetailDomain - credentials 매핑`() {
+        val result =
+            AfternoteDetailResponse(
+                afternoteId = 1L,
+                category = "SOCIAL",
+                title = "t",
+                credentials = AfternoteCredentials(id = "user", password = "pw"),
+            ).toDetailDomain()
+
+        assertEquals("user", result.credentials!!.id)
+        assertEquals("pw", result.credentials!!.password)
+    }
+
+    @Test
+    fun `toDetailDomain - memorialPhotoUrl 없으면 profilePhoto로 대체`() {
+        val result =
+            AfternoteDetailResponse(
+                afternoteId = 1L,
+                category = "PLAYLIST",
+                title = "t",
+                playlist =
+                    AfternotePlaylist(
+                        profilePhoto = "profile.jpg",
+                        memorialPhotoUrl = null,
+                        songs = listOf(AfternoteSong(id = 3L, title = "s", artist = "a")),
+                        memorialVideo = AfternoteMemorialVideo(videoUrl = "v.mp4", thumbnailUrl = "t.jpg"),
+                    ),
+            ).toDetailDomain()
+
+        val media = result.playlist!!.playlistDetailMemorialMedia
+        assertEquals("profile.jpg", media.photoUrl)
+        assertEquals("v.mp4", media.videoUrl)
+        assertEquals("t.jpg", media.thumbnailUrl)
+        assertEquals(1, result.playlist!!.songs.size)
+        assertEquals(
+            3L,
+            result.playlist!!
+                .songs
+                .single()
+                .id,
+        )
+    }
+
+    @Test
+    fun `toDetailDomain - memorialPhotoUrl 있으면 그대로`() {
+        val result =
+            AfternoteDetailResponse(
+                afternoteId = 1L,
+                category = "PLAYLIST",
+                title = "t",
+                playlist = AfternotePlaylist(profilePhoto = "profile.jpg", memorialPhotoUrl = "memorial.jpg"),
+            ).toDetailDomain()
+
+        assertEquals("memorial.jpg", result.playlist!!.playlistDetailMemorialMedia.photoUrl)
+    }
+
+    @Test
+    fun `toDetailDomain - memorialVideo null이면 video thumbnail null`() {
+        val result =
+            AfternoteDetailResponse(
+                afternoteId = 1L,
+                category = "PLAYLIST",
+                title = "t",
+                playlist = AfternotePlaylist(profilePhoto = "p", memorialVideo = null),
+            ).toDetailDomain()
+
+        val media = result.playlist!!.playlistDetailMemorialMedia
+        assertNull(media.videoUrl)
+        assertNull(media.thumbnailUrl)
+    }
+}

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/response/ReceivedAfternoteDetailResponseMapperTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/response/ReceivedAfternoteDetailResponseMapperTest.kt
@@ -1,0 +1,83 @@
+package com.afternote.feature.afternote.data.mapper.response
+
+import com.afternote.feature.afternote.data.dto.ReceivedAfternoteDetailResponse
+import com.afternote.feature.afternote.data.dto.ReceivedCredentialsInfo
+import com.afternote.feature.afternote.data.dto.ReceivedMemorialVideoInfo
+import com.afternote.feature.afternote.data.dto.ReceivedPlaylistInfo
+import com.afternote.feature.afternote.data.dto.ReceivedSongInfo
+import com.afternote.feature.afternote.domain.AfternoteServiceType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * [ReceivedAfternoteDetailResponse.toDomain] 회귀 가드 (수신자 상세).
+ * 경계: createdAt null→null·있으면 포맷, category null→type null, playlist·credentials nullable 매핑,
+ * memorialVideo의 video/thumbnail 추출.
+ */
+class ReceivedAfternoteDetailResponseMapperTest {
+    @Test
+    fun `toDomain - 필드 매핑 + createdAt 포맷 + type 매핑`() {
+        val result =
+            ReceivedAfternoteDetailResponse(
+                id = 1L,
+                category = "MUSIC",
+                title = "추모",
+                senderName = "홍길동",
+                createdAt = "2025-11-26T14:30:00",
+            ).toDomain()
+
+        assertEquals("추모", result.title)
+        assertEquals("홍길동", result.senderName)
+        assertEquals("2025.11.26", result.createdAt)
+        assertEquals("MUSIC", result.category)
+        assertEquals(AfternoteServiceType.MEMORIAL, result.type)
+    }
+
+    @Test
+    fun `toDomain - category null이면 type null`() {
+        assertNull(ReceivedAfternoteDetailResponse(id = 1L, category = null).toDomain().type)
+    }
+
+    @Test
+    fun `toDomain - createdAt null이면 createdAt null`() {
+        assertNull(ReceivedAfternoteDetailResponse(id = 1L, createdAt = null).toDomain().createdAt)
+    }
+
+    @Test
+    fun `toDomain - playlist null이면 null`() {
+        assertNull(ReceivedAfternoteDetailResponse(id = 1L, playlist = null).toDomain().playlist)
+    }
+
+    @Test
+    fun `toDomain - playlist 있으면 songs·atmosphere·memorialVideo 매핑`() {
+        val result =
+            ReceivedAfternoteDetailResponse(
+                id = 1L,
+                playlist =
+                    ReceivedPlaylistInfo(
+                        atmosphere = "차분",
+                        songs = listOf(ReceivedSongInfo(title = "s", artist = "a", coverUrl = "c")),
+                        memorialVideo = ReceivedMemorialVideoInfo(videoUrl = "v", thumbnailUrl = "t"),
+                    ),
+            ).toDomain()
+
+        val playlist = result.playlist!!
+        assertEquals("차분", playlist.atmosphere)
+        assertEquals(1, playlist.songs.size)
+        assertEquals("v", playlist.memorialVideoUrl)
+        assertEquals("t", playlist.memorialThumbnailUrl)
+    }
+
+    @Test
+    fun `toDomain - credentials 매핑`() {
+        val result =
+            ReceivedAfternoteDetailResponse(
+                id = 1L,
+                credentials = ReceivedCredentialsInfo(id = "u", password = "p"),
+            ).toDomain()
+
+        assertEquals("u", result.credentials!!.id)
+        assertEquals("p", result.credentials!!.password)
+    }
+}

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/repositoryimpl/author/AfternoteAuthoringFailureMapperTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/repositoryimpl/author/AfternoteAuthoringFailureMapperTest.kt
@@ -1,0 +1,75 @@
+package com.afternote.feature.afternote.data.repositoryimpl.author
+
+import com.afternote.core.network.model.ApiException
+import com.afternote.feature.afternote.domain.error.AfternoteAuthoringValidationException
+import com.afternote.feature.afternote.domain.error.AfternoteAuthoringValidationKind
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+
+/**
+ * [mapAuthoringFailure] 회귀 가드.
+ * 저장 API 실패 Throwable 중 "수신자 최소 1명 필요(서버 코드 475)" 만 도메인 검증 예외로 치환하고,
+ * 나머지는 원본 인스턴스를 그대로 통과시키는지 검증한다. 475 는 두 경로(ApiException·HttpException 바디)
+ * 로 들어올 수 있어 둘 다 커버한다.
+ */
+class AfternoteAuthoringFailureMapperTest {
+    @Test
+    fun `이미 검증 예외면 그대로 반환`() {
+        val original = AfternoteAuthoringValidationException(AfternoteAuthoringValidationKind.RECEIVERS_REQUIRED)
+        assertSame(original, mapAuthoringFailure(original))
+    }
+
+    @Test
+    fun `ApiException 475면 RECEIVERS_REQUIRED 검증 예외로 치환`() {
+        val result = mapAuthoringFailure(ApiException(code = 475, serverMessage = null, message = "x"))
+        assertTrue(result is AfternoteAuthoringValidationException)
+        assertEquals(
+            AfternoteAuthoringValidationKind.RECEIVERS_REQUIRED,
+            (result as AfternoteAuthoringValidationException).kind,
+        )
+    }
+
+    @Test
+    fun `ApiException 다른 코드는 그대로 통과`() {
+        val original = ApiException(code = 400, serverMessage = null, message = "x")
+        assertSame(original, mapAuthoringFailure(original))
+    }
+
+    @Test
+    fun `일반 예외는 그대로 통과`() {
+        val original = IllegalStateException("boom")
+        assertSame(original, mapAuthoringFailure(original))
+    }
+
+    @Test
+    fun `HttpException 400 + 바디 code 475면 검증 예외로 치환`() {
+        val result = mapAuthoringFailure(httpException(code = 400, body = """{"code":475}"""))
+        assertTrue(result is AfternoteAuthoringValidationException)
+    }
+
+    @Test
+    fun `HttpException 400 + 바디 code가 475가 아니면 통과`() {
+        val original = httpException(code = 400, body = """{"code":999}""")
+        assertSame(original, mapAuthoringFailure(original))
+    }
+
+    @Test
+    fun `HttpException 비400은 통과`() {
+        val original = httpException(code = 500, body = """{"code":475}""")
+        assertSame(original, mapAuthoringFailure(original))
+    }
+
+    private fun httpException(
+        code: Int,
+        body: String,
+    ): HttpException {
+        val responseBody = body.toResponseBody("application/json".toMediaTypeOrNull())
+        return HttpException(Response.error<Any>(code, responseBody))
+    }
+}


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #350

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- Afternote data 레이어 DTO→domain 매퍼 + 에러 핸들러 회귀 테스트 6종(38건) 추가 — 전부 통과, 프로덕션 코드 변경 없음
- 대상: `ReceiverAuthDtoMapper` · `AfternoteListItemDtoToDomain` · `ReceiverAfternoteListItemDtoToDomain` · `AfternoteDetailResponseMapper` · `ReceivedAfternoteDetailResponseMapper` · `AfternoteAuthoringFailureMapper`(에러 핸들러)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- 해당 없음 (단위 테스트 추가)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- DTO→domain 변환의 필드 누락·뒤바뀜과 에러 매핑을 막는 회귀 가드입니다. #351(AuthMapper)·#349(UseCase) 와 같은 결의 테스트 보강 작업.
