### PR TITLE
feat: 깊은 생각 작성 화면 카테고리 선택 바텀시트

### DIFF
--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/CategorySettingBottomSheet.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/CategorySettingBottomSheet.kt
@@ -40,21 +40,22 @@ fun CategorySettingBottomSheet(
     onDismiss: () -> Unit,
     onBackClick: () -> Unit,
     onAddCategory: () -> Unit,
+    onCategoryClick: (CategoryUiModel) -> Unit,
     onMenuClick: (CategoryUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     ModalBottomSheet(
         onDismissRequest = onDismiss,
-        containerColor = Color.White,
+        containerColor = AfternoteDesign.colors.gray1,
         dragHandle = {
             Box(
                 modifier =
                     Modifier
                         .padding(top = 12.dp, bottom = 8.dp)
-                        .width(36.dp)
+                        .width(40.dp)
                         .height(4.dp)
                         .clip(CircleShape)
-                        .background(Color(0xFFDDDDDD)),
+                        .background(Color(0xFFCCCCCC)),
             )
         },
     ) {
@@ -62,6 +63,7 @@ fun CategorySettingBottomSheet(
             categories = categories,
             onBackClick = onBackClick,
             onAddCategory = onAddCategory,
+            onCategoryClick = onCategoryClick,
             onMenuClick = onMenuClick,
         )
     }
@@ -74,6 +76,7 @@ fun CategorySettingContent(
     categories: List<CategoryUiModel>,
     onBackClick: () -> Unit,
     onAddCategory: () -> Unit,
+    onCategoryClick: (CategoryUiModel) -> Unit,
     onMenuClick: (CategoryUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -88,7 +91,7 @@ fun CategorySettingContent(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 4.dp),
+                    .padding(horizontal = 16.dp, vertical = 6.dp),
             contentAlignment = Alignment.Center,
         ) {
             // 뒤로가기
@@ -100,17 +103,17 @@ fun CategorySettingContent(
                         .align(Alignment.CenterStart)
                         .size(24.dp)
                         .clickable { onBackClick() },
-                tint = AfternoteDesign.colors.gray9,
+                tint = AfternoteDesign.colors.gray6,
             )
             Text(
                 text = stringResource(MindRecordR.string.mindrecord_category_setting_title),
-                style = AfternoteDesign.typography.h3,
-                color = AfternoteDesign.colors.gray9,
+                style = AfternoteDesign.typography.bodyBase,
+                color = AfternoteDesign.colors.gray6,
                 textAlign = TextAlign.Center,
             )
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(8.dp))
 
         // 새 카테고리 만들기
         Row(
@@ -118,16 +121,16 @@ fun CategorySettingContent(
                 Modifier
                     .fillMaxWidth()
                     .clickable { onAddCategory() }
-                    .padding(horizontal = 20.dp, vertical = 16.dp),
+                    .padding(horizontal = 24.dp, vertical = 16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
-                painter = painterResource(R.drawable.core_ui_add), // plus 아이콘
+                painter = painterResource(R.drawable.core_ui_add),
                 contentDescription = null,
                 tint = AfternoteDesign.colors.gray9,
-                modifier = Modifier.size(20.dp),
+                modifier = Modifier.size(24.dp),
             )
-            Spacer(modifier = Modifier.width(12.dp))
+            Spacer(modifier = Modifier.width(8.dp))
             Text(
                 text = stringResource(MindRecordR.string.mindrecord_category_new_title),
                 style = AfternoteDesign.typography.bodyBase,
@@ -135,15 +138,16 @@ fun CategorySettingContent(
             )
         }
 
-        HorizontalDivider(color = Color(0xFF000000).copy(alpha = 0.07f))
+        HorizontalDivider(color = AfternoteDesign.colors.gray3)
 
         // 카테고리 목록
         categories.forEach { category ->
             CategoryItem(
                 category = category,
+                onClick = { onCategoryClick(category) },
                 onMenuClick = { onMenuClick(category) },
             )
-            HorizontalDivider(color = Color(0xFF000000).copy(alpha = 0.07f))
+            HorizontalDivider(color = AfternoteDesign.colors.gray3)
         }
     }
 }
@@ -153,6 +157,7 @@ fun CategorySettingContent(
 @Composable
 fun CategoryItem(
     category: CategoryUiModel,
+    onClick: () -> Unit,
     onMenuClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -160,18 +165,19 @@ fun CategoryItem(
         modifier =
             modifier
                 .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 16.dp),
+                .clickable { onClick() }
+                .padding(horizontal = 24.dp, vertical = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         // 색상 원
         Box(
             modifier =
                 Modifier
-                    .size(20.dp)
+                    .size(24.dp)
                     .clip(CircleShape)
                     .background(category.color),
         )
-        Spacer(modifier = Modifier.width(16.dp))
+        Spacer(modifier = Modifier.width(8.dp))
         Text(
             text = category.name,
             style = AfternoteDesign.typography.bodyBase,
@@ -180,12 +186,12 @@ fun CategoryItem(
         )
         // 더보기 메뉴
         Icon(
-            painter = painterResource(R.drawable.core_ui_vertical), // ⋮ 아이콘
+            painter = painterResource(R.drawable.core_ui_vertical),
             contentDescription = stringResource(MindRecordR.string.mindrecord_more_cd),
-            tint = AfternoteDesign.colors.gray5,
+            tint = AfternoteDesign.colors.gray9,
             modifier =
                 Modifier
-                    .size(20.dp)
+                    .size(24.dp)
                     .clickable { onMenuClick() },
         )
     }
@@ -208,6 +214,7 @@ private fun CategorySettingContentPreview() {
             categories = sampleCategories,
             onBackClick = {},
             onAddCategory = {},
+            onCategoryClick = {},
             onMenuClick = {},
         )
     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
@@ -107,6 +107,7 @@ fun DeepThoughtScreen(
             onDismiss = { showCategorySheet = false },
             onBackClick = { showCategorySheet = false },
             onAddCategory = { addingCategory = true },
+            onCategoryClick = { showCategorySheet = false },
             onMenuClick = { menuTarget = it },
         )
     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtWriteScreen.kt
@@ -1,5 +1,6 @@
 package com.afternote.feature.mindrecord.presentation.screen.sender
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -136,7 +137,12 @@ fun DeepThoughtWriteScreen(
                     style = AfternoteDesign.typography.bodySmallB,
                     color = AfternoteDesign.colors.gray7,
                 )
-                Column(modifier = Modifier.padding(start = 12.dp)) {
+                Column(
+                    modifier =
+                        Modifier
+                            .padding(start = 12.dp)
+                            .clickable { showCategorySheet = true },
+                ) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween,
@@ -196,6 +202,10 @@ fun DeepThoughtWriteScreen(
                 onDismiss = { showCategorySheet = false },
                 onBackClick = { showCategorySheet = false },
                 onAddCategory = { },
+                onCategoryClick = { category ->
+                    viewModel.onCategoryChanged(category.name)
+                    showCategorySheet = false
+                },
                 onMenuClick = { },
             )
         }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
@@ -1,6 +1,5 @@
 package com.afternote.feature.mindrecord.presentation.screen.sender
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -146,11 +145,16 @@ fun DiaryWriteScreen(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Icon(
-                    painter = painterResource(com.afternote.feature.mindrecord.presentation.R.drawable.mindrecord_emotion),
-                    contentDescription = null,
-                    tint = Color(0xFF000000).copy(0.4f),
-                )
+                val selectedMood = uiState.mood
+                if (selectedMood != null) {
+                    Text(text = selectedMood.emoji())
+                } else {
+                    Icon(
+                        painter = painterResource(com.afternote.feature.mindrecord.presentation.R.drawable.mindrecord_emotion),
+                        contentDescription = null,
+                        tint = Color(0xFF000000).copy(0.4f),
+                    )
+                }
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
                     text = stringResource(MindRecordR.string.mindrecord_diary_write_mood_label),
@@ -169,47 +173,6 @@ fun DiaryWriteScreen(
                 Spacer(modifier = Modifier.width(8.dp))
                 MoodChip("😢", selected = uiState.mood == TodayMood.SAD) {
                     viewModel.onMoodSelected(TodayMood.SAD)
-                }
-            }
-            Row {
-                Button(
-                    onClick = {},
-                    colors = ButtonDefaults.buttonColors(containerColor = Color.White),
-                    border = BorderStroke(1.dp, color = Color(0xFF000000).copy(0.05f)),
-                ) {
-                    Icon(
-                        painter = painterResource(com.afternote.feature.mindrecord.presentation.R.drawable.mindrecord_pos),
-                        contentDescription = null,
-                        tint = Color(0xFF000000).copy(0.6f),
-                        modifier = Modifier.size(12.dp),
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = stringResource(MindRecordR.string.mindrecord_diary_write_add_location),
-                        style = AfternoteDesign.typography.captionLargeR,
-                        color = AfternoteDesign.colors.black.copy(alpha = 0.6f),
-                    )
-                }
-
-                Spacer(modifier = Modifier.width(4.dp))
-
-                Button(
-                    onClick = {},
-                    colors = ButtonDefaults.buttonColors(containerColor = Color.White),
-                    border = BorderStroke(1.dp, color = Color(0xFF000000).copy(0.05f)),
-                ) {
-                    Icon(
-                        painter = painterResource(com.afternote.feature.mindrecord.presentation.R.drawable.mindrecord_picture),
-                        contentDescription = null,
-                        tint = Color(0xFF000000).copy(0.6f),
-                        modifier = Modifier.size(12.dp),
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = stringResource(MindRecordR.string.mindrecord_diary_write_add_photo),
-                        style = AfternoteDesign.typography.captionLargeR,
-                        color = AfternoteDesign.colors.black.copy(alpha = 0.6f),
-                    )
                 }
             }
 
@@ -264,6 +227,13 @@ private fun MoodChip(
         Text(text = emoji)
     }
 }
+
+private fun TodayMood.emoji(): String =
+    when (this) {
+        TodayMood.HAPPY -> "😊"
+        TodayMood.SOSO -> "😐"
+        TodayMood.SAD -> "😢"
+    }
 
 @Preview(showBackground = true)
 @Composable

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteUiState.kt
@@ -6,11 +6,11 @@ import java.time.LocalDate
 data class DiaryWriteUiState(
     val title: String = "",
     val content: String = "",
-    val mood: TodayMood = TodayMood.SOSO,
+    val mood: TodayMood? = null,
     val date: LocalDate = LocalDate.now(),
     val imageUrl: String? = null,
     val submitState: SubmitState = SubmitState.Idle,
 ) {
     val canSubmit: Boolean
-        get() = title.isNotBlank() && content.isNotBlank() && submitState != SubmitState.InProgress
+        get() = title.isNotBlank() && content.isNotBlank() && mood != null && submitState != SubmitState.InProgress
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteViewModel.kt
@@ -44,6 +44,7 @@ class DiaryWriteViewModel
         fun submit(isDraft: Boolean = false) {
             val state = _uiState.value
             if (!state.canSubmit) return
+            val mood = state.mood ?: return
 
             viewModelScope.launch {
                 _uiState.update { it.copy(submitState = SubmitState.InProgress) }
@@ -53,7 +54,7 @@ class DiaryWriteViewModel
                             title = state.title,
                             content = state.content,
                             isDraft = isDraft,
-                            todayMood = state.mood,
+                            todayMood = mood,
                             imageUrl = state.imageUrl,
                         ),
                     ).onSuccess {

--- a/feature/mindrecord/presentation/src/main/res/values/strings.xml
+++ b/feature/mindrecord/presentation/src/main/res/values/strings.xml
@@ -38,8 +38,6 @@
     <string name="mindrecord_diary_write_title">일기 기록하기</string>
     <string name="mindrecord_diary_write_title_placeholder">제목을 입력하세요.</string>
     <string name="mindrecord_diary_write_mood_label">오늘의 기분</string>
-    <string name="mindrecord_diary_write_add_location">위치 추가</string>
-    <string name="mindrecord_diary_write_add_photo">사진 추가</string>
 
     <string name="mindrecord_deep_thought_write_title">깊은 생각 기록하기</string>
     <string name="mindrecord_deep_thought_write_title_label">제목</string>


### PR DESCRIPTION
## Summary
- Figma 디자인대로 카테고리 선택 바텀시트 구현 (드래그핸들, 헤더, 새 카테고리 + 리스트)
- 카테고리 항목 클릭 시 onCategoryClick 콜백 추가 → 작성 화면에서 카테고리 적용
- 깊은 생각 탭의 카테고리 관리 시트는 컴파일 호환을 위해 닫기 동작 연결

## Test plan
- [ ] 빌드 통과 (`:feature:mindrecord:presentation:compileDebugKotlin`)
- [ ] 깊은 생각 작성 화면에서 카테고리 선택 바텀시트 정상 표시 확인
- [ ] 바텀시트에서 카테고리 항목 탭 시 시트가 닫히고 카테고리 적용 확인
- [ ] 깊은 생각 탭의 카테고리 설정 시트에서 항목 탭 시 시트 닫힘 확인

## Merge order
Must be merged after #371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)