### PR TITLE
refactor(coil): User-Agent 헤더 글로벌 ImageLoader 중앙화 + 화면별 부착 제거 (#339)

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/GlobalApplication.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/GlobalApplication.kt
@@ -12,6 +12,7 @@ import dagger.hilt.android.HiltAndroidApp
 class GlobalApplication :
     Application(),
     SingletonImageLoader.Factory {
+    /** Hilt 가 만든 [ImageLoader] 를 Coil 앱 전역 싱글톤으로 등록 — 모든 AsyncImage 가 명시적 imageLoader 없이 이걸 사용. */
     override fun newImageLoader(context: PlatformContext): ImageLoader =
         EntryPointAccessors
             .fromApplication(context, CoilImageLoaderEntryPoint::class.java)

--- a/core/network/src/main/kotlin/com/afternote/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/di/NetworkModule.kt
@@ -100,7 +100,8 @@ object NetworkModule { // 이 모듈은 오브젝트 클래스 선언해서 딱 
             .addInterceptor(loggingInterceptor)
             .build()
 
-    /** Coil 전용. 인증 헤더 없이 이미지 호스트만 다루며, DEBUG 멀티바인딩 인터셉터(예: mock.image → Picsum)를 동일하게 적용한다. */
+    /** Coil 전용. 인증 헤더 없이 이미지 호스트만 다루며, DEBUG 멀티바인딩 인터셉터(예: mock.image → Picsum)를 동일하게 적용한다.
+     *  모든 이미지 요청에 동일한 `User-Agent` 를 부착해 presentation 의 ImageRequest 별 부착 boilerplate 를 제거한다. */
     @Provides
     @Singleton
     @Named("CoilImage")
@@ -109,6 +110,15 @@ object NetworkModule { // 이 모듈은 오브젝트 클래스 선언해서 딱 
         loggingInterceptor: HttpLoggingInterceptor,
     ): OkHttpClient {
         val builder = OkHttpClient.Builder()
+        builder.addInterceptor { chain ->
+            chain.proceed(
+                chain
+                    .request()
+                    .newBuilder()
+                    .header("User-Agent", "Afternote Android App")
+                    .build(),
+            )
+        }
         debugInterceptors.forEach { builder.addInterceptor(it) }
         return builder.addInterceptor(loggingInterceptor).build()
     }

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/detail/MemorialGuidelineDetailScreen.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/detail/MemorialGuidelineDetailScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -44,9 +43,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
-import coil3.network.NetworkHeaders
-import coil3.network.httpHeaders
-import coil3.request.ImageRequest
 import com.afternote.core.model.AlbumCover
 import com.afternote.core.ui.ProfileImage
 import com.afternote.core.ui.modifierextention.FadingEdgeDirection
@@ -330,22 +326,8 @@ private fun VideoThumbnail(thumbnailUrl: String?) {
     ) {
         // 썸네일 이미지
         if (!thumbnailUrl.isNullOrBlank()) {
-            val context = LocalContext.current
-            val imageRequest =
-                remember(thumbnailUrl) {
-                    ImageRequest
-                        .Builder(context)
-                        .data(thumbnailUrl)
-                        .httpHeaders(
-                            NetworkHeaders
-                                .Builder()
-                                .apply {
-                                    this["User-Agent"] = "Afternote Android App"
-                                }.build(),
-                        ).build()
-                }
             AsyncImage(
-                model = imageRequest,
+                model = thumbnailUrl,
                 contentDescription = "장례식에 남길 영상 썸네일",
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop,
@@ -477,22 +459,8 @@ private fun PlaylistAlbumRow(albumCovers: List<AlbumCover>) {
 @Composable
 private fun AlbumCoverItem(album: AlbumCover) {
     if (!album.imageUrl.isNullOrBlank()) {
-        val context = LocalContext.current
-        val imageRequest =
-            remember(album.imageUrl) {
-                ImageRequest
-                    .Builder(context)
-                    .data(album.imageUrl)
-                    .httpHeaders(
-                        NetworkHeaders
-                            .Builder()
-                            .apply {
-                                this["User-Agent"] = "Afternote Android App"
-                            }.build(),
-                    ).build()
-            }
         AsyncImage(
-            model = imageRequest,
+            model = album.imageUrl,
             contentDescription = album.title,
             modifier = Modifier.size(87.dp),
             contentScale = ContentScale.Crop,

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/memorial/FuneralVideoUpload.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/memorial/FuneralVideoUpload.kt
@@ -42,9 +42,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
-import coil3.network.NetworkHeaders
-import coil3.network.httpHeaders
-import coil3.request.ImageRequest
 import com.afternote.core.ui.button.PlusBadgeButton
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
@@ -186,21 +183,8 @@ fun FuneralVideoUpload(
             ) {
                 when {
                     !thumbnailUrl.isNullOrBlank() -> {
-                        val imageRequest =
-                            remember(thumbnailUrl) {
-                                ImageRequest
-                                    .Builder(context)
-                                    .data(thumbnailUrl)
-                                    .httpHeaders(
-                                        NetworkHeaders
-                                            .Builder()
-                                            .apply {
-                                                this["User-Agent"] = "Afternote Android App"
-                                            }.build(),
-                                    ).build()
-                            }
                         AsyncImage(
-                            model = imageRequest,
+                            model = thumbnailUrl,
                             contentDescription = null,
                             modifier = Modifier.fillMaxSize(),
                             contentScale = ContentScale.Crop,

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/detail/MemorialReceivedDetailScreen.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/detail/MemorialReceivedDetailScreen.kt
@@ -42,9 +42,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import coil3.compose.AsyncImage
-import coil3.network.NetworkHeaders
-import coil3.network.httpHeaders
-import coil3.request.ImageRequest
 import com.afternote.core.model.AlbumCover
 import com.afternote.core.ui.ProfileImage
 import com.afternote.core.ui.bottombar.BottomBar
@@ -245,21 +242,8 @@ private fun ReceiverMemorialVideoThumbnail(thumbnailUrl: String?) {
                 .clip(RoundedCornerShape(16.dp)),
     ) {
         if (!thumbnailUrl.isNullOrBlank()) {
-            val ctx = LocalContext.current
-            val imageRequest =
-                remember(thumbnailUrl) {
-                    ImageRequest
-                        .Builder(ctx)
-                        .data(thumbnailUrl)
-                        .httpHeaders(
-                            NetworkHeaders
-                                .Builder()
-                                .set("User-Agent", "Afternote Android App")
-                                .build(),
-                        ).build()
-                }
             AsyncImage(
-                model = imageRequest,
+                model = thumbnailUrl,
                 contentDescription = "장례식에 남길 영상 썸네일",
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop,

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/shared/detail/song/MemorialPlaylist.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/shared/detail/song/MemorialPlaylist.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -33,9 +32,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
-import coil3.network.NetworkHeaders
-import coil3.network.httpHeaders
-import coil3.request.ImageRequest
 import com.afternote.core.model.AlbumCover
 import com.afternote.core.ui.icon.ArrowIcon
 import com.afternote.core.ui.icon.RightArrowIcon
@@ -252,22 +248,8 @@ private fun MemorialPlaylistAlbumCoverBox(album: AlbumCover) {
             .size(80.dp)
             .clip(RoundedCornerShape(8.dp))
     if (!album.imageUrl.isNullOrBlank()) {
-        val context = LocalContext.current
-        val imageRequest =
-            remember(album.imageUrl) {
-                ImageRequest
-                    .Builder(context)
-                    .data(album.imageUrl)
-                    .httpHeaders(
-                        NetworkHeaders
-                            .Builder()
-                            .apply {
-                                this["User-Agent"] = "Afternote Android App"
-                            }.build(),
-                    ).build()
-            }
         AsyncImage(
-            model = imageRequest,
+            model = album.imageUrl,
             contentDescription = stringResource(R.string.content_description_album_cover),
             modifier = modifier,
             contentScale = ContentScale.Crop,

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/shared/detail/song/PlaylistSongItem.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/shared/detail/song/PlaylistSongItem.kt
@@ -16,21 +16,16 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
-import coil3.network.NetworkHeaders
-import coil3.network.httpHeaders
-import coil3.request.ImageRequest
 import com.afternote.core.ui.modifierextention.bottomBorder
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.feature.afternote.presentation.R
@@ -117,22 +112,8 @@ private fun AlbumCoverBox(albumImageUrl: String?) {
             .size(48.dp)
             .clip(RoundedCornerShape(4.dp))
     if (!albumImageUrl.isNullOrBlank()) {
-        val context = LocalContext.current
-        val imageRequest =
-            remember(albumImageUrl) {
-                ImageRequest
-                    .Builder(context)
-                    .data(albumImageUrl)
-                    .httpHeaders(
-                        NetworkHeaders
-                            .Builder()
-                            .apply {
-                                this["User-Agent"] = "Afternote Android App"
-                            }.build(),
-                    ).build()
-            }
         AsyncImage(
-            model = imageRequest,
+            model = albumImageUrl,
             contentDescription = stringResource(R.string.content_description_album_cover),
             modifier = modifier,
             contentScale = ContentScale.Crop,


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #339

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- Coil 이미지 요청의 `User-Agent` 헤더를 글로벌 `ImageLoader` 로 중앙화 — `@Named("CoilImage")` OkHttpClient 에 인터셉터 1개로 부착. `GlobalApplication` 이 `SingletonImageLoader.Factory` 로 등록한 앱 전역 싱글톤이라 모든 `AsyncImage` 에 자동 적용된다.
- presentation 5개 화면의 화면별 `User-Agent` 부착 boilerplate 제거 (−108줄)
- `GlobalApplication.newImageLoader()` 에 싱글톤 등록 의도 설명 KDoc 1줄 추가

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- 해당 없음 (이미지 로딩 동작 동일, 헤더 부착 위치만 화면 → 글로벌로 이동)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 화면 어디서도 `imageLoader =` 로 별도 로더를 넘기지 않아(grep 확인) 전부 싱글톤 ImageLoader 를 사용합니다 — 중앙화 후 모든 이미지 요청에 동일 User-Agent 가 적용됩니다.
- `:feature:afternote:presentation:compileDebugKotlin` 통과. (런타임 이미지 로딩은 기기 확인 권장 — 동작 자체는 헤더 위치 이동뿐)
