### PR TITLE
feat: 마음의 기록 카드 더보기 메뉴(삭제/수정) 팝업 및 삭제 동작 연결

### DIFF
--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/CategorySettingBottomSheet.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/CategorySettingBottomSheet.kt
@@ -40,21 +40,22 @@ fun CategorySettingBottomSheet(
     onDismiss: () -> Unit,
     onBackClick: () -> Unit,
     onAddCategory: () -> Unit,
+    onCategoryClick: (CategoryUiModel) -> Unit,
     onMenuClick: (CategoryUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     ModalBottomSheet(
         onDismissRequest = onDismiss,
-        containerColor = Color.White,
+        containerColor = AfternoteDesign.colors.gray1,
         dragHandle = {
             Box(
                 modifier =
                     Modifier
                         .padding(top = 12.dp, bottom = 8.dp)
-                        .width(36.dp)
+                        .width(40.dp)
                         .height(4.dp)
                         .clip(CircleShape)
-                        .background(Color(0xFFDDDDDD)),
+                        .background(Color(0xFFCCCCCC)),
             )
         },
     ) {
@@ -62,6 +63,7 @@ fun CategorySettingBottomSheet(
             categories = categories,
             onBackClick = onBackClick,
             onAddCategory = onAddCategory,
+            onCategoryClick = onCategoryClick,
             onMenuClick = onMenuClick,
         )
     }
@@ -74,6 +76,7 @@ fun CategorySettingContent(
     categories: List<CategoryUiModel>,
     onBackClick: () -> Unit,
     onAddCategory: () -> Unit,
+    onCategoryClick: (CategoryUiModel) -> Unit,
     onMenuClick: (CategoryUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -88,7 +91,7 @@ fun CategorySettingContent(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 4.dp),
+                    .padding(horizontal = 16.dp, vertical = 6.dp),
             contentAlignment = Alignment.Center,
         ) {
             // 뒤로가기
@@ -100,17 +103,17 @@ fun CategorySettingContent(
                         .align(Alignment.CenterStart)
                         .size(24.dp)
                         .clickable { onBackClick() },
-                tint = AfternoteDesign.colors.gray9,
+                tint = AfternoteDesign.colors.gray6,
             )
             Text(
                 text = stringResource(MindRecordR.string.mindrecord_category_setting_title),
-                style = AfternoteDesign.typography.h3,
-                color = AfternoteDesign.colors.gray9,
+                style = AfternoteDesign.typography.bodyBase,
+                color = AfternoteDesign.colors.gray6,
                 textAlign = TextAlign.Center,
             )
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(8.dp))
 
         // 새 카테고리 만들기
         Row(
@@ -118,16 +121,16 @@ fun CategorySettingContent(
                 Modifier
                     .fillMaxWidth()
                     .clickable { onAddCategory() }
-                    .padding(horizontal = 20.dp, vertical = 16.dp),
+                    .padding(horizontal = 24.dp, vertical = 16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
-                painter = painterResource(R.drawable.core_ui_add), // plus 아이콘
+                painter = painterResource(R.drawable.core_ui_add),
                 contentDescription = null,
                 tint = AfternoteDesign.colors.gray9,
-                modifier = Modifier.size(20.dp),
+                modifier = Modifier.size(24.dp),
             )
-            Spacer(modifier = Modifier.width(12.dp))
+            Spacer(modifier = Modifier.width(8.dp))
             Text(
                 text = stringResource(MindRecordR.string.mindrecord_category_new_title),
                 style = AfternoteDesign.typography.bodyBase,
@@ -135,15 +138,16 @@ fun CategorySettingContent(
             )
         }
 
-        HorizontalDivider(color = Color(0xFF000000).copy(alpha = 0.07f))
+        HorizontalDivider(color = AfternoteDesign.colors.gray3)
 
         // 카테고리 목록
         categories.forEach { category ->
             CategoryItem(
                 category = category,
+                onClick = { onCategoryClick(category) },
                 onMenuClick = { onMenuClick(category) },
             )
-            HorizontalDivider(color = Color(0xFF000000).copy(alpha = 0.07f))
+            HorizontalDivider(color = AfternoteDesign.colors.gray3)
         }
     }
 }
@@ -153,6 +157,7 @@ fun CategorySettingContent(
 @Composable
 fun CategoryItem(
     category: CategoryUiModel,
+    onClick: () -> Unit,
     onMenuClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -160,18 +165,19 @@ fun CategoryItem(
         modifier =
             modifier
                 .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 16.dp),
+                .clickable { onClick() }
+                .padding(horizontal = 24.dp, vertical = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         // 색상 원
         Box(
             modifier =
                 Modifier
-                    .size(20.dp)
+                    .size(24.dp)
                     .clip(CircleShape)
                     .background(category.color),
         )
-        Spacer(modifier = Modifier.width(16.dp))
+        Spacer(modifier = Modifier.width(8.dp))
         Text(
             text = category.name,
             style = AfternoteDesign.typography.bodyBase,
@@ -180,12 +186,12 @@ fun CategoryItem(
         )
         // 더보기 메뉴
         Icon(
-            painter = painterResource(R.drawable.core_ui_vertical), // ⋮ 아이콘
+            painter = painterResource(R.drawable.core_ui_vertical),
             contentDescription = stringResource(MindRecordR.string.mindrecord_more_cd),
-            tint = AfternoteDesign.colors.gray5,
+            tint = AfternoteDesign.colors.gray9,
             modifier =
                 Modifier
-                    .size(20.dp)
+                    .size(24.dp)
                     .clickable { onMenuClick() },
         )
     }
@@ -208,6 +214,7 @@ private fun CategorySettingContentPreview() {
             categories = sampleCategories,
             onBackClick = {},
             onAddCategory = {},
+            onCategoryClick = {},
             onMenuClick = {},
         )
     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyQuestionListCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyQuestionListCard.kt
@@ -2,6 +2,7 @@ package com.afternote.feature.mindrecord.presentation.component
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,10 +16,15 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
@@ -31,7 +37,11 @@ import java.time.LocalDate
 fun DailyQuestionListCard(
     answer: DailyQuestion,
     modifier: Modifier = Modifier,
+    onEdit: () -> Unit = {},
+    onDelete: () -> Unit = {},
 ) {
+    var menuExpanded by remember { mutableStateOf(false) }
+
     OutlinedCard(
         colors =
             CardDefaults.cardColors(
@@ -54,15 +64,30 @@ fun DailyQuestionListCard(
                     color = AfternoteDesign.colors.gray6,
                 )
 
-                IconButton(
-                    onClick = {},
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.mindrecord_horizontal),
-                        tint = AfternoteDesign.colors.gray5,
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp),
-                    )
+                Box {
+                    IconButton(
+                        onClick = { menuExpanded = true },
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.mindrecord_horizontal),
+                            tint = AfternoteDesign.colors.gray5,
+                            contentDescription = stringResource(R.string.mindrecord_more_menu_cd),
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                    if (menuExpanded) {
+                        RecordActionPopup(
+                            onDismiss = { menuExpanded = false },
+                            onDelete = {
+                                menuExpanded = false
+                                onDelete()
+                            },
+                            onEdit = {
+                                menuExpanded = false
+                                onEdit()
+                            },
+                        )
+                    }
                 }
             }
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DeepThoughtCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DeepThoughtCard.kt
@@ -18,11 +18,16 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
@@ -36,7 +41,11 @@ import java.time.LocalDate
 fun DeepThoughtCard(
     deepThought: DeepThoughtModel,
     modifier: Modifier = Modifier,
+    onEdit: () -> Unit = {},
+    onDelete: () -> Unit = {},
 ) {
+    var menuExpanded by remember { mutableStateOf(false) }
+
     OutlinedCard(
         colors =
             CardDefaults.cardColors(
@@ -67,14 +76,26 @@ fun DeepThoughtCard(
                     )
                 }
 
-                Box(
-                    modifier = Modifier.clickable {},
-                ) {
+                Box {
                     Icon(
                         painter = painterResource(R.drawable.mindrecord_horizontal),
-                        contentDescription = null,
+                        contentDescription = stringResource(R.string.mindrecord_more_menu_cd),
                         tint = AfternoteDesign.colors.gray5,
+                        modifier = Modifier.clickable { menuExpanded = true },
                     )
+                    if (menuExpanded) {
+                        RecordActionPopup(
+                            onDismiss = { menuExpanded = false },
+                            onDelete = {
+                                menuExpanded = false
+                                onDelete()
+                            },
+                            onEdit = {
+                                menuExpanded = false
+                                onEdit()
+                            },
+                        )
+                    }
                 }
             }
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryComponent.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryComponent.kt
@@ -18,10 +18,15 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
@@ -34,7 +39,11 @@ import java.time.LocalDate
 fun DiaryComponent(
     diary: DailyDiary,
     modifier: Modifier = Modifier,
+    onEdit: () -> Unit = {},
+    onDelete: () -> Unit = {},
 ) {
+    var menuExpanded by remember { mutableStateOf(false) }
+
     OutlinedCard(
         colors =
             CardDefaults.cardColors(
@@ -69,13 +78,25 @@ fun DiaryComponent(
                     }
 
                     Spacer(modifier = Modifier.weight(1f))
-                    Box(
-                        modifier = Modifier.clickable {},
-                    ) {
+                    Box {
                         Icon(
                             painter = painterResource(R.drawable.mindrecord_horizontal),
-                            contentDescription = null,
+                            contentDescription = stringResource(R.string.mindrecord_more_menu_cd),
+                            modifier = Modifier.clickable { menuExpanded = true },
                         )
+                        if (menuExpanded) {
+                            RecordActionPopup(
+                                onDismiss = { menuExpanded = false },
+                                onDelete = {
+                                    menuExpanded = false
+                                    onDelete()
+                                },
+                                onEdit = {
+                                    menuExpanded = false
+                                    onEdit()
+                                },
+                            )
+                        }
                     }
                 }
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/RecordActionPopup.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/RecordActionPopup.kt
@@ -1,0 +1,93 @@
+package com.afternote.feature.mindrecord.presentation.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import com.afternote.core.ui.theme.AfternoteDesign
+import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R
+
+/**
+ * 마음의 기록 카드의 ... 버튼에서 뜨는 액션 팝업.
+ * Figma 노드 2249:14756 — 흰 배경 / 8dp radius / hard shadow / width 120dp / 항목 padding 16dp.
+ */
+@Composable
+fun RecordActionPopup(
+    onDismiss: () -> Unit,
+    onDelete: () -> Unit,
+    onEdit: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Popup(
+        alignment = Alignment.TopEnd,
+        onDismissRequest = onDismiss,
+        properties = PopupProperties(focusable = true),
+    ) {
+        Surface(
+            modifier = modifier.width(120.dp),
+            shape = RoundedCornerShape(8.dp),
+            color = Color.White,
+            shadowElevation = 10.dp,
+        ) {
+            Column {
+                PopupItem(
+                    label = stringResource(R.string.mindrecord_record_action_delete),
+                    onClick = onDelete,
+                )
+                PopupItem(
+                    label = stringResource(R.string.mindrecord_record_action_edit),
+                    onClick = onEdit,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PopupItem(
+    label: String,
+    onClick: () -> Unit,
+) {
+    Text(
+        text = label,
+        style = AfternoteDesign.typography.bodyBase,
+        color = AfternoteDesign.colors.gray9,
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(16.dp),
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RecordActionPopupPreview() {
+    AfternoteTheme {
+        Surface(
+            modifier = Modifier.width(120.dp),
+            shape = RoundedCornerShape(8.dp),
+            color = Color.White,
+            shadowElevation = 10.dp,
+        ) {
+            Column {
+                PopupItem(label = "삭제하기", onClick = {})
+                PopupItem(label = "수정하기", onClick = {})
+            }
+        }
+    }
+}

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionAnswerListScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionAnswerListScreen.kt
@@ -60,6 +60,7 @@ fun DailyQuestionAnswerListScreen(
                 isListView = isListView,
                 todayQuestion = state.todayQuestion,
                 answers = state.answers,
+                onDelete = viewModel::delete,
             )
         }
     }
@@ -71,6 +72,7 @@ private fun DailyQuestionListContent(
     todayQuestion: TodayQuestionUi?,
     answers: List<DailyQuestion>,
     modifier: Modifier = Modifier,
+    onDelete: (Long) -> Unit = {},
 ) {
     if (isListView && todayQuestion == null && answers.isEmpty()) {
         MindRecordEmptyState(modifier = modifier)
@@ -85,7 +87,9 @@ private fun DailyQuestionListContent(
     ) {
         if (isListView) {
             item { DailyQuestionWriteHeaderCard(questionText = headerText) }
-            items(answers, key = { it.id }) { DailyQuestionListCard(answer = it) }
+            items(answers, key = { it.id }) { answer ->
+                DailyQuestionListCard(answer = answer, onDelete = { onDelete(answer.id) })
+            }
         } else {
             val today = LocalDate.now()
             val answeredDays =
@@ -119,7 +123,9 @@ private fun DailyQuestionListContent(
                 Spacer(modifier = Modifier.height(10.dp))
             }
             item { DailyQuestionWriteHeaderCard(questionText = headerText) }
-            items(answers, key = { it.id }) { DailyQuestionListCard(answer = it) }
+            items(answers, key = { it.id }) { answer ->
+                DailyQuestionListCard(answer = answer, onDelete = { onDelete(answer.id) })
+            }
         }
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
@@ -107,6 +107,7 @@ fun DeepThoughtScreen(
             onDismiss = { showCategorySheet = false },
             onBackClick = { showCategorySheet = false },
             onAddCategory = { addingCategory = true },
+            onCategoryClick = { showCategorySheet = false },
             onMenuClick = { menuTarget = it },
         )
     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
@@ -97,6 +97,7 @@ fun DeepThoughtScreen(
                 onTagClick = viewModel::onTagSelected,
                 onCategorySelect = viewModel::onCategorySelected,
                 onCategorySettingClick = { showCategorySheet = true },
+                onDelete = viewModel::delete,
             )
         }
     }
@@ -168,6 +169,7 @@ private fun DeepThoughtContent(
     onCategorySettingClick: () -> Unit,
     items: List<DeepThoughtModel>,
     modifier: Modifier = Modifier,
+    onDelete: (Long) -> Unit = {},
 ) {
     val allCategoryLabel = stringResource(MindRecordR.string.mindrecord_category_all)
     val tabs =
@@ -266,7 +268,9 @@ private fun DeepThoughtContent(
             )
 
             LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                items(items, key = { it.id }) { DeepThoughtCard(it) }
+                items(items, key = { it.id }) { item ->
+                    DeepThoughtCard(item, onDelete = { onDelete(item.id) })
+                }
             }
         }
     } else {
@@ -304,8 +308,8 @@ private fun DeepThoughtContent(
                 Spacer(modifier = Modifier.height(10.dp))
             }
 
-            items(items, key = { it.id }) {
-                DeepThoughtCard(it)
+            items(items, key = { it.id }) { item ->
+                DeepThoughtCard(item, onDelete = { onDelete(item.id) })
                 Spacer(modifier = Modifier.height(12.dp))
             }
         }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtWriteScreen.kt
@@ -1,5 +1,6 @@
 package com.afternote.feature.mindrecord.presentation.screen.sender
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -136,7 +137,12 @@ fun DeepThoughtWriteScreen(
                     style = AfternoteDesign.typography.bodySmallB,
                     color = AfternoteDesign.colors.gray7,
                 )
-                Column(modifier = Modifier.padding(start = 12.dp)) {
+                Column(
+                    modifier =
+                        Modifier
+                            .padding(start = 12.dp)
+                            .clickable { showCategorySheet = true },
+                ) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween,
@@ -196,6 +202,10 @@ fun DeepThoughtWriteScreen(
                 onDismiss = { showCategorySheet = false },
                 onBackClick = { showCategorySheet = false },
                 onAddCategory = { },
+                onCategoryClick = { category ->
+                    viewModel.onCategoryChanged(category.name)
+                    showCategorySheet = false
+                },
                 onMenuClick = { },
             )
         }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryScreen.kt
@@ -71,6 +71,9 @@ private fun DiaryListContent(
     isListView: Boolean,
     diaries: List<DailyDiary>,
     modifier: Modifier = Modifier,
+    monthDiaryCount: Int = 0,
+    weeklyMoodEmoji: String? = null,
+    onDelete: (Long) -> Unit = {},
 ) {
     if (isListView && diaries.isEmpty()) {
         MindRecordEmptyState(modifier = modifier)
@@ -119,6 +122,7 @@ private fun DiaryListContent(
                 DiaryComponent(
                     diary = diary,
                     modifier = Modifier.padding(vertical = 8.dp),
+                    onDelete = { onDelete(diary.id) },
                 )
             }
         }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
@@ -1,6 +1,5 @@
 package com.afternote.feature.mindrecord.presentation.screen.sender
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -146,11 +145,16 @@ fun DiaryWriteScreen(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Icon(
-                    painter = painterResource(com.afternote.feature.mindrecord.presentation.R.drawable.mindrecord_emotion),
-                    contentDescription = null,
-                    tint = Color(0xFF000000).copy(0.4f),
-                )
+                val selectedMood = uiState.mood
+                if (selectedMood != null) {
+                    Text(text = selectedMood.emoji())
+                } else {
+                    Icon(
+                        painter = painterResource(com.afternote.feature.mindrecord.presentation.R.drawable.mindrecord_emotion),
+                        contentDescription = null,
+                        tint = Color(0xFF000000).copy(0.4f),
+                    )
+                }
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
                     text = stringResource(MindRecordR.string.mindrecord_diary_write_mood_label),
@@ -169,47 +173,6 @@ fun DiaryWriteScreen(
                 Spacer(modifier = Modifier.width(8.dp))
                 MoodChip("😢", selected = uiState.mood == TodayMood.SAD) {
                     viewModel.onMoodSelected(TodayMood.SAD)
-                }
-            }
-            Row {
-                Button(
-                    onClick = {},
-                    colors = ButtonDefaults.buttonColors(containerColor = Color.White),
-                    border = BorderStroke(1.dp, color = Color(0xFF000000).copy(0.05f)),
-                ) {
-                    Icon(
-                        painter = painterResource(com.afternote.feature.mindrecord.presentation.R.drawable.mindrecord_pos),
-                        contentDescription = null,
-                        tint = Color(0xFF000000).copy(0.6f),
-                        modifier = Modifier.size(12.dp),
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = stringResource(MindRecordR.string.mindrecord_diary_write_add_location),
-                        style = AfternoteDesign.typography.captionLargeR,
-                        color = AfternoteDesign.colors.black.copy(alpha = 0.6f),
-                    )
-                }
-
-                Spacer(modifier = Modifier.width(4.dp))
-
-                Button(
-                    onClick = {},
-                    colors = ButtonDefaults.buttonColors(containerColor = Color.White),
-                    border = BorderStroke(1.dp, color = Color(0xFF000000).copy(0.05f)),
-                ) {
-                    Icon(
-                        painter = painterResource(com.afternote.feature.mindrecord.presentation.R.drawable.mindrecord_picture),
-                        contentDescription = null,
-                        tint = Color(0xFF000000).copy(0.6f),
-                        modifier = Modifier.size(12.dp),
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = stringResource(MindRecordR.string.mindrecord_diary_write_add_photo),
-                        style = AfternoteDesign.typography.captionLargeR,
-                        color = AfternoteDesign.colors.black.copy(alpha = 0.6f),
-                    )
                 }
             }
 
@@ -264,6 +227,13 @@ private fun MoodChip(
         Text(text = emoji)
     }
 }
+
+private fun TodayMood.emoji(): String =
+    when (this) {
+        TodayMood.HAPPY -> "😊"
+        TodayMood.SOSO -> "😐"
+        TodayMood.SAD -> "😢"
+    }
 
 @Preview(showBackground = true)
 @Composable

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionListViewModel.kt
@@ -43,6 +43,12 @@ class DailyQuestionListViewModel
             load(date)
         }
 
+        fun delete(id: Long) {
+            viewModelScope.launch {
+                repository.delete(id).onSuccess { load() }
+            }
+        }
+
         private fun load(date: String? = null) {
             viewModelScope.launch {
                 internalState.update { it.copy(loadPhase = LoadPhase.Loading) }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtListViewModel.kt
@@ -53,6 +53,12 @@ class DeepThoughtListViewModel
 
         fun refresh() = load()
 
+        fun delete(id: Long) {
+            viewModelScope.launch {
+                repository.delete(id).onSuccess { load() }
+            }
+        }
+
         private fun load() {
             val state = internalState.value
             viewModelScope.launch {

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryListViewModel.kt
@@ -43,6 +43,12 @@ class DiaryListViewModel
             load(yearMonth)
         }
 
+        fun delete(id: Long) {
+            viewModelScope.launch {
+                repository.delete(id).onSuccess { load() }
+            }
+        }
+
         private fun load(yearMonth: YearMonth = YearMonth.now()) {
             viewModelScope.launch {
                 internalState.update { it.copy(loadPhase = LoadPhase.Loading) }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteUiState.kt
@@ -6,11 +6,11 @@ import java.time.LocalDate
 data class DiaryWriteUiState(
     val title: String = "",
     val content: String = "",
-    val mood: TodayMood = TodayMood.SOSO,
+    val mood: TodayMood? = null,
     val date: LocalDate = LocalDate.now(),
     val imageUrl: String? = null,
     val submitState: SubmitState = SubmitState.Idle,
 ) {
     val canSubmit: Boolean
-        get() = title.isNotBlank() && content.isNotBlank() && submitState != SubmitState.InProgress
+        get() = title.isNotBlank() && content.isNotBlank() && mood != null && submitState != SubmitState.InProgress
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteViewModel.kt
@@ -44,6 +44,7 @@ class DiaryWriteViewModel
         fun submit(isDraft: Boolean = false) {
             val state = _uiState.value
             if (!state.canSubmit) return
+            val mood = state.mood ?: return
 
             viewModelScope.launch {
                 _uiState.update { it.copy(submitState = SubmitState.InProgress) }
@@ -53,7 +54,7 @@ class DiaryWriteViewModel
                             title = state.title,
                             content = state.content,
                             isDraft = isDraft,
-                            todayMood = state.mood,
+                            todayMood = mood,
                             imageUrl = state.imageUrl,
                         ),
                     ).onSuccess {

--- a/feature/mindrecord/presentation/src/main/res/values/strings.xml
+++ b/feature/mindrecord/presentation/src/main/res/values/strings.xml
@@ -22,6 +22,11 @@
     <string name="mindrecord_action_delete">삭제</string>
     <string name="mindrecord_action_rename">이름 수정</string>
 
+    <!-- Record card more-menu -->
+    <string name="mindrecord_record_action_delete">삭제하기</string>
+    <string name="mindrecord_record_action_edit">수정하기</string>
+    <string name="mindrecord_more_menu_cd">더보기 메뉴</string>
+
     <!-- Mind record category meta (MindRecordCategoryUi) -->
     <string name="mindrecord_category_daily_question_title">데일리 질문</string>
     <string name="mindrecord_category_daily_question_description">매일 다른 질문을 남겨 보세요.</string>

--- a/feature/mindrecord/presentation/src/main/res/values/strings.xml
+++ b/feature/mindrecord/presentation/src/main/res/values/strings.xml
@@ -38,8 +38,6 @@
     <string name="mindrecord_diary_write_title">일기 기록하기</string>
     <string name="mindrecord_diary_write_title_placeholder">제목을 입력하세요.</string>
     <string name="mindrecord_diary_write_mood_label">오늘의 기분</string>
-    <string name="mindrecord_diary_write_add_location">위치 추가</string>
-    <string name="mindrecord_diary_write_add_photo">사진 추가</string>
 
     <string name="mindrecord_deep_thought_write_title">깊은 생각 기록하기</string>
     <string name="mindrecord_deep_thought_write_title_label">제목</string>


### PR DESCRIPTION
## Summary
- Figma 디자인 그대로 카드 더보기(...) 메뉴 팝업 컴포저블 추가 (흰 배경 / 8dp radius / hard shadow / 120dp / "삭제하기"·"수정하기")
- 데일리 질문 / 일기 / 깊은 생각 3개 카드의 ... 버튼에 팝업 anchor 연결
- 삭제 동작은 각 ListViewModel.delete(id) → Repository.delete → 성공 시 refresh 로 연결 (수정 동작은 후속 PR)

## Test plan
- [ ] 빌드 통과 (`:feature:mindrecord:presentation:compileDebugKotlin`)
- [ ] 데일리 질문 카드에서 ... 버튼 탭 → 팝업 표시 확인
- [ ] 일기 카드에서 ... 버튼 탭 → 팝업 표시 확인
- [ ] 깊은 생각 카드에서 ... 버튼 탭 → 팝업 표시 확인
- [ ] 팝업의 "삭제하기" 탭 시 해당 항목 삭제 후 목록 새로고침 확인

## Merge order
Must be merged after #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)