### PR TITLE
refactor(afternote): 추모 미디어 입력 String? 3상태 → sealed MediaInput 타입 안전화 (#346)

### DIFF
--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/author/MemorialPhotoUploadRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/author/MemorialPhotoUploadRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.afternote.feature.afternote.data.repositoryimpl.author
 
 import com.afternote.core.domain.repository.PhotoUploadRepository
+import com.afternote.feature.afternote.domain.repository.author.MediaInput
 import com.afternote.feature.afternote.domain.repository.author.MemorialPhotoUploadRepository
 import com.afternote.feature.afternote.domain.repository.author.PhotoUploadOutcome
 import javax.inject.Inject
@@ -13,38 +14,32 @@ import javax.inject.Inject
 internal const val DIRECTORY_AFTERNOTES = "afternotes"
 
 /**
- * Android 의 *로컬 파일 URI* 스킴. 갤러리/카메라 picker 결과는 `content://...` 로 시작 → "아직 서버에 없음, 업로드 필요" 의 신호. `https://...` 같은 원격 URL 과 구분하는 용도.
+ * 영정 사진 *상태 해석* + 필요 시 업로드. 입력 [MediaInput] 의 sealed 분기:
+ * - [MediaInput.Local] → [PhotoUploadRepository] 업로드 후 [PhotoUploadOutcome.FreshlyUploaded]
+ * - [MediaInput.Remote] → 입력 그대로 [PhotoUploadOutcome.Existing]
+ * - [MediaInput.None] → [PhotoUploadOutcome.Empty]
  *
- * 같은 패키지의 [MemorialVideoUploadRepositoryImpl] 가 이 값을 공유하므로 `internal`.
- */
-internal const val LOCAL_CONTENT_SCHEME = "content://"
-
-/**
- * 영정 사진 *상태 해석* + 필요 시 업로드.
- *
- * `pickedUri` 가 로컬 `content://` 면 [PhotoUploadRepository] 로 업로드 후
- * [PhotoUploadOutcome.FreshlyUploaded]. 그 외엔 `existingUrl` 기준으로
- * [PhotoUploadOutcome.Existing] / [PhotoUploadOutcome.Empty] 분기.
- *
- * `content://` prefix 비교는 *data 레이어 안* 에 격리 — 도메인은 인프라 형식 디테일을 모름.
+ * 픽 우선순위·로컬/원격 판별은 호출부가 [MediaInput] 을 구성할 때 끝낸다.
  */
 class MemorialPhotoUploadRepositoryImpl
     @Inject
     constructor(
         private val photoUploadRepository: PhotoUploadRepository,
     ) : MemorialPhotoUploadRepository {
-        override suspend fun resolvePhoto(
-            existingUrl: String?,
-            pickedUri: String?,
-        ): Result<PhotoUploadOutcome> {
-            if (!pickedUri.isNullOrBlank() && pickedUri.startsWith(LOCAL_CONTENT_SCHEME)) {
-                return photoUploadRepository
-                    .upload(pickedUri, DIRECTORY_AFTERNOTES)
-                    .map { PhotoUploadOutcome.FreshlyUploaded(it) }
+        override suspend fun resolvePhoto(input: MediaInput): Result<PhotoUploadOutcome> =
+            when (input) {
+                MediaInput.None -> {
+                    Result.success(PhotoUploadOutcome.Empty)
+                }
+
+                is MediaInput.Remote -> {
+                    Result.success(PhotoUploadOutcome.Existing(input.url))
+                }
+
+                is MediaInput.Local -> {
+                    photoUploadRepository
+                        .upload(input.uri, DIRECTORY_AFTERNOTES)
+                        .map { PhotoUploadOutcome.FreshlyUploaded(it) }
+                }
             }
-            val fallback = existingUrl?.takeIf { it.isNotBlank() }
-            return Result.success(
-                if (fallback == null) PhotoUploadOutcome.Empty else PhotoUploadOutcome.Existing(fallback),
-            )
-        }
     }

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/author/MemorialVideoUploadRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/author/MemorialVideoUploadRepositoryImpl.kt
@@ -1,35 +1,41 @@
 package com.afternote.feature.afternote.data.repositoryimpl.author
 
 import com.afternote.core.domain.repository.VideoUploadRepository
+import com.afternote.feature.afternote.domain.repository.author.MediaInput
 import com.afternote.feature.afternote.domain.repository.author.MemorialVideoUploadRepository
 import com.afternote.feature.afternote.domain.repository.author.VideoUploadOutcome
 import javax.inject.Inject
 
-// DIRECTORY_AFTERNOTES, LOCAL_CONTENT_SCHEME 는 같은 패키지 [MemorialPhotoUploadRepositoryImpl] 의 internal const 공유.
+// DIRECTORY_AFTERNOTES 는 같은 패키지 [MemorialPhotoUploadRepositoryImpl] 의 internal const 공유.
 
 /**
- * 추모 영상 *상태 해석* + 필요 시 업로드.
+ * 추모 영상 *상태 해석* + 필요 시 업로드. 입력 [MediaInput] 의 sealed 분기로 반환:
+ * - [MediaInput.Local] → [VideoUploadRepository] 위임 후 [VideoUploadOutcome.FreshlyUploaded]
+ * - [MediaInput.Remote] → 입력 그대로 [VideoUploadOutcome.Existing]
+ * - [MediaInput.None] → [VideoUploadOutcome.Empty]
  *
- * 입력 String 의 형식을 판별해 sealed 분기로 반환:
- * - 로컬 `content://` URI → [VideoUploadRepository] 위임 후 [VideoUploadOutcome.FreshlyUploaded]
- * - 원격 HTTPS URL → 입력 그대로 [VideoUploadOutcome.Existing]
- * - null/blank → [VideoUploadOutcome.Empty]
- *
- * `content://` prefix 비교는 *data 레이어 안* 에 격리 — 도메인은 인프라 형식 디테일을 모름.
- * S3 PUT·MIME 추론·temp 파일 관리는 [VideoUploadRepository] 가 담당. 본 클래스는 분기 라우팅만.
+ * 로컬/원격 판별은 호출부에서 [MediaInput] 으로 끝나 있다. S3 PUT·MIME 추론·temp 파일 관리는
+ * [VideoUploadRepository] 가 담당. 본 클래스는 분기 라우팅만.
  */
 class MemorialVideoUploadRepositoryImpl
     @Inject
     constructor(
         private val videoUploadRepository: VideoUploadRepository,
     ) : MemorialVideoUploadRepository {
-        override suspend fun resolveVideo(input: String?): Result<VideoUploadOutcome> {
-            if (input.isNullOrBlank()) return Result.success(VideoUploadOutcome.Empty)
-            if (!input.startsWith(LOCAL_CONTENT_SCHEME)) {
-                return Result.success(VideoUploadOutcome.Existing(input))
+        override suspend fun resolveVideo(input: MediaInput): Result<VideoUploadOutcome> =
+            when (input) {
+                MediaInput.None -> {
+                    Result.success(VideoUploadOutcome.Empty)
+                }
+
+                is MediaInput.Remote -> {
+                    Result.success(VideoUploadOutcome.Existing(input.url))
+                }
+
+                is MediaInput.Local -> {
+                    videoUploadRepository
+                        .upload(input.uri, DIRECTORY_AFTERNOTES)
+                        .map { VideoUploadOutcome.FreshlyUploaded(it) }
+                }
             }
-            return videoUploadRepository
-                .upload(input, DIRECTORY_AFTERNOTES)
-                .map { VideoUploadOutcome.FreshlyUploaded(it) }
-        }
     }

--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/repository/author/MediaInput.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/repository/author/MediaInput.kt
@@ -1,0 +1,23 @@
+package com.afternote.feature.afternote.domain.repository.author
+
+/**
+ * 추모 미디어(영상·영정 사진) 입력의 출처 상태.
+ *
+ * 진입 시점(presentation)에 로컬/원격을 *한 번* 확정해 resolve 경계로 넘긴다. 그러면 data 레이어가
+ * `content://` 같은 prefix 를 런타임에 문자열 비교하지 않고 [when] 분기(exhaustive)로 처리할 수 있다.
+ * 새 상태가 늘면 분기 누락이 컴파일 에러로 드러난다. (출력단 sealed `*UploadOutcome` #247 의 입력단 대칭.)
+ */
+sealed interface MediaInput {
+    /** 사용자가 이번 세션에 새로 고른 로컬 파일(`content://` URI). 업로드 대상. */
+    data class Local(
+        val uri: String,
+    ) : MediaInput
+
+    /** 이미 서버에 있는 원격 URL(영구 public 또는 presigned). 그대로 유지. */
+    data class Remote(
+        val url: String,
+    ) : MediaInput
+
+    /** 미첨부. */
+    data object None : MediaInput
+}

--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/repository/author/MemorialPhotoUploadRepository.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/repository/author/MemorialPhotoUploadRepository.kt
@@ -3,22 +3,13 @@ package com.afternote.feature.afternote.domain.repository.author
 /**
  * 영정 사진의 *서버 자원 상태 해석* + 필요 시 업로드.
  *
- * 영상과 달리 사진은 *기존 영구 URL* (`existingUrl`) 과 *새로 고른 로컬 URI* (`pickedUri`) 가
- * 별도 인자로 들어오며, Repository 가 둘을 함께 보고 분기를 결정한다.
+ * 새로 고른 로컬 사진과 기존 원격 사진의 우선순위(픽 우선)는 *호출부* 가 [MediaInput] 을 구성할 때 정한다.
+ * Repository 는 확정된 [MediaInput] 을 [when] 분기로 처리한다.
  *
- * - `pickedUri` 가 로컬 `content://` → 업로드 → [PhotoUploadOutcome.FreshlyUploaded]
- * - 그 외에 `existingUrl` 이 있음 → [PhotoUploadOutcome.Existing]
- * - 둘 다 비어있음 → [PhotoUploadOutcome.Empty]
+ * - [MediaInput.Local] → 업로드 → [PhotoUploadOutcome.FreshlyUploaded]
+ * - [MediaInput.Remote] → 입력 그대로 [PhotoUploadOutcome.Existing]
+ * - [MediaInput.None] → [PhotoUploadOutcome.Empty]
  */
 fun interface MemorialPhotoUploadRepository {
-    /**
-     * @param existingUrl 직전 상태에 이미 저장돼 있던 *서버 영구 URL*. 수정 모드 진입 시 prefill 되는 기존 사진.
-     *                    사용자가 이번 세션에 새 사진을 고르지 않았다면 이 값이 그대로 유지되어야 한다.
-     * @param pickedUri 사용자가 *이번 편집 세션에 새로 선택* 한 로컬 `content://` URI.
-     *                  null/blank 이면 새 선택이 없었다는 뜻이고, 그땐 `existingUrl` 로 폴백한다.
-     */
-    suspend fun resolvePhoto(
-        existingUrl: String?,
-        pickedUri: String?,
-    ): Result<PhotoUploadOutcome>
+    suspend fun resolvePhoto(input: MediaInput): Result<PhotoUploadOutcome>
 }

--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/repository/author/MemorialVideoUploadRepository.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/repository/author/MemorialVideoUploadRepository.kt
@@ -3,13 +3,13 @@ package com.afternote.feature.afternote.domain.repository.author
 /**
  * 추모(플레이리스트) 영상의 *서버 자원 상태 해석* + 필요 시 업로드.
  *
- * 입력 String 의 형식(로컬 `content://` 인지 원격 URL 인지)을 *Repository 가 직접 판별* 하고
- * [VideoUploadOutcome] sealed 분기로 도메인에 결과를 전달한다. 도메인은 인프라 형식 디테일을 모름.
+ * 입력 [MediaInput] 으로 로컬/원격이 이미 확정돼 들어오므로, Repository 는 `content://` prefix 를
+ * 판별하지 않고 [when] 분기로 [VideoUploadOutcome] 를 만든다.
  *
- * - 로컬 `content://` → S3 presigned upload → [VideoUploadOutcome.FreshlyUploaded]
- * - 원격 HTTPS URL (영구 또는 presigned GET) → 입력 그대로 [VideoUploadOutcome.Existing]
- * - null/blank → [VideoUploadOutcome.Empty]
+ * - [MediaInput.Local] → S3 presigned upload → [VideoUploadOutcome.FreshlyUploaded]
+ * - [MediaInput.Remote] → 입력 그대로 [VideoUploadOutcome.Existing]
+ * - [MediaInput.None] → [VideoUploadOutcome.Empty]
  */
 fun interface MemorialVideoUploadRepository {
-    suspend fun resolveVideo(input: String?): Result<VideoUploadOutcome>
+    suspend fun resolveVideo(input: MediaInput): Result<VideoUploadOutcome>
 }

--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/usecase/editor/ResolveMemorialMediaForSaveUseCase.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/usecase/editor/ResolveMemorialMediaForSaveUseCase.kt
@@ -1,5 +1,6 @@
 package com.afternote.feature.afternote.domain.usecase.editor
 
+import com.afternote.feature.afternote.domain.repository.author.MediaInput
 import com.afternote.feature.afternote.domain.repository.author.MemorialPhotoUploadRepository
 import com.afternote.feature.afternote.domain.repository.author.MemorialVideoUploadRepository
 import com.afternote.feature.afternote.domain.repository.author.PhotoUploadOutcome
@@ -17,8 +18,8 @@ class MemorialPhotoSaveException(
 /**
  * 추모 영상·영정 사진의 *서버 저장 직전 정리* 도메인 로직.
  *
- * Repository 가 입력 String 의 형식을 판별해 sealed [VideoUploadOutcome]/[PhotoUploadOutcome] 로
- * 결과를 주고, 본 UseCase 는 그 sealed 분기를 저장 페이로드 규칙에 매핑한다.
+ * 호출부가 로컬/원격을 확정한 [MediaInput] 을 받아 Repository 가 sealed [VideoUploadOutcome]/[PhotoUploadOutcome]
+ * 로 결과를 주고, 본 UseCase 는 그 sealed 분기를 저장 페이로드 규칙에 매핑한다.
  * 도메인 본문이 `"content://"`, `"X-Amz-"` 같은 인프라 형식 디테일 문자열을 직접 비교하지 않는다.
  *
  * **POST/PATCH 동일 규칙** — 백엔드가 `S3Service.resolvePublicUrl(key)` 로 영구 public URL 을 발급하므로
@@ -37,25 +38,23 @@ class ResolveMemorialMediaForSaveUseCase
         private val memorialPhotoUploadRepository: MemorialPhotoUploadRepository,
     ) {
         /**
-         * @param funeralVideoUrl 현재 ViewModel 의 영상 URL — 로컬/원격 중 하나, 또는 null.
-         * @param memorialPhotoUrl 현재 영정 사진의 *영구 원격* URL (없으면 null).
-         * @param pickedMemorialPhotoUri 사용자가 *방금 새로 고른* 영정 사진의 로컬 URI (안 골랐으면 null).
+         * @param video 영상 입력 — 호출부가 로컬/원격/없음을 확정한 [MediaInput].
+         * @param photo 영정 사진 입력 — 픽 우선순위까지 반영해 호출부가 확정한 [MediaInput].
          */
         suspend operator fun invoke(
-            funeralVideoUrl: String?,
-            memorialPhotoUrl: String?,
-            pickedMemorialPhotoUri: String?,
+            video: MediaInput,
+            photo: MediaInput,
         ): Result<ResolvedMemorialMediaForSave> {
             // 두 Repository 중 하나라도 실패 → 도메인 예외로 wrap 후 invoke 자체를 즉시 종료
             // (getOrElse 람다 안의 `return` 은 non-local return — 함수 전체에서 빠져나감)
             val videoOutcome =
                 memorialVideoUploadRepository
-                    .resolveVideo(funeralVideoUrl)
+                    .resolveVideo(video)
                     .getOrElse { return Result.failure(MemorialVideoSaveException(it)) }
 
             val photoOutcome =
                 memorialPhotoUploadRepository
-                    .resolvePhoto(existingUrl = memorialPhotoUrl, pickedUri = pickedMemorialPhotoUri)
+                    .resolvePhoto(photo)
                     .getOrElse { return Result.failure(MemorialPhotoSaveException(it)) }
 
             return Result.success(

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/AfternoteEditorViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/AfternoteEditorViewModel.kt
@@ -12,6 +12,7 @@ import com.afternote.feature.afternote.domain.model.author.CreateAfternoteInput
 import com.afternote.feature.afternote.domain.model.author.SaveAfternoteCommand
 import com.afternote.feature.afternote.domain.repository.author.AfternoteRepository
 import com.afternote.feature.afternote.domain.repository.author.AuthorReceiverRepository
+import com.afternote.feature.afternote.domain.repository.author.MediaInput
 import com.afternote.feature.afternote.domain.repository.author.MemorialThumbnailUploadRepository
 import com.afternote.feature.afternote.domain.usecase.editor.ResolveMemorialMediaForSaveUseCase
 import com.afternote.feature.afternote.presentation.R
@@ -371,6 +372,23 @@ class AfternoteEditorViewModel
                 }
             }
 
+        // 영상: 로컬 pick(content://) 인지 원격 prefill URL 인지를 진입 경계에서 한 번 확정해 MediaInput 으로 넘긴다.
+        private fun videoMediaInput(url: String?): MediaInput {
+            if (url.isNullOrBlank()) return MediaInput.None
+            return if (url.startsWith("content://")) MediaInput.Local(url) else MediaInput.Remote(url)
+        }
+
+        // 영정 사진: 새로 고른 로컬 픽 우선 → 없으면 기존 원격 → 둘 다 없으면 없음.
+        private fun photoMediaInput(
+            picked: String?,
+            existing: String?,
+        ): MediaInput =
+            when {
+                !picked.isNullOrBlank() -> MediaInput.Local(picked)
+                !existing.isNullOrBlank() -> MediaInput.Remote(existing)
+                else -> MediaInput.None
+            }
+
         private suspend fun buildSaveCommand(
             editingId: Long?,
             categoryForApi: EditorCategory,
@@ -381,9 +399,12 @@ class AfternoteEditorViewModel
         ): Result<SaveAfternoteCommand> {
             val resolved =
                 resolveMemorialMediaForSave(
-                    funeralVideoUrl = memorialMedia.funeralVideoUrl,
-                    memorialPhotoUrl = memorialMedia.memorialPhotoUrl,
-                    pickedMemorialPhotoUri = memorialMedia.pickedMemorialPhotoUri,
+                    video = videoMediaInput(memorialMedia.funeralVideoUrl),
+                    photo =
+                        photoMediaInput(
+                            picked = memorialMedia.pickedMemorialPhotoUri,
+                            existing = memorialMedia.memorialPhotoUrl,
+                        ),
                 ).getOrElse { return Result.failure(it) }
 
             val command =


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #346

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 추모 미디어(영상·영정사진) 입력의 `String?` 3상태(로컬 `content://` / 원격 URL / null)를 `sealed MediaInput { Local / Remote / None }` 로 타입 안전화
- `resolveVideo`/`resolvePhoto` 시그니처를 `MediaInput` 기반으로 → 두 Impl 의 `content://` 런타임 prefix 판별 제거, `when(input)` exhaustive 분기
- `ResolveMemorialMediaForSaveUseCase(video, photo: MediaInput)` — 로컬/원격 확정(영상 `content://` 판별)·사진 픽 우선순위를 진입 경계(에디터 VM)로 이동
- dead 가 된 `LOCAL_CONTENT_SCHEME` const 제거 (thumbnail 은 `DIRECTORY_AFTERNOTES` 만 사용)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- 해당 없음 (입력 타입 안전화, 런타임 동작 동일)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- #247(출력단 sealed `*UploadOutcome`) 의 **입력단 대칭 후속**. 미디어 3종 제네릭 통합·form-state 자체 타입화는 범위 제외(이슈 명시 — premature abstraction 회피).
- 사진은 (picked, existing) 2인자를 단일 `MediaInput` 으로 합치고, 픽 우선순위는 VM 이 `displayMemorialPhotoUri()` 와 동일 규칙으로 결정.
- 검증: afternote domain+data+presentation `compileDebugKotlin` 통과.
- #349 잔여(ResolveMemorialMediaForSaveUseCase 단위 테스트)는 본 PR 머지 후 진행 예정.
