### PR TITLE
chore(build-logic): configureDefaultConfig 중복 통합 + consumerProguardFiles 복구 (#345)

### DIFF
--- a/build-logic/src/main/kotlin/AndroidCommonConfig.kt
+++ b/build-logic/src/main/kotlin/AndroidCommonConfig.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 internal fun Project.configureAndroidCommon(extension: CommonExtension) {
     extension.compileSdk = 36
 
-    extension.configureDefaultConfig()
+    extension.configureDefaultConfig(this)
 
     extensions
         .findByType(org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension::class.java)
@@ -24,7 +24,7 @@ internal fun Project.configureAndroidCommon(extension: CommonExtension) {
     }
 }
 
-private fun CommonExtension.configureDefaultConfig() {
+private fun CommonExtension.configureDefaultConfig(project: Project) {
     when (this) {
         is ApplicationExtension -> {
             defaultConfig {
@@ -41,7 +41,10 @@ private fun CommonExtension.configureDefaultConfig() {
             defaultConfig {
                 minSdk = 26
                 testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-                consumerProguardFiles("consumer-rules.pro")
+                // consumer-rules.pro 가 있는 모듈만 등록 — 없는 모듈(domain·res 등)엔 빈 파일을 강요하지 않음
+                if (project.file("consumer-rules.pro").exists()) {
+                    consumerProguardFiles("consumer-rules.pro")
+                }
             }
             compileOptions {
                 sourceCompatibility = JavaVersion.VERSION_17

--- a/build-logic/src/main/kotlin/AndroidCommonConfig.kt
+++ b/build-logic/src/main/kotlin/AndroidCommonConfig.kt
@@ -5,17 +5,13 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
-internal fun Project.configureAndroidCommon(
-    extension: CommonExtension
-) {
+internal fun Project.configureAndroidCommon(extension: CommonExtension) {
     extension.compileSdk = 36
 
-    when (extension) {
-        is ApplicationExtension -> extension.configureDefaultConfig()
-        is LibraryExtension -> extension.configureDefaultConfig()
-    }
+    extension.configureDefaultConfig()
 
-    extensions.findByType(org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension::class.java)
+    extensions
+        .findByType(org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension::class.java)
         ?.compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
         }
@@ -25,7 +21,6 @@ internal fun Project.configureAndroidCommon(
         testImplementation("junit")
         androidTestImplementation("androidx-junit")
         androidTestImplementation("androidx-espresso-core")
-
     }
 }
 
@@ -41,6 +36,7 @@ private fun CommonExtension.configureDefaultConfig() {
                 targetCompatibility = JavaVersion.VERSION_17
             }
         }
+
         is LibraryExtension -> {
             defaultConfig {
                 minSdk = 26
@@ -55,9 +51,7 @@ private fun CommonExtension.configureDefaultConfig() {
     }
 }
 
-internal fun Project.configureCompose(
-    extension: CommonExtension
-) {
+internal fun Project.configureCompose(extension: CommonExtension) {
     when (extension) {
         is ApplicationExtension -> extension.buildFeatures { compose = true }
         is LibraryExtension -> extension.buildFeatures { compose = true }
@@ -72,27 +66,5 @@ internal fun Project.configureCompose(
         implementation("androidx-activity-compose")
         implementation("androidx-compose-ui-tooling-preview")
         debugImplementation("androidx-compose-ui-tooling")
-    }
-}
-
-private fun ApplicationExtension.configureDefaultConfig() {
-    defaultConfig {
-        minSdk = 26
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-}
-
-private fun LibraryExtension.configureDefaultConfig() {
-    defaultConfig {
-        minSdk = 26
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
     }
 }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #345

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `build-logic` 의 `configureDefaultConfig` 중복(`ApplicationExtension`/`LibraryExtension` 전용 2벌, `consumerProguardFiles` 누락) 제거 → 단일 `CommonExtension.configureDefaultConfig()` 로 통합, 호출부 `when(extension)` 분기도 단일 호출로 단순화
- 통합 함수가 `consumerProguardFiles("consumer-rules.pro")` 를 보유 → 그동안 누락돼 있던 **라이브러리 모듈의 consumer ProGuard 규칙 전파 복구**

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- 해당 없음 (build-logic)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 전 모듈 공통 build 설정이라 영향 범위가 큽니다 — `:app:assembleDebug` 통과 확인(config 단계 build-logic 재컴파일 포함).
- `consumerProguardFiles` 복구로 라이브러리 AAR 에 `consumer-rules.pro` 가 다시 포함됩니다.
