### PR TITLE
feat: 마음의 기록 화면 디자인 및 API 연결 — 감정 이모지·카테고리 시트·카드 더보기 메뉴·일기 리포트

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
@@ -115,6 +115,14 @@ fun rememberMindRecordNavActions(navController: NavController): MindRecordNavAct
             override fun onWriteSubmitSuccess() {
                 navController.popBackStack()
             }
+
+            override fun onNavigateToDraftList() {
+                navController.navigate(MindRecordRoute.DraftListRoute)
+            }
+
+            override fun onDraftListBack() {
+                navController.popBackStack()
+            }
         }
     }
 

--- a/app/src/main/java/com/afternote/afternote_fe/usecase/GetHomeSummaryUseCase.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/usecase/GetHomeSummaryUseCase.kt
@@ -39,7 +39,7 @@ class GetHomeSummaryUseCase
 
                     val profile = profileDeferred.await()
                     val receivers = receiversDeferred.await()
-                    val diaryCount = diaryDeferred.await().getOrNull()?.size ?: 0
+                    val diaryCount = diaryDeferred.await().getOrNull()?.monthDiaryCount ?: 0
                     val deepThoughtCount =
                         deepThoughtDeferred
                             .await()

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DiaryDto.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DiaryDto.kt
@@ -44,10 +44,11 @@ data class DiaryListItem(
     @SerialName("todayMood") val todayMood: TodayMood,
 )
 
-// `/diary` 응답의 `data` 는 배열이 아니라 객체 — `diaries` 외에도
-// `yearMonth`, `monthDiaryCount`, `weeklyDominantMood` 가 함께 내려오지만
-// 현재는 목록만 사용. (Json 글로벌 설정에 `ignoreUnknownKeys = true` 적용됨)
+// `/diary` 응답의 `data` 는 객체 — `diaries` 외에 조회 대상 달의 비-임시 다이어리 수
+// (`monthDiaryCount`)와 최근 7일 최빈 기분(`weeklyDominantMood`)이 함께 내려옴.
 @Serializable
 data class DiaryListResponse(
     @SerialName("diaries") val diaries: List<DiaryListItem> = emptyList(),
+    @SerialName("monthDiaryCount") val monthDiaryCount: Int = 0,
+    @SerialName("weeklyDominantMood") val weeklyDominantMood: TodayMood? = null,
 )

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DiaryMapper.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DiaryMapper.kt
@@ -2,9 +2,11 @@ package com.afternote.feature.mindrecord.data.mapper
 
 import com.afternote.feature.mindrecord.data.dto.DiaryCreateRequest
 import com.afternote.feature.mindrecord.data.dto.DiaryListItem
+import com.afternote.feature.mindrecord.data.dto.DiaryListResponse
 import com.afternote.feature.mindrecord.data.dto.DiaryUpdateRequest
 import com.afternote.feature.mindrecord.domain.model.Diary
 import com.afternote.feature.mindrecord.domain.model.DiaryCreatePayload
+import com.afternote.feature.mindrecord.domain.model.DiaryList
 import com.afternote.feature.mindrecord.domain.model.DiaryUpdatePayload
 import com.afternote.feature.mindrecord.domain.model.TodayMood
 import com.afternote.feature.mindrecord.data.dto.TodayMood as TodayMoodDto
@@ -17,6 +19,13 @@ fun DiaryListItem.toDomain(): Diary =
         createdAt = createdAt,
         todayMood = todayMood.toDomain(),
         imageUrl = imageUrl,
+    )
+
+fun DiaryListResponse.toDomain(): DiaryList =
+    DiaryList(
+        diaries = diaries.map { it.toDomain() },
+        monthDiaryCount = monthDiaryCount,
+        weeklyDominantMood = weeklyDominantMood?.toDomain(),
     )
 
 fun TodayMoodDto.toDomain(): TodayMood =

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/repositoryimpl/DiaryRepositoryImpl.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/repositoryimpl/DiaryRepositoryImpl.kt
@@ -5,8 +5,8 @@ import com.afternote.core.network.model.requireStatus
 import com.afternote.feature.mindrecord.data.api.DiaryApiService
 import com.afternote.feature.mindrecord.data.mapper.toDomain
 import com.afternote.feature.mindrecord.data.mapper.toRequest
-import com.afternote.feature.mindrecord.domain.model.Diary
 import com.afternote.feature.mindrecord.domain.model.DiaryCreatePayload
+import com.afternote.feature.mindrecord.domain.model.DiaryList
 import com.afternote.feature.mindrecord.domain.model.DiaryUpdatePayload
 import com.afternote.feature.mindrecord.domain.repository.DiaryRepository
 import javax.inject.Inject
@@ -19,13 +19,12 @@ class DiaryRepositoryImpl
         override suspend fun getList(
             yearMonth: String,
             draftOnly: Boolean?,
-        ): Result<List<Diary>> =
+        ): Result<DiaryList> =
             runCatching {
                 api
                     .getDiaries(yearMonth = yearMonth, draftOnly = draftOnly)
                     .requireData()
-                    .diaries
-                    .map { it.toDomain() }
+                    .toDomain()
             }
 
         override suspend fun create(payload: DiaryCreatePayload): Result<Unit> =

--- a/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/DiaryModels.kt
+++ b/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/DiaryModels.kt
@@ -15,6 +15,12 @@ data class Diary(
     val imageUrl: String? = null,
 )
 
+data class DiaryList(
+    val diaries: List<Diary>,
+    val monthDiaryCount: Int,
+    val weeklyDominantMood: TodayMood?,
+)
+
 data class DiaryCreatePayload(
     val title: String,
     val content: String,

--- a/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/repository/DiaryRepository.kt
+++ b/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/repository/DiaryRepository.kt
@@ -1,14 +1,14 @@
 package com.afternote.feature.mindrecord.domain.repository
 
-import com.afternote.feature.mindrecord.domain.model.Diary
 import com.afternote.feature.mindrecord.domain.model.DiaryCreatePayload
+import com.afternote.feature.mindrecord.domain.model.DiaryList
 import com.afternote.feature.mindrecord.domain.model.DiaryUpdatePayload
 
 interface DiaryRepository {
     suspend fun getList(
         yearMonth: String,
         draftOnly: Boolean? = null,
-    ): Result<List<Diary>>
+    ): Result<DiaryList>
 
     suspend fun create(payload: DiaryCreatePayload): Result<Unit>
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/CategorySettingBottomSheet.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/CategorySettingBottomSheet.kt
@@ -40,21 +40,22 @@ fun CategorySettingBottomSheet(
     onDismiss: () -> Unit,
     onBackClick: () -> Unit,
     onAddCategory: () -> Unit,
+    onCategoryClick: (CategoryUiModel) -> Unit,
     onMenuClick: (CategoryUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     ModalBottomSheet(
         onDismissRequest = onDismiss,
-        containerColor = Color.White,
+        containerColor = AfternoteDesign.colors.gray1,
         dragHandle = {
             Box(
                 modifier =
                     Modifier
                         .padding(top = 12.dp, bottom = 8.dp)
-                        .width(36.dp)
+                        .width(40.dp)
                         .height(4.dp)
                         .clip(CircleShape)
-                        .background(Color(0xFFDDDDDD)),
+                        .background(Color(0xFFCCCCCC)),
             )
         },
     ) {
@@ -62,6 +63,7 @@ fun CategorySettingBottomSheet(
             categories = categories,
             onBackClick = onBackClick,
             onAddCategory = onAddCategory,
+            onCategoryClick = onCategoryClick,
             onMenuClick = onMenuClick,
         )
     }
@@ -74,6 +76,7 @@ fun CategorySettingContent(
     categories: List<CategoryUiModel>,
     onBackClick: () -> Unit,
     onAddCategory: () -> Unit,
+    onCategoryClick: (CategoryUiModel) -> Unit,
     onMenuClick: (CategoryUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -88,7 +91,7 @@ fun CategorySettingContent(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 4.dp),
+                    .padding(horizontal = 16.dp, vertical = 6.dp),
             contentAlignment = Alignment.Center,
         ) {
             // 뒤로가기
@@ -100,17 +103,17 @@ fun CategorySettingContent(
                         .align(Alignment.CenterStart)
                         .size(24.dp)
                         .clickable { onBackClick() },
-                tint = AfternoteDesign.colors.gray9,
+                tint = AfternoteDesign.colors.gray6,
             )
             Text(
                 text = stringResource(MindRecordR.string.mindrecord_category_setting_title),
-                style = AfternoteDesign.typography.h3,
-                color = AfternoteDesign.colors.gray9,
+                style = AfternoteDesign.typography.bodyBase,
+                color = AfternoteDesign.colors.gray6,
                 textAlign = TextAlign.Center,
             )
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(8.dp))
 
         // 새 카테고리 만들기
         Row(
@@ -118,16 +121,16 @@ fun CategorySettingContent(
                 Modifier
                     .fillMaxWidth()
                     .clickable { onAddCategory() }
-                    .padding(horizontal = 20.dp, vertical = 16.dp),
+                    .padding(horizontal = 24.dp, vertical = 16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
-                painter = painterResource(R.drawable.core_ui_add), // plus 아이콘
+                painter = painterResource(R.drawable.core_ui_add),
                 contentDescription = null,
                 tint = AfternoteDesign.colors.gray9,
-                modifier = Modifier.size(20.dp),
+                modifier = Modifier.size(24.dp),
             )
-            Spacer(modifier = Modifier.width(12.dp))
+            Spacer(modifier = Modifier.width(8.dp))
             Text(
                 text = stringResource(MindRecordR.string.mindrecord_category_new_title),
                 style = AfternoteDesign.typography.bodyBase,
@@ -135,15 +138,16 @@ fun CategorySettingContent(
             )
         }
 
-        HorizontalDivider(color = Color(0xFF000000).copy(alpha = 0.07f))
+        HorizontalDivider(color = AfternoteDesign.colors.gray3)
 
         // 카테고리 목록
         categories.forEach { category ->
             CategoryItem(
                 category = category,
+                onClick = { onCategoryClick(category) },
                 onMenuClick = { onMenuClick(category) },
             )
-            HorizontalDivider(color = Color(0xFF000000).copy(alpha = 0.07f))
+            HorizontalDivider(color = AfternoteDesign.colors.gray3)
         }
     }
 }
@@ -153,6 +157,7 @@ fun CategorySettingContent(
 @Composable
 fun CategoryItem(
     category: CategoryUiModel,
+    onClick: () -> Unit,
     onMenuClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -160,18 +165,19 @@ fun CategoryItem(
         modifier =
             modifier
                 .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 16.dp),
+                .clickable { onClick() }
+                .padding(horizontal = 24.dp, vertical = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         // 색상 원
         Box(
             modifier =
                 Modifier
-                    .size(20.dp)
+                    .size(24.dp)
                     .clip(CircleShape)
                     .background(category.color),
         )
-        Spacer(modifier = Modifier.width(16.dp))
+        Spacer(modifier = Modifier.width(8.dp))
         Text(
             text = category.name,
             style = AfternoteDesign.typography.bodyBase,
@@ -180,12 +186,12 @@ fun CategoryItem(
         )
         // 더보기 메뉴
         Icon(
-            painter = painterResource(R.drawable.core_ui_vertical), // ⋮ 아이콘
+            painter = painterResource(R.drawable.core_ui_vertical),
             contentDescription = stringResource(MindRecordR.string.mindrecord_more_cd),
-            tint = AfternoteDesign.colors.gray5,
+            tint = AfternoteDesign.colors.gray9,
             modifier =
                 Modifier
-                    .size(20.dp)
+                    .size(24.dp)
                     .clickable { onMenuClick() },
         )
     }
@@ -208,6 +214,7 @@ private fun CategorySettingContentPreview() {
             categories = sampleCategories,
             onBackClick = {},
             onAddCategory = {},
+            onCategoryClick = {},
             onMenuClick = {},
         )
     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyCalendar.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyCalendar.kt
@@ -2,12 +2,12 @@ package com.afternote.feature.mindrecord.presentation.component
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedCard
@@ -43,34 +43,40 @@ fun DailyCalendar(
 ) {
     val days = buildDays(year, month, answeredDays, emotionByDay)
 
-    Column(modifier = modifier) {
-        Row(
-            modifier = Modifier.clickable {},
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.core_ui_arrow_left),
-                contentDescription = null,
-                modifier = Modifier.clickable { onPrevMonth() },
-            )
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        // Figma 700:35895 — 헤더 영역 (chevron < / 년월 / chevron >), 그 아래 답변 카운트
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.core_ui_arrow_left),
+                    contentDescription = null,
+                    modifier = Modifier.clickable { onPrevMonth() },
+                )
+                Text(
+                    text = stringResource(MindRecordR.string.mindrecord_calendar_year_month, year, month),
+                    color = AfternoteDesign.colors.gray9,
+                    style = AfternoteDesign.typography.h3,
+                )
+                Icon(
+                    painter = painterResource(R.drawable.core_ui_right),
+                    contentDescription = null,
+                    modifier = Modifier.clickable { onNextMonth() },
+                )
+            }
             Text(
-                text = stringResource(MindRecordR.string.mindrecord_calendar_year_month, year, month),
-                color = AfternoteDesign.colors.gray9,
-                style = AfternoteDesign.typography.h3,
-            )
-            Icon(
-                painter = painterResource(R.drawable.core_ui_right),
-                contentDescription = null,
-                modifier = Modifier.clickable { onNextMonth() },
+                text = stringResource(MindRecordR.string.mindrecord_calendar_answered_count, answeredDays.size),
+                style = AfternoteDesign.typography.captionLargeR,
+                color = AfternoteDesign.colors.black.copy(alpha = 0.35f),
             )
         }
-        Spacer(modifier = Modifier.height(4.dp))
-        Text(
-            text = stringResource(MindRecordR.string.mindrecord_calendar_answered_count, answeredDays.size),
-            style = AfternoteDesign.typography.captionLargeR,
-            color = AfternoteDesign.colors.black.copy(alpha = 0.35f),
-        )
-        Spacer(modifier = Modifier.height(18.dp))
+
+        // Figma 110:19831 — 캘린더 카드: bg white / border #eee / p=16 / gap=12 / radius=6
         OutlinedCard(
             colors =
                 CardDefaults.cardColors(
@@ -79,7 +85,10 @@ fun DailyCalendar(
             border = BorderStroke(1.dp, color = Color(0xFF000000).copy(alpha = 0.05f)),
             modifier = Modifier.fillMaxWidth(),
         ) {
-            Column {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
                 val dayLabels =
                     listOf(
                         stringResource(MindRecordR.string.mindrecord_calendar_day_label_sun),
@@ -91,22 +100,19 @@ fun DailyCalendar(
                         stringResource(MindRecordR.string.mindrecord_calendar_day_label_sat),
                     )
 
-                Spacer(modifier = Modifier.height(16.dp))
                 Row(modifier = Modifier.fillMaxWidth()) {
                     dayLabels.forEach { dayLabel ->
                         Text(
                             text = dayLabel,
                             modifier = Modifier.weight(1f),
-                            color = AfternoteDesign.colors.black.copy(alpha = 0.3f),
+                            color = AfternoteDesign.colors.gray6,
                             style = AfternoteDesign.typography.footnoteCaption,
                             textAlign = TextAlign.Center,
                         )
                     }
                 }
 
-                Spacer(modifier = Modifier.height(10.dp))
                 val chunked = days.chunked(7)
-
                 Column {
                     chunked.forEach { week ->
                         Row(modifier = Modifier.fillMaxWidth()) {
@@ -117,13 +123,11 @@ fun DailyCalendar(
                             }
                             // 마지막 주가 7개 미만이면 빈 셀로 채우기
                             repeat(7 - week.size) {
-                                Spacer(modifier = Modifier.weight(1f))
+                                Box(modifier = Modifier.weight(1f))
                             }
                         }
                     }
                 }
-
-                Spacer(modifier = Modifier.height(18.dp))
             }
         }
     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyQuestionListCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyQuestionListCard.kt
@@ -31,6 +31,7 @@ import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.model.DailyQuestion
+import com.afternote.feature.mindrecord.presentation.util.htmlToPlainText
 import java.time.LocalDate
 
 @Composable
@@ -99,7 +100,7 @@ fun DailyQuestionListCard(
 
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = answer.content,
+                text = answer.content.htmlToPlainText(),
                 style = AfternoteDesign.typography.captionLargeR,
                 color = AfternoteDesign.colors.gray6,
             )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyQuestionListCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyQuestionListCard.kt
@@ -2,6 +2,7 @@ package com.afternote.feature.mindrecord.presentation.component
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,10 +16,15 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
@@ -31,7 +37,11 @@ import java.time.LocalDate
 fun DailyQuestionListCard(
     answer: DailyQuestion,
     modifier: Modifier = Modifier,
+    onEdit: () -> Unit = {},
+    onDelete: () -> Unit = {},
 ) {
+    var menuExpanded by remember { mutableStateOf(false) }
+
     OutlinedCard(
         colors =
             CardDefaults.cardColors(
@@ -54,15 +64,30 @@ fun DailyQuestionListCard(
                     color = AfternoteDesign.colors.gray6,
                 )
 
-                IconButton(
-                    onClick = {},
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.mindrecord_horizontal),
-                        tint = AfternoteDesign.colors.gray5,
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp),
-                    )
+                Box {
+                    IconButton(
+                        onClick = { menuExpanded = true },
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.mindrecord_horizontal),
+                            tint = AfternoteDesign.colors.gray5,
+                            contentDescription = stringResource(R.string.mindrecord_more_menu_cd),
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                    if (menuExpanded) {
+                        RecordActionPopup(
+                            onDismiss = { menuExpanded = false },
+                            onDelete = {
+                                menuExpanded = false
+                                onDelete()
+                            },
+                            onEdit = {
+                                menuExpanded = false
+                                onEdit()
+                            },
+                        )
+                    }
                 }
             }
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DeepThoughtCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DeepThoughtCard.kt
@@ -18,11 +18,16 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
@@ -36,7 +41,11 @@ import java.time.LocalDate
 fun DeepThoughtCard(
     deepThought: DeepThoughtModel,
     modifier: Modifier = Modifier,
+    onEdit: () -> Unit = {},
+    onDelete: () -> Unit = {},
 ) {
+    var menuExpanded by remember { mutableStateOf(false) }
+
     OutlinedCard(
         colors =
             CardDefaults.cardColors(
@@ -67,14 +76,26 @@ fun DeepThoughtCard(
                     )
                 }
 
-                Box(
-                    modifier = Modifier.clickable {},
-                ) {
+                Box {
                     Icon(
                         painter = painterResource(R.drawable.mindrecord_horizontal),
-                        contentDescription = null,
+                        contentDescription = stringResource(R.string.mindrecord_more_menu_cd),
                         tint = AfternoteDesign.colors.gray5,
+                        modifier = Modifier.clickable { menuExpanded = true },
                     )
+                    if (menuExpanded) {
+                        RecordActionPopup(
+                            onDismiss = { menuExpanded = false },
+                            onDelete = {
+                                menuExpanded = false
+                                onDelete()
+                            },
+                            onEdit = {
+                                menuExpanded = false
+                                onEdit()
+                            },
+                        )
+                    }
                 }
             }
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DeepThoughtCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DeepThoughtCard.kt
@@ -35,6 +35,7 @@ import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.model.DeepThoughtModel
 import com.afternote.feature.mindrecord.presentation.model.Tag
+import com.afternote.feature.mindrecord.presentation.util.htmlToPlainText
 import java.time.LocalDate
 
 @Composable
@@ -108,7 +109,7 @@ fun DeepThoughtCard(
 
             Spacer(modifier = Modifier.height(8.dp))
             Text(
-                text = deepThought.content,
+                text = deepThought.content.htmlToPlainText(),
                 style = AfternoteDesign.typography.bodySmallR,
                 color = AfternoteDesign.colors.black.copy(alpha = 0.5f),
             )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryCard.kt
@@ -29,6 +29,7 @@ import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.model.DailyDiary
+import com.afternote.feature.mindrecord.presentation.util.htmlToPlainText
 import java.time.LocalDate
 
 @Composable
@@ -106,7 +107,7 @@ fun DiaryCard(
 
             Spacer(modifier = Modifier.height(2.5.dp))
             Text(
-                text = diary.content,
+                text = diary.content.htmlToPlainText(),
                 style = AfternoteDesign.typography.captionLargeR,
                 color = AfternoteDesign.colors.gray6,
                 maxLines = 2,

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryComponent.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryComponent.kt
@@ -33,6 +33,7 @@ import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.model.DailyDiary
+import com.afternote.feature.mindrecord.presentation.util.htmlToPlainText
 import java.time.LocalDate
 
 @Composable
@@ -111,7 +112,7 @@ fun DiaryComponent(
                 Spacer(modifier = Modifier.height(5.dp))
 
                 Text(
-                    text = diary.content,
+                    text = diary.content.htmlToPlainText(),
                     style = AfternoteDesign.typography.captionLargeR,
                     color = AfternoteDesign.colors.gray5,
                 )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryComponent.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryComponent.kt
@@ -18,10 +18,15 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
@@ -34,7 +39,11 @@ import java.time.LocalDate
 fun DiaryComponent(
     diary: DailyDiary,
     modifier: Modifier = Modifier,
+    onEdit: () -> Unit = {},
+    onDelete: () -> Unit = {},
 ) {
+    var menuExpanded by remember { mutableStateOf(false) }
+
     OutlinedCard(
         colors =
             CardDefaults.cardColors(
@@ -69,13 +78,25 @@ fun DiaryComponent(
                     }
 
                     Spacer(modifier = Modifier.weight(1f))
-                    Box(
-                        modifier = Modifier.clickable {},
-                    ) {
+                    Box {
                         Icon(
                             painter = painterResource(R.drawable.mindrecord_horizontal),
-                            contentDescription = null,
+                            contentDescription = stringResource(R.string.mindrecord_more_menu_cd),
+                            modifier = Modifier.clickable { menuExpanded = true },
                         )
+                        if (menuExpanded) {
+                            RecordActionPopup(
+                                onDismiss = { menuExpanded = false },
+                                onDelete = {
+                                    menuExpanded = false
+                                    onDelete()
+                                },
+                                onEdit = {
+                                    menuExpanded = false
+                                    onEdit()
+                                },
+                            )
+                        }
                     }
                 }
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryReportCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryReportCard.kt
@@ -23,7 +23,11 @@ import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R
 
 @Composable
-fun DiaryReportCard(modifier: Modifier = Modifier) {
+fun DiaryReportCard(
+    monthDiaryCount: Int,
+    weeklyMoodEmoji: String?,
+    modifier: Modifier = Modifier,
+) {
     OutlinedCard(
         colors =
             CardDefaults.cardColors(
@@ -64,13 +68,13 @@ fun DiaryReportCard(modifier: Modifier = Modifier) {
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 Text(
-                    text = "18",
+                    text = monthDiaryCount.toString(),
                     style = AfternoteDesign.typography.h2,
                     color = AfternoteDesign.colors.gray9,
                 )
 
                 Text(
-                    text = "\uD83D\uDE0A",
+                    text = weeklyMoodEmoji.orEmpty(),
                 )
             }
         }
@@ -81,6 +85,6 @@ fun DiaryReportCard(modifier: Modifier = Modifier) {
 @Composable
 private fun DiaryCardPreview() {
     AfternoteTheme {
-        DiaryReportCard()
+        DiaryReportCard(monthDiaryCount = 18, weeklyMoodEmoji = "\uD83D\uDE0A")
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/EmotionKeywordCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/EmotionKeywordCard.kt
@@ -5,13 +5,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
@@ -27,76 +27,62 @@ import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R
+import com.afternote.feature.mindrecord.presentation.model.EmotionKeyword
 
-// ───────────────────────────────────────────────
-// 데이터 모델
-// ───────────────────────────────────────────────
-
-data class EmotionBubble(
-    val keyword: String,
-    val count: Int,
-    val size: Dp, // 원 지름
-    val bgColor: Color,
-    val textColor: Color = Color.White,
-    val offsetX: Dp,
-    val offsetY: Dp,
-)
-
-// ───────────────────────────────────────────────
-// 메인 카드
-// ───────────────────────────────────────────────
-
+/**
+ * 주간 리포트의 "나의 감정 키워드" 카드.
+ *
+ * Figma 노드 2249:14059 — 키워드 개수(0~4)별로 버블 layout 이 다르며, 카드 자체에서 슬롯을 결정한다
+ * (ViewModel 은 keyword·count 만 넘긴다).
+ *
+ * - 4건: 가족(96) / 감사(72) / 사랑(56) / 그리움(64)
+ * - 3건: 가족(96) / 감사(72) / 사랑(56)
+ * - 2건: 가족(96) / 감사(72)
+ * - 1건: 가족(96)
+ * - 0건: 빈 96dp 검은 원에 "0" 만 표시 + 별도 안내 메시지(호출부 책임)
+ */
 @Composable
 fun EmotionKeywordCard(
+    keywords: List<EmotionKeyword>,
+    descriptionText: String,
     modifier: Modifier = Modifier,
     title: String = stringResource(R.string.mindrecord_emotion_card_title),
-    bubbles: List<EmotionBubble> = defaultBubbles(),
-    descriptionText: String = stringResource(R.string.mindrecord_emotion_card_default_description),
 ) {
-    val canvasHeight = 180.dp // 버블 영역 고정 높이
+    val capped = keywords.take(MAX_KEYWORDS)
 
     OutlinedCard(
-        colors =
-            CardDefaults.cardColors(
-                containerColor = Color(0xFFFFFFFF),
-            ),
-        border = BorderStroke(1.dp, color = Color(0xFF000000).copy(alpha = 0.05f)),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        border = BorderStroke(1.dp, AfternoteDesign.colors.gray2),
         modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(8.dp),
     ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            // ── 타이틀 ──
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
             Text(
                 text = title,
-                style = AfternoteDesign.typography.bodyLargeR,
+                style = AfternoteDesign.typography.bodyLargeB,
                 color = AfternoteDesign.colors.gray9,
             )
 
-            // ── 버블 캔버스 ──
+            // Figma Frame 128: 320×133, 버블은 그 안에서 absolute offset.
             Box(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .height(canvasHeight),
+                        .height(BUBBLE_AREA_HEIGHT),
             ) {
-                bubbles.forEach { bubble ->
-                    BubbleItem(
-                        bubble = bubble,
-                        modifier = Modifier.offset(x = bubble.offsetX, y = bubble.offsetY),
-                    )
+                if (capped.isEmpty()) {
+                    EmptyBubble()
+                } else {
+                    val slots = slotsFor(capped.size)
+                    capped.forEachIndexed { index, keyword ->
+                        Bubble(slot = slots[index], keyword = keyword)
+                    }
                 }
             }
 
-            // ── 구분선 ──
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .height(1.dp)
-                        .background(Color(0xFFEEEEEE)),
-            )
-
-            Spacer(modifier = Modifier.height(5.dp))
-            // ── 하단 설명 텍스트 ──
             Text(
                 text = descriptionText,
                 style = AfternoteDesign.typography.bodySmallB,
@@ -106,94 +92,154 @@ fun EmotionKeywordCard(
     }
 }
 
-// ───────────────────────────────────────────────
-// 개별 버블
-// ───────────────────────────────────────────────
-
 @Composable
-private fun BubbleItem(
-    bubble: EmotionBubble,
-    modifier: Modifier = Modifier,
+private fun Bubble(
+    slot: BubbleSlot,
+    keyword: EmotionKeyword,
 ) {
     Box(
-        contentAlignment = Alignment.Center,
         modifier =
-            modifier
-                .size(bubble.size)
+            Modifier
+                .offset(x = slot.offsetX, y = slot.offsetY)
+                .size(slot.size)
                 .clip(CircleShape)
-                .background(bubble.bgColor),
+                .background(slot.color),
+        contentAlignment = Alignment.Center,
     ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
-                text = bubble.keyword,
-                color = bubble.textColor,
-                style = AfternoteDesign.typography.bodySmallB,
+                text = keyword.keyword,
+                style =
+                    if (slot.size >= LARGE_TEXT_THRESHOLD) {
+                        AfternoteDesign.typography.bodyLargeB
+                    } else {
+                        AfternoteDesign.typography.bodySmallB
+                    },
+                color = Color.White,
             )
-            Spacer(modifier = Modifier.height(2.dp))
             Text(
-                text = bubble.count.toString(),
-                color = bubble.textColor.copy(alpha = 0.7f),
-                style = AfternoteDesign.typography.captionLargeR,
+                text = keyword.count.toString(),
+                style = AfternoteDesign.typography.footnoteCaption,
+                color = AfternoteDesign.colors.gray3,
             )
         }
     }
 }
 
-// ───────────────────────────────────────────────
-// 기본 버블 데이터 (이미지 기준 위치/크기)
-// ───────────────────────────────────────────────
+@Composable
+private fun EmptyBubble() {
+    val slot = EMPTY_SLOT
+    Box(
+        modifier =
+            Modifier
+                .offset(x = slot.offsetX, y = slot.offsetY)
+                .size(slot.size)
+                .clip(CircleShape)
+                .background(slot.color),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "0",
+            style = AfternoteDesign.typography.bodySmallR,
+            color = Color.White,
+        )
+    }
+}
 
-fun defaultBubbles() =
-    listOf(
-        // 가족 - 가장 크고 왼쪽 상단, 진한 회색
-        EmotionBubble(
-            keyword = "가족",
-            count = 8,
-            size = 100.dp,
-            bgColor = Color(0xFF212121),
-            offsetX = 0.dp,
-            offsetY = 30.dp,
-        ),
-        // 감사 - 두 번째 크기, 중앙 상단
-        EmotionBubble(
-            keyword = "감사",
-            count = 8,
-            size = 82.dp,
-            bgColor = Color(0xFF424242),
-            offsetX = 88.dp,
-            offsetY = 0.dp,
-        ),
-        // 사랑 - 세 번째 크기, 중앙 하단
-        EmotionBubble(
-            keyword = "사랑",
-            count = 8,
-            size = 68.dp,
-            bgColor = Color(0xFF616161),
-            offsetX = 158.dp,
-            offsetY = 68.dp,
-        ),
-        // 그리움 - 가장 작고 오른쪽
-        EmotionBubble(
-            keyword = "그리움",
-            count = 8,
-            size = 58.dp,
-            bgColor = Color(0xFF9E9E9E),
-            offsetX = 230.dp,
-            offsetY = 42.dp,
-        ),
-    )
+// ── Slot ──────────────────────────────────────────────────────────────────────
 
-// ───────────────────────────────────────────────
-// Preview
-// ───────────────────────────────────────────────
+private data class BubbleSlot(
+    val size: Dp,
+    val offsetX: Dp,
+    val offsetY: Dp,
+    val color: Color,
+)
+
+private const val MAX_KEYWORDS = 4
+private val BUBBLE_AREA_HEIGHT = 133.dp
+private val LARGE_TEXT_THRESHOLD = 72.dp
+
+// 색상 순위: 1위(가장 진함) → 4위(가장 옅음)
+private val ColorRank1 = Color(0xFF212121)
+private val ColorRank2 = Color(0xFF424242)
+private val ColorRank3 = Color(0xFF616161)
+private val ColorRank4 = Color(0xFF9E9E9E)
+
+// 0건 안내용 빈 검은 원.
+private val EMPTY_SLOT =
+    BubbleSlot(size = 96.dp, offsetX = 112.dp, offsetY = 15.dp, color = ColorRank1)
+
+private fun slotsFor(count: Int): List<BubbleSlot> =
+    when (count) {
+        1 -> {
+            listOf(
+                BubbleSlot(96.dp, 112.dp, 15.dp, ColorRank1),
+            )
+        }
+
+        2 -> {
+            listOf(
+                BubbleSlot(96.dp, 78.dp, 0.dp, ColorRank1),
+                BubbleSlot(72.dp, 171.dp, 47.dp, ColorRank2),
+            )
+        }
+
+        3 -> {
+            listOf(
+                BubbleSlot(96.dp, 48.dp, 4.dp, ColorRank1),
+                BubbleSlot(72.dp, 141.dp, 51.dp, ColorRank2),
+                BubbleSlot(56.dp, 205.dp, 25.dp, ColorRank3),
+            )
+        }
+
+        else -> {
+            // 4 이상은 4 로 cap
+            listOf(
+                BubbleSlot(96.dp, 37.dp, 30.dp, ColorRank1),
+                BubbleSlot(72.dp, 124.dp, 0.dp, ColorRank2),
+                BubbleSlot(56.dp, 149.dp, 72.dp, ColorRank3),
+                BubbleSlot(64.dp, 200.dp, 36.dp, ColorRank4),
+            )
+        }
+    }
+
+// ── Preview ───────────────────────────────────────────────────────────────────
 
 @Preview(showBackground = true, backgroundColor = 0xFFF5F5F5, widthDp = 360)
 @Composable
-private fun EmotionKeywordCardPreview() {
+private fun EmotionKeywordCardPreview4() {
     AfternoteTheme {
-        EmotionKeywordCard()
+        EmotionKeywordCard(
+            keywords =
+                listOf(
+                    EmotionKeyword("가족", 8),
+                    EmotionKeyword("감사", 8),
+                    EmotionKeyword("사랑", 8),
+                    EmotionKeyword("그리움", 8),
+                ),
+            descriptionText = "이번 주 박서연 님의 기록에서는 '가족'을 위한 '감사'의 마음이 엿보입니다.",
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFF5F5F5, widthDp = 360)
+@Composable
+private fun EmotionKeywordCardPreview1() {
+    AfternoteTheme {
+        EmotionKeywordCard(
+            keywords = listOf(EmotionKeyword("가족", 8)),
+            descriptionText = "이번 주 박서연 님의 기록에서는 '가족'의 마음이 엿보입니다.",
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFF5F5F5, widthDp = 360)
+@Composable
+private fun EmotionKeywordCardPreview0() {
+    AfternoteTheme {
+        EmotionKeywordCard(
+            keywords = emptyList(),
+            descriptionText = "이번 주 박서연 님의 기록에서는 키워드가 나오지 않았어요.",
+        )
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/KeyBoardToolBar.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/KeyBoardToolBar.kt
@@ -42,6 +42,9 @@ fun BottomToolbar(
     onAlignChange: (TextAlign) -> Unit,
     modifier: Modifier = Modifier,
     onLinkClick: () -> Unit = {},
+    onSaveDraftClick: () -> Unit = {},
+    onDraftCountClick: () -> Unit = {},
+    draftCount: Int = 0,
 ) {
     Row(
         modifier =
@@ -89,11 +92,21 @@ fun BottomToolbar(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        Text(
-            text = stringResource(R.string.mindrecord_toolbar_draft_count, 1),
-            style = AfternoteDesign.typography.captionLargeR,
-            color = AfternoteDesign.colors.gray6,
-        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(R.string.mindrecord_toolbar_draft_label),
+                style = AfternoteDesign.typography.captionLargeR,
+                color = AfternoteDesign.colors.gray6,
+                modifier = Modifier.clickable(onClick = onSaveDraftClick),
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                text = draftCount.toString(),
+                style = AfternoteDesign.typography.captionLargeR,
+                color = AfternoteDesign.colors.gray4,
+                modifier = Modifier.clickable(onClick = onDraftCountClick),
+            )
+        }
     }
 }
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/LinkBottomSheet.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/LinkBottomSheet.kt
@@ -1,0 +1,165 @@
+package com.afternote.feature.mindrecord.presentation.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.afternote.core.ui.theme.AfternoteDesign
+import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R
+
+/**
+ * 키보드 툴바의 링크 버튼에서 호출되는 "링크 추가하기" 바텀시트.
+ *
+ * Figma 노드 533:16183 (link variant) — 헤더(드래그 핸들 + 제목 + 완료 버튼) + URL 입력 필드.
+ * 완료 시 [onConfirm] 으로 입력된 URL 을 전달한다 (호출부에서 에디터에 삽입).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LinkBottomSheet(
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var url by remember { mutableStateOf("") }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = AfternoteDesign.colors.gray1,
+        dragHandle = {
+            Box(
+                modifier =
+                    Modifier
+                        .padding(top = 12.dp, bottom = 8.dp)
+                        .width(40.dp)
+                        .height(4.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFFCCCCCC)),
+            )
+        },
+    ) {
+        LinkSheetContent(
+            url = url,
+            onUrlChange = { url = it },
+            onConfirm = { onConfirm(url) },
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun LinkSheetContent(
+    url: String,
+    onUrlChange: (String) -> Unit,
+    onConfirm: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 32.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        // 헤더 — 좌(52dp placeholder) / 가운데 제목 / 우(완료 버튼). 좌우 균형으로 제목이 가운데 정렬.
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Box(modifier = Modifier.width(52.dp))
+
+            Text(
+                text = stringResource(R.string.mindrecord_link_sheet_title),
+                style = AfternoteDesign.typography.bodyBase,
+                color = AfternoteDesign.colors.gray6,
+            )
+
+            ConfirmPill(onClick = onConfirm)
+        }
+
+        OutlinedTextField(
+            value = url,
+            onValueChange = onUrlChange,
+            singleLine = true,
+            placeholder = {
+                Text(
+                    text = stringResource(R.string.mindrecord_link_sheet_placeholder),
+                    style = AfternoteDesign.typography.bodyBase,
+                    color = AfternoteDesign.colors.gray4,
+                )
+            },
+            shape = RoundedCornerShape(8.dp),
+            colors =
+                TextFieldDefaults.colors(
+                    focusedContainerColor = Color.White,
+                    unfocusedContainerColor = Color.White,
+                    focusedIndicatorColor = AfternoteDesign.colors.gray2,
+                    unfocusedIndicatorColor = AfternoteDesign.colors.gray2,
+                ),
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+private fun ConfirmPill(onClick: () -> Unit) {
+    Box(
+        modifier =
+            Modifier
+                .clip(CircleShape)
+                .background(AfternoteDesign.colors.gray2)
+                .border(BorderStroke(1.dp, AfternoteDesign.colors.gray4), CircleShape)
+                .clickable(onClick = onClick)
+                .padding(horizontal = 15.dp, vertical = 9.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.mindrecord_link_sheet_confirm),
+            style = AfternoteDesign.typography.captionLargeB,
+            color = AfternoteDesign.colors.gray9,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LinkBottomSheetPreview() {
+    AfternoteTheme {
+        LinkSheetContent(
+            url = "",
+            onUrlChange = {},
+            onConfirm = {},
+        )
+    }
+}

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/MediaSelectBottomSheet.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/MediaSelectBottomSheet.kt
@@ -1,0 +1,175 @@
+package com.afternote.feature.mindrecord.presentation.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.afternote.core.ui.theme.AfternoteDesign
+import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R
+import com.afternote.core.ui.R as CoreUiR
+
+/**
+ * 키보드 툴바 링크(미디어) 버튼에서 호출되는 "미디어 추가하기" 메인 메뉴 바텀시트.
+ *
+ * Figma 노드 495:16938 (media_select variant) — 헤더(드래그 핸들 + 제목) + 4개 항목
+ * (이미지/음성/파일/링크 추가하기). 항목 사이 #E0E0E0 디바이더.
+ *
+ * "링크 추가하기" 를 누르면 [LinkBottomSheet] 가 후속으로 뜨도록 호출부에서 분기한다.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MediaSelectBottomSheet(
+    onDismiss: () -> Unit,
+    onImageClick: () -> Unit,
+    onVoiceClick: () -> Unit,
+    onFileClick: () -> Unit,
+    onLinkClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = AfternoteDesign.colors.gray1,
+        dragHandle = {
+            Box(
+                modifier =
+                    Modifier
+                        .padding(top = 12.dp, bottom = 8.dp)
+                        .width(40.dp)
+                        .height(4.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFFCCCCCC)),
+            )
+        },
+    ) {
+        MediaSelectContent(
+            onImageClick = onImageClick,
+            onVoiceClick = onVoiceClick,
+            onFileClick = onFileClick,
+            onLinkClick = onLinkClick,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun MediaSelectContent(
+    onImageClick: () -> Unit,
+    onVoiceClick: () -> Unit,
+    onFileClick: () -> Unit,
+    onLinkClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(bottom = 32.dp),
+    ) {
+        // 헤더 — 가운데 정렬, py=6
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 6.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = stringResource(R.string.mindrecord_media_sheet_title),
+                style = AfternoteDesign.typography.bodyBase,
+                color = AfternoteDesign.colors.gray6,
+            )
+        }
+
+        // 4개 항목 — 각 row p=16 gap=10, 사이 #E0E0E0 디바이더
+        MediaItem(
+            icon = painterResource(CoreUiR.drawable.core_ui_ic_image),
+            text = stringResource(R.string.mindrecord_media_sheet_image),
+            onClick = onImageClick,
+        )
+        HorizontalDivider(thickness = 1.dp, color = AfternoteDesign.colors.gray3)
+        MediaItem(
+            icon = painterResource(R.drawable.mindrecord_ic_mic),
+            text = stringResource(R.string.mindrecord_media_sheet_voice),
+            onClick = onVoiceClick,
+        )
+        HorizontalDivider(thickness = 1.dp, color = AfternoteDesign.colors.gray3)
+        MediaItem(
+            icon = painterResource(CoreUiR.drawable.core_ui_ic_file),
+            text = stringResource(R.string.mindrecord_media_sheet_file),
+            onClick = onFileClick,
+        )
+        HorizontalDivider(thickness = 1.dp, color = AfternoteDesign.colors.gray3)
+        MediaItem(
+            icon = painterResource(CoreUiR.drawable.core_ui_ic_link),
+            text = stringResource(R.string.mindrecord_media_sheet_link),
+            onClick = onLinkClick,
+        )
+        HorizontalDivider(thickness = 1.dp, color = AfternoteDesign.colors.gray3)
+    }
+}
+
+@Composable
+private fun MediaItem(
+    icon: Painter,
+    text: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Icon(
+            painter = icon,
+            contentDescription = null,
+            tint = AfternoteDesign.colors.gray9,
+            modifier = Modifier.size(24.dp),
+        )
+        Text(
+            text = text,
+            style = AfternoteDesign.typography.bodyBase,
+            color = AfternoteDesign.colors.gray9,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MediaSelectBottomSheetPreview() {
+    AfternoteTheme {
+        MediaSelectContent(
+            onImageClick = {},
+            onVoiceClick = {},
+            onFileClick = {},
+            onLinkClick = {},
+        )
+    }
+}

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/RecordActionPopup.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/RecordActionPopup.kt
@@ -1,0 +1,93 @@
+package com.afternote.feature.mindrecord.presentation.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import com.afternote.core.ui.theme.AfternoteDesign
+import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R
+
+/**
+ * 마음의 기록 카드의 ... 버튼에서 뜨는 액션 팝업.
+ * Figma 노드 2249:14756 — 흰 배경 / 8dp radius / hard shadow / width 120dp / 항목 padding 16dp.
+ */
+@Composable
+fun RecordActionPopup(
+    onDismiss: () -> Unit,
+    onDelete: () -> Unit,
+    onEdit: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Popup(
+        alignment = Alignment.TopEnd,
+        onDismissRequest = onDismiss,
+        properties = PopupProperties(focusable = true),
+    ) {
+        Surface(
+            modifier = modifier.width(120.dp),
+            shape = RoundedCornerShape(8.dp),
+            color = Color.White,
+            shadowElevation = 10.dp,
+        ) {
+            Column {
+                PopupItem(
+                    label = stringResource(R.string.mindrecord_record_action_delete),
+                    onClick = onDelete,
+                )
+                PopupItem(
+                    label = stringResource(R.string.mindrecord_record_action_edit),
+                    onClick = onEdit,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PopupItem(
+    label: String,
+    onClick: () -> Unit,
+) {
+    Text(
+        text = label,
+        style = AfternoteDesign.typography.bodyBase,
+        color = AfternoteDesign.colors.gray9,
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(16.dp),
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RecordActionPopupPreview() {
+    AfternoteTheme {
+        Surface(
+            modifier = Modifier.width(120.dp),
+            shape = RoundedCornerShape(8.dp),
+            color = Color.White,
+            shadowElevation = 10.dp,
+        ) {
+            Column {
+                PopupItem(label = "삭제하기", onClick = {})
+                PopupItem(label = "수정하기", onClick = {})
+            }
+        }
+    }
+}

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyModelCalendar.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyModelCalendar.kt
@@ -40,10 +40,7 @@ fun WeeklyMoodCalendar(
     days: List<DayItem> = defaultPreviewDays(),
 ) {
     Column(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+        modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         // 상단 슬라이더

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WriteTextField.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WriteTextField.kt
@@ -93,27 +93,30 @@ fun WriteTextField(
         runCatching { editorFocusRequester.requestFocus() }
     }
 
-    // 선택된 미디어 URI 를 에디터에 추가. TODO: compose-richeditor 의 image / audio / file
-    // 노드 삽입 API 로 교체 + 업로드 → 영구 URL 치환. 현재는 raw URI 를 plain text 로 append.
-    fun appendUriToEditor(uri: Uri?) {
+    // 선택된 미디어 URI 를 HTML 태그로 감싸 에디터에 append. compose-richeditor 의 setHtml 이
+    // <img>·<a href> 같은 표준 태그를 파싱해 rich span 으로 변환한다.
+    // 업로드 → 영구 URL 치환은 후속 PR (지금은 raw content:// URI 를 그대로 src/href 로 사용).
+    fun appendMediaToEditor(
+        uri: Uri?,
+        asImage: Boolean,
+    ) {
         if (uri == null) return
-        keepEditorFocus {
-            val current = state.toHtml()
-            state.setHtml(current + uri)
-        }
+        val html =
+            if (asImage) "<img src=\"$uri\" />" else "<a href=\"$uri\">$uri</a>"
+        keepEditorFocus { state.setHtml(state.toHtml() + html) }
     }
 
     val imageLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
-            appendUriToEditor(uri)
+            appendMediaToEditor(uri, asImage = true)
         }
     val voiceLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
-            appendUriToEditor(uri)
+            appendMediaToEditor(uri, asImage = false)
         }
     val fileLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
-            appendUriToEditor(uri)
+            appendMediaToEditor(uri, asImage = false)
         }
 
     Column(modifier = modifier.fillMaxSize()) {
@@ -216,11 +219,8 @@ fun WriteTextField(
             LinkBottomSheet(
                 onDismiss = { sheet = KeyboardSheet.None },
                 onConfirm = { url ->
-                    // TODO: compose-richeditor 의 link API 로 hyperlink 삽입 후속 처리.
-                    //  지금은 사용자 입력 URL 을 plain text 로 에디터에 추가한다.
                     keepEditorFocus {
-                        val current = state.toHtml()
-                        state.setHtml(current + url)
+                        state.setHtml(state.toHtml() + "<a href=\"$url\">$url</a>")
                     }
                     sheet = KeyboardSheet.None
                 },

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WriteTextField.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WriteTextField.kt
@@ -52,6 +52,9 @@ fun WriteTextField(
     modifier: Modifier = Modifier,
     value: String? = null,
     onValueChange: ((String) -> Unit)? = null,
+    onSaveDraftClick: () -> Unit = {},
+    onDraftCountClick: () -> Unit = {},
+    draftCount: Int = 0,
 ) {
     val state = rememberRichTextState()
 
@@ -151,6 +154,9 @@ fun WriteTextField(
             onAlignChange = { align ->
                 keepEditorFocus { state.addParagraphStyle(ParagraphStyle(textAlign = align)) }
             },
+            onSaveDraftClick = onSaveDraftClick,
+            onDraftCountClick = onDraftCountClick,
+            draftCount = draftCount,
         )
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WriteTextField.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WriteTextField.kt
@@ -77,7 +77,7 @@ fun WriteTextField(
         )
 
     var showTextStyleToolbar by remember { mutableStateOf(false) }
-    var showLinkSheet by remember { mutableStateOf(false) }
+    var sheet: KeyboardSheet by remember { mutableStateOf(KeyboardSheet.None) }
     val imeVisible = WindowInsets.isImeVisible
     val editorFocusRequester = remember { FocusRequester() }
 
@@ -155,27 +155,53 @@ fun WriteTextField(
             onAlignChange = { align ->
                 keepEditorFocus { state.addParagraphStyle(ParagraphStyle(textAlign = align)) }
             },
-            onLinkClick = { showLinkSheet = true },
+            onLinkClick = { sheet = KeyboardSheet.MediaSelect },
             onSaveDraftClick = onSaveDraftClick,
             onDraftCountClick = onDraftCountClick,
             draftCount = draftCount,
         )
     }
 
-    if (showLinkSheet) {
-        LinkBottomSheet(
-            onDismiss = { showLinkSheet = false },
-            onConfirm = { url ->
-                // TODO: compose-richeditor 의 link API 로 hyperlink 삽입 후속 처리.
-                //  지금은 사용자 입력 URL 을 plain text 로 에디터에 추가한다.
-                keepEditorFocus {
-                    val current = state.toHtml()
-                    state.setHtml(current + url)
-                }
-                showLinkSheet = false
-            },
-        )
+    when (sheet) {
+        KeyboardSheet.None -> {
+            Unit
+        }
+
+        KeyboardSheet.MediaSelect -> {
+            MediaSelectBottomSheet(
+                onDismiss = { sheet = KeyboardSheet.None },
+                // 이미지/음성/파일 추가는 후속 PR. 일단 시트 닫기만.
+                onImageClick = { sheet = KeyboardSheet.None },
+                onVoiceClick = { sheet = KeyboardSheet.None },
+                onFileClick = { sheet = KeyboardSheet.None },
+                onLinkClick = { sheet = KeyboardSheet.LinkAdd },
+            )
+        }
+
+        KeyboardSheet.LinkAdd -> {
+            LinkBottomSheet(
+                onDismiss = { sheet = KeyboardSheet.None },
+                onConfirm = { url ->
+                    // TODO: compose-richeditor 의 link API 로 hyperlink 삽입 후속 처리.
+                    //  지금은 사용자 입력 URL 을 plain text 로 에디터에 추가한다.
+                    keepEditorFocus {
+                        val current = state.toHtml()
+                        state.setHtml(current + url)
+                    }
+                    sheet = KeyboardSheet.None
+                },
+            )
+        }
     }
+}
+
+/** [WriteTextField] 의 키보드 영역에서 토글되는 바텀시트 상태. 한 번에 하나만 표시한다. */
+private sealed interface KeyboardSheet {
+    data object None : KeyboardSheet
+
+    data object MediaSelect : KeyboardSheet
+
+    data object LinkAdd : KeyboardSheet
 }
 
 private fun TextStyleType.toSpanStyle(): SpanStyle =

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WriteTextField.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WriteTextField.kt
@@ -1,5 +1,8 @@
 package com.afternote.feature.mindrecord.presentation.component
 
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -90,6 +93,29 @@ fun WriteTextField(
         runCatching { editorFocusRequester.requestFocus() }
     }
 
+    // 선택된 미디어 URI 를 에디터에 추가. TODO: compose-richeditor 의 image / audio / file
+    // 노드 삽입 API 로 교체 + 업로드 → 영구 URL 치환. 현재는 raw URI 를 plain text 로 append.
+    fun appendUriToEditor(uri: Uri?) {
+        if (uri == null) return
+        keepEditorFocus {
+            val current = state.toHtml()
+            state.setHtml(current + uri)
+        }
+    }
+
+    val imageLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+            appendUriToEditor(uri)
+        }
+    val voiceLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+            appendUriToEditor(uri)
+        }
+    val fileLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+            appendUriToEditor(uri)
+        }
+
     Column(modifier = modifier.fillMaxSize()) {
         Box(
             modifier =
@@ -170,10 +196,18 @@ fun WriteTextField(
         KeyboardSheet.MediaSelect -> {
             MediaSelectBottomSheet(
                 onDismiss = { sheet = KeyboardSheet.None },
-                // 이미지/음성/파일 추가는 후속 PR. 일단 시트 닫기만.
-                onImageClick = { sheet = KeyboardSheet.None },
-                onVoiceClick = { sheet = KeyboardSheet.None },
-                onFileClick = { sheet = KeyboardSheet.None },
+                onImageClick = {
+                    sheet = KeyboardSheet.None
+                    imageLauncher.launch("image/*")
+                },
+                onVoiceClick = {
+                    sheet = KeyboardSheet.None
+                    voiceLauncher.launch("audio/*")
+                },
+                onFileClick = {
+                    sheet = KeyboardSheet.None
+                    fileLauncher.launch("*/*")
+                },
                 onLinkClick = { sheet = KeyboardSheet.LinkAdd },
             )
         }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WriteTextField.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WriteTextField.kt
@@ -77,6 +77,7 @@ fun WriteTextField(
         )
 
     var showTextStyleToolbar by remember { mutableStateOf(false) }
+    var showLinkSheet by remember { mutableStateOf(false) }
     val imeVisible = WindowInsets.isImeVisible
     val editorFocusRequester = remember { FocusRequester() }
 
@@ -154,9 +155,25 @@ fun WriteTextField(
             onAlignChange = { align ->
                 keepEditorFocus { state.addParagraphStyle(ParagraphStyle(textAlign = align)) }
             },
+            onLinkClick = { showLinkSheet = true },
             onSaveDraftClick = onSaveDraftClick,
             onDraftCountClick = onDraftCountClick,
             draftCount = draftCount,
+        )
+    }
+
+    if (showLinkSheet) {
+        LinkBottomSheet(
+            onDismiss = { showLinkSheet = false },
+            onConfirm = { url ->
+                // TODO: compose-richeditor 의 link API 로 hyperlink 삽입 후속 처리.
+                //  지금은 사용자 입력 URL 을 plain text 로 에디터에 추가한다.
+                keepEditorFocus {
+                    val current = state.toHtml()
+                    state.setHtml(current + url)
+                }
+                showLinkSheet = false
+            },
         )
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/memoryspace/MemoryDetailOverlay.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/memoryspace/MemoryDetailOverlay.kt
@@ -38,6 +38,7 @@ import com.afternote.core.ui.modifierextention.shimmerLoadingPlaceholder
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.model.memoryspace.MemoryItem
+import com.afternote.feature.mindrecord.presentation.util.htmlToPlainText
 
 @Composable
 fun MemoryDetailOverlay(
@@ -141,7 +142,7 @@ fun MemoryDetailOverlay(
                 )
 
                 Text(
-                    text = memory.content,
+                    text = memory.content.htmlToPlainText(),
                     style =
                         AfternoteDesign.typography.inter.copy(
                             fontSize = 14.sp,

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/model/EmotionKeyword.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/model/EmotionKeyword.kt
@@ -1,0 +1,13 @@
+package com.afternote.feature.mindrecord.presentation.model
+
+/**
+ * 주간 리포트의 감정 키워드 1건.
+ *
+ * size·offset·color 같은 UI 좌표는 [com.afternote.feature.mindrecord.presentation.component.EmotionKeywordCard]
+ * 안에서 키워드 개수(0~4)에 따라 슬롯으로 결정한다. ViewModel 은 keyword·count 만 노출한다
+ * (메모리 노트: VM 은 Context/색·치수 금지).
+ */
+data class EmotionKeyword(
+    val keyword: String,
+    val count: Int,
+)

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/navigation/MindRecordNavActions.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/navigation/MindRecordNavActions.kt
@@ -19,4 +19,8 @@ interface MindRecordNavActions {
     fun onWriteBack()
 
     fun onWriteSubmitSuccess()
+
+    fun onNavigateToDraftList()
+
+    fun onDraftListBack()
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/navigation/MindRecordNavGraph.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/navigation/MindRecordNavGraph.kt
@@ -9,6 +9,7 @@ import com.afternote.feature.mindrecord.presentation.screen.receiver.ReceiverMin
 import com.afternote.feature.mindrecord.presentation.screen.sender.DailyQuestionWriteScreen
 import com.afternote.feature.mindrecord.presentation.screen.sender.DeepThoughtWriteScreen
 import com.afternote.feature.mindrecord.presentation.screen.sender.DiaryWriteScreen
+import com.afternote.feature.mindrecord.presentation.screen.sender.DraftListScreen
 import com.afternote.feature.mindrecord.presentation.screen.sender.HomeScreen
 
 /**
@@ -40,18 +41,24 @@ fun NavGraphBuilder.mindRecordNavGraph(actions: MindRecordNavActions) {
         DailyQuestionWriteScreen(
             onSubmitSuccess = actions::onWriteSubmitSuccess,
             onBackClick = actions::onWriteBack,
+            onDraftListClick = actions::onNavigateToDraftList,
         )
     }
     composable<MindRecordRoute.DiaryWriteRoute> {
         DiaryWriteScreen(
             onSubmitSuccess = actions::onWriteSubmitSuccess,
             onBackClick = actions::onWriteBack,
+            onDraftListClick = actions::onNavigateToDraftList,
         )
     }
     composable<MindRecordRoute.DeepThoughtWriteRoute> {
         DeepThoughtWriteScreen(
             onSubmitSuccess = actions::onWriteSubmitSuccess,
             onBackClick = actions::onWriteBack,
+            onDraftListClick = actions::onNavigateToDraftList,
         )
+    }
+    composable<MindRecordRoute.DraftListRoute> {
+        DraftListScreen(onBackClick = actions::onDraftListBack)
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/navigation/MindRecordRoute.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/navigation/MindRecordRoute.kt
@@ -11,4 +11,8 @@ sealed interface MindRecordRoute {
 
     @Serializable
     data object DeepThoughtWriteRoute : MindRecordRoute
+
+    /** 작성 화면 키보드 툴바의 "임시저장 N" 영역에서 진입하는 임시저장 목록 화면. */
+    @Serializable
+    data object DraftListRoute : MindRecordRoute
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionAnswerListScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionAnswerListScreen.kt
@@ -15,6 +15,9 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -35,7 +38,7 @@ import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
 import com.afternote.feature.mindrecord.presentation.viewmodel.DailyQuestionListUiState
 import com.afternote.feature.mindrecord.presentation.viewmodel.DailyQuestionListViewModel
 import com.afternote.feature.mindrecord.presentation.viewmodel.TodayQuestionUi
-import java.time.LocalDate
+import java.time.YearMonth
 
 @Composable
 fun DailyQuestionAnswerListScreen(
@@ -74,6 +77,9 @@ private fun DailyQuestionListContent(
     modifier: Modifier = Modifier,
     onDelete: (Long) -> Unit = {},
 ) {
+    var yearMonth by remember { mutableStateOf(YearMonth.now()) }
+    val onYearMonthChanged: (YearMonth) -> Unit = { yearMonth = it }
+
     if (isListView && todayQuestion == null && answers.isEmpty()) {
         MindRecordEmptyState(modifier = modifier)
         return
@@ -91,19 +97,18 @@ private fun DailyQuestionListContent(
                 DailyQuestionListCard(answer = answer, onDelete = { onDelete(answer.id) })
             }
         } else {
-            val today = LocalDate.now()
             val answeredDays =
                 answers
-                    .filter { it.date.year == today.year && it.date.monthValue == today.monthValue }
+                    .filter { it.date.year == yearMonth.year && it.date.monthValue == yearMonth.monthValue }
                     .map { it.date.dayOfMonth }
                     .toSet()
             item {
                 DailyCalendar(
-                    year = today.year,
-                    month = today.monthValue,
+                    year = yearMonth.year,
+                    month = yearMonth.monthValue,
                     type = MindRecordCategoryUi.DailyQuestion,
-                    onPrevMonth = {},
-                    onNextMonth = {},
+                    onPrevMonth = { onYearMonthChanged(yearMonth.minusMonths(1)) },
+                    onNextMonth = { onYearMonthChanged(yearMonth.plusMonths(1)) },
                     answeredDays = answeredDays,
                 )
             }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionAnswerListScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionAnswerListScreen.kt
@@ -60,6 +60,7 @@ fun DailyQuestionAnswerListScreen(
                 isListView = isListView,
                 todayQuestion = state.todayQuestion,
                 answers = state.answers,
+                onDelete = viewModel::delete,
             )
         }
     }
@@ -71,6 +72,7 @@ private fun DailyQuestionListContent(
     todayQuestion: TodayQuestionUi?,
     answers: List<DailyQuestion>,
     modifier: Modifier = Modifier,
+    onDelete: (Long) -> Unit = {},
 ) {
     if (isListView && todayQuestion == null && answers.isEmpty()) {
         MindRecordEmptyState(modifier = modifier)
@@ -85,7 +87,9 @@ private fun DailyQuestionListContent(
     ) {
         if (isListView) {
             item { DailyQuestionWriteHeaderCard(questionText = headerText) }
-            items(answers, key = { it.id }) { DailyQuestionListCard(answer = it) }
+            items(answers, key = { it.id }) { answer ->
+                DailyQuestionListCard(answer = answer, onDelete = { onDelete(answer.id) })
+            }
         } else {
             val today = LocalDate.now()
             val answeredDays =
@@ -119,7 +123,9 @@ private fun DailyQuestionListContent(
                 Spacer(modifier = Modifier.height(10.dp))
             }
             item { DailyQuestionWriteHeaderCard(questionText = headerText) }
-            items(answers, key = { it.id }) { DailyQuestionListCard(answer = it) }
+            items(answers, key = { it.id }) { answer ->
+                DailyQuestionListCard(answer = answer, onDelete = { onDelete(answer.id) })
+            }
         }
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionWriteScreen.kt
@@ -40,6 +40,7 @@ fun DailyQuestionWriteScreen(
     modifier: Modifier = Modifier,
     onSubmitSuccess: () -> Unit = {},
     onBackClick: () -> Unit = {},
+    onDraftListClick: () -> Unit = {},
     viewModel: DailyQuestionWriteViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -117,6 +118,8 @@ fun DailyQuestionWriteScreen(
             WriteTextField(
                 value = uiState.answer,
                 onValueChange = viewModel::onAnswerChanged,
+                onSaveDraftClick = { viewModel.submit(isDraft = true) },
+                onDraftCountClick = onDraftListClick,
             )
         }
     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
@@ -107,6 +107,7 @@ fun DeepThoughtScreen(
             onDismiss = { showCategorySheet = false },
             onBackClick = { showCategorySheet = false },
             onAddCategory = { addingCategory = true },
+            onCategoryClick = { showCategorySheet = false },
             onMenuClick = { menuTarget = it },
         )
     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
@@ -97,6 +97,7 @@ fun DeepThoughtScreen(
                 onTagClick = viewModel::onTagSelected,
                 onCategorySelect = viewModel::onCategorySelected,
                 onCategorySettingClick = { showCategorySheet = true },
+                onDelete = viewModel::delete,
             )
         }
     }
@@ -168,6 +169,7 @@ private fun DeepThoughtContent(
     onCategorySettingClick: () -> Unit,
     items: List<DeepThoughtModel>,
     modifier: Modifier = Modifier,
+    onDelete: (Long) -> Unit = {},
 ) {
     val allCategoryLabel = stringResource(MindRecordR.string.mindrecord_category_all)
     val tabs =
@@ -266,7 +268,9 @@ private fun DeepThoughtContent(
             )
 
             LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                items(items, key = { it.id }) { DeepThoughtCard(it) }
+                items(items, key = { it.id }) { item ->
+                    DeepThoughtCard(item, onDelete = { onDelete(item.id) })
+                }
             }
         }
     } else {
@@ -304,8 +308,8 @@ private fun DeepThoughtContent(
                 Spacer(modifier = Modifier.height(10.dp))
             }
 
-            items(items, key = { it.id }) {
-                DeepThoughtCard(it)
+            items(items, key = { it.id }) { item ->
+                DeepThoughtCard(item, onDelete = { onDelete(item.id) })
                 Spacer(modifier = Modifier.height(12.dp))
             }
         }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtScreen.kt
@@ -274,20 +274,20 @@ private fun DeepThoughtContent(
             }
         }
     } else {
-        val today = java.time.LocalDate.now()
+        var yearMonth by remember { mutableStateOf(java.time.YearMonth.now()) }
         val answeredDays =
             items
-                .filter { it.date.year == today.year && it.date.monthValue == today.monthValue }
+                .filter { it.date.year == yearMonth.year && it.date.monthValue == yearMonth.monthValue }
                 .map { it.date.dayOfMonth }
                 .toSet()
         LazyColumn(modifier = modifier) {
             item {
                 DailyCalendar(
-                    year = today.year,
-                    month = today.monthValue,
+                    year = yearMonth.year,
+                    month = yearMonth.monthValue,
                     type = MindRecordCategoryUi.DeepThought,
-                    onNextMonth = {},
-                    onPrevMonth = {},
+                    onPrevMonth = { yearMonth = yearMonth.minusMonths(1) },
+                    onNextMonth = { yearMonth = yearMonth.plusMonths(1) },
                     answeredDays = answeredDays,
                 )
                 Spacer(modifier = Modifier.height(16.dp))

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtWriteScreen.kt
@@ -51,6 +51,7 @@ fun DeepThoughtWriteScreen(
     modifier: Modifier = Modifier,
     onSubmitSuccess: () -> Unit = {},
     onBackClick: () -> Unit = {},
+    onDraftListClick: () -> Unit = {},
     viewModel: DeepThoughtWriteViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -176,6 +177,8 @@ fun DeepThoughtWriteScreen(
             WriteTextField(
                 value = uiState.content,
                 onValueChange = viewModel::onContentChanged,
+                onSaveDraftClick = { viewModel.submit(isDraft = true) },
+                onDraftCountClick = onDraftListClick,
             )
         }
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DeepThoughtWriteScreen.kt
@@ -1,5 +1,6 @@
 package com.afternote.feature.mindrecord.presentation.screen.sender
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -136,7 +137,12 @@ fun DeepThoughtWriteScreen(
                     style = AfternoteDesign.typography.bodySmallB,
                     color = AfternoteDesign.colors.gray7,
                 )
-                Column(modifier = Modifier.padding(start = 12.dp)) {
+                Column(
+                    modifier =
+                        Modifier
+                            .padding(start = 12.dp)
+                            .clickable { showCategorySheet = true },
+                ) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween,
@@ -196,6 +202,10 @@ fun DeepThoughtWriteScreen(
                 onDismiss = { showCategorySheet = false },
                 onBackClick = { showCategorySheet = false },
                 onAddCategory = { },
+                onCategoryClick = { category ->
+                    viewModel.onCategoryChanged(category.name)
+                    showCategorySheet = false
+                },
                 onMenuClick = { },
             )
         }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryScreen.kt
@@ -71,6 +71,9 @@ private fun DiaryListContent(
     isListView: Boolean,
     diaries: List<DailyDiary>,
     modifier: Modifier = Modifier,
+    monthDiaryCount: Int = 0,
+    weeklyMoodEmoji: String? = null,
+    onDelete: (Long) -> Unit = {},
 ) {
     if (isListView && diaries.isEmpty()) {
         MindRecordEmptyState(modifier = modifier)
@@ -119,6 +122,7 @@ private fun DiaryListContent(
                 DiaryComponent(
                     diary = diary,
                     modifier = Modifier.padding(vertical = 8.dp),
+                    onDelete = { onDelete(diary.id) },
                 )
             }
         }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryScreen.kt
@@ -32,6 +32,7 @@ import com.afternote.feature.mindrecord.presentation.component.DiaryCard
 import com.afternote.feature.mindrecord.presentation.component.DiaryComponent
 import com.afternote.feature.mindrecord.presentation.component.DiaryReportCard
 import com.afternote.feature.mindrecord.presentation.component.MindRecordEmptyState
+import com.afternote.feature.mindrecord.presentation.mapper.toEmoji
 import com.afternote.feature.mindrecord.presentation.model.DailyDiary
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
 import com.afternote.feature.mindrecord.presentation.viewmodel.DiaryListUiState
@@ -61,6 +62,9 @@ fun DiaryScreen(
                 modifier = modifier,
                 isListView = isListView,
                 diaries = state.diaries,
+                monthDiaryCount = state.monthDiaryCount,
+                weeklyMoodEmoji = state.weeklyDominantMood?.toEmoji(),
+                onDelete = viewModel::delete,
             )
         }
     }
@@ -134,7 +138,10 @@ private fun DiaryListContent(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             item(span = { GridItemSpan(2) }) {
-                DiaryReportCard()
+                DiaryReportCard(
+                    monthDiaryCount = monthDiaryCount,
+                    weeklyMoodEmoji = weeklyMoodEmoji,
+                )
                 Spacer(modifier = Modifier.height(24.dp))
             }
             gridItems(diaries, key = { it.id }) { diary ->

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryScreen.kt
@@ -18,6 +18,9 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -37,7 +40,7 @@ import com.afternote.feature.mindrecord.presentation.model.DailyDiary
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
 import com.afternote.feature.mindrecord.presentation.viewmodel.DiaryListUiState
 import com.afternote.feature.mindrecord.presentation.viewmodel.DiaryListViewModel
-import java.time.LocalDate
+import java.time.YearMonth
 import androidx.compose.foundation.lazy.grid.items as gridItems
 
 @Composable
@@ -65,6 +68,7 @@ fun DiaryScreen(
                 monthDiaryCount = state.monthDiaryCount,
                 weeklyMoodEmoji = state.weeklyDominantMood?.toEmoji(),
                 onDelete = viewModel::delete,
+                onYearMonthChanged = viewModel::refresh,
             )
         }
     }
@@ -78,14 +82,16 @@ private fun DiaryListContent(
     monthDiaryCount: Int = 0,
     weeklyMoodEmoji: String? = null,
     onDelete: (Long) -> Unit = {},
+    onYearMonthChanged: (YearMonth) -> Unit = {},
 ) {
     if (isListView && diaries.isEmpty()) {
         MindRecordEmptyState(modifier = modifier)
         return
     }
 
-    val today = LocalDate.now()
-    val currentMonthDiaries = diaries.filter { it.date.year == today.year && it.date.monthValue == today.monthValue }
+    var yearMonth by remember { mutableStateOf(YearMonth.now()) }
+    val currentMonthDiaries =
+        diaries.filter { it.date.year == yearMonth.year && it.date.monthValue == yearMonth.monthValue }
     val answeredDays = currentMonthDiaries.map { it.date.dayOfMonth }.toSet()
     val emotionByDay =
         currentMonthDiaries
@@ -96,11 +102,17 @@ private fun DiaryListContent(
         LazyColumn(modifier = modifier) {
             item {
                 DailyCalendar(
-                    year = today.year,
-                    month = today.monthValue,
+                    year = yearMonth.year,
+                    month = yearMonth.monthValue,
                     type = MindRecordCategoryUi.Diary,
-                    onNextMonth = {},
-                    onPrevMonth = {},
+                    onPrevMonth = {
+                        yearMonth = yearMonth.minusMonths(1)
+                        onYearMonthChanged(yearMonth)
+                    },
+                    onNextMonth = {
+                        yearMonth = yearMonth.plusMonths(1)
+                        onYearMonthChanged(yearMonth)
+                    },
                     answeredDays = answeredDays,
                     emotionByDay = emotionByDay,
                 )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
@@ -1,6 +1,5 @@
 package com.afternote.feature.mindrecord.presentation.screen.sender
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -146,11 +145,16 @@ fun DiaryWriteScreen(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Icon(
-                    painter = painterResource(com.afternote.feature.mindrecord.presentation.R.drawable.mindrecord_emotion),
-                    contentDescription = null,
-                    tint = Color(0xFF000000).copy(0.4f),
-                )
+                val selectedMood = uiState.mood
+                if (selectedMood != null) {
+                    Text(text = selectedMood.emoji())
+                } else {
+                    Icon(
+                        painter = painterResource(com.afternote.feature.mindrecord.presentation.R.drawable.mindrecord_emotion),
+                        contentDescription = null,
+                        tint = Color(0xFF000000).copy(0.4f),
+                    )
+                }
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
                     text = stringResource(MindRecordR.string.mindrecord_diary_write_mood_label),
@@ -169,47 +173,6 @@ fun DiaryWriteScreen(
                 Spacer(modifier = Modifier.width(8.dp))
                 MoodChip("😢", selected = uiState.mood == TodayMood.SAD) {
                     viewModel.onMoodSelected(TodayMood.SAD)
-                }
-            }
-            Row {
-                Button(
-                    onClick = {},
-                    colors = ButtonDefaults.buttonColors(containerColor = Color.White),
-                    border = BorderStroke(1.dp, color = Color(0xFF000000).copy(0.05f)),
-                ) {
-                    Icon(
-                        painter = painterResource(com.afternote.feature.mindrecord.presentation.R.drawable.mindrecord_pos),
-                        contentDescription = null,
-                        tint = Color(0xFF000000).copy(0.6f),
-                        modifier = Modifier.size(12.dp),
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = stringResource(MindRecordR.string.mindrecord_diary_write_add_location),
-                        style = AfternoteDesign.typography.captionLargeR,
-                        color = AfternoteDesign.colors.black.copy(alpha = 0.6f),
-                    )
-                }
-
-                Spacer(modifier = Modifier.width(4.dp))
-
-                Button(
-                    onClick = {},
-                    colors = ButtonDefaults.buttonColors(containerColor = Color.White),
-                    border = BorderStroke(1.dp, color = Color(0xFF000000).copy(0.05f)),
-                ) {
-                    Icon(
-                        painter = painterResource(com.afternote.feature.mindrecord.presentation.R.drawable.mindrecord_picture),
-                        contentDescription = null,
-                        tint = Color(0xFF000000).copy(0.6f),
-                        modifier = Modifier.size(12.dp),
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = stringResource(MindRecordR.string.mindrecord_diary_write_add_photo),
-                        style = AfternoteDesign.typography.captionLargeR,
-                        color = AfternoteDesign.colors.black.copy(alpha = 0.6f),
-                    )
                 }
             }
 
@@ -264,6 +227,13 @@ private fun MoodChip(
         Text(text = emoji)
     }
 }
+
+private fun TodayMood.emoji(): String =
+    when (this) {
+        TodayMood.HAPPY -> "😊"
+        TodayMood.SOSO -> "😐"
+        TodayMood.SAD -> "😢"
+    }
 
 @Preview(showBackground = true)
 @Composable

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
@@ -57,6 +57,7 @@ fun DiaryWriteScreen(
     modifier: Modifier = Modifier,
     onSubmitSuccess: () -> Unit = {},
     onBackClick: () -> Unit = {},
+    onDraftListClick: () -> Unit = {},
     viewModel: DiaryWriteViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -188,6 +189,8 @@ fun DiaryWriteScreen(
             WriteTextField(
                 value = uiState.content,
                 onValueChange = viewModel::onContentChanged,
+                onSaveDraftClick = { viewModel.submit(isDraft = true) },
+                onDraftCountClick = onDraftListClick,
             )
         }
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DraftListScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DraftListScreen.kt
@@ -1,0 +1,299 @@
+package com.afternote.feature.mindrecord.presentation.screen.sender
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.afternote.core.ui.R
+import com.afternote.core.ui.asString
+import com.afternote.core.ui.theme.AfternoteDesign
+import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.core.ui.topbar.DetailTopBar
+import com.afternote.feature.mindrecord.presentation.viewmodel.DraftCategory
+import com.afternote.feature.mindrecord.presentation.viewmodel.DraftItem
+import com.afternote.feature.mindrecord.presentation.viewmodel.DraftListUiState
+import com.afternote.feature.mindrecord.presentation.viewmodel.DraftListViewModel
+import java.time.format.DateTimeFormatter
+import com.afternote.feature.mindrecord.presentation.R as MindRecordR
+
+/**
+ * 임시저장 목록 화면. Figma 노드 1716:13536 — 카테고리 필터 칩 + 총 개수 + 항목 리스트.
+ */
+@Composable
+fun DraftListScreen(
+    modifier: Modifier = Modifier,
+    onBackClick: () -> Unit = {},
+    viewModel: DraftListViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            DetailTopBar(
+                title = stringResource(MindRecordR.string.mindrecord_draft_list_title),
+                onBackClick = onBackClick,
+                actions = {
+                    Box(
+                        modifier =
+                            Modifier
+                                .clip(RoundedCornerShape(6.dp))
+                                .background(AfternoteDesign.colors.gray2)
+                                .padding(horizontal = 18.dp, vertical = 8.dp),
+                    ) {
+                        Text(
+                            text = stringResource(MindRecordR.string.mindrecord_draft_list_edit),
+                            style = AfternoteDesign.typography.bodySmallB,
+                            color = AfternoteDesign.colors.gray6,
+                        )
+                    }
+                },
+            )
+        },
+        modifier = modifier,
+    ) { paddingValues ->
+        Box(modifier = Modifier.padding(paddingValues)) {
+            when (val state = uiState) {
+                DraftListUiState.Loading -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                is DraftListUiState.Error -> {
+                    Box(modifier = Modifier.fillMaxSize().padding(20.dp), contentAlignment = Alignment.Center) {
+                        Text(text = state.message.asString(), color = AfternoteDesign.colors.gray9)
+                    }
+                }
+
+                is DraftListUiState.Success -> {
+                    SuccessContent(
+                        state = state,
+                        onFilterChanged = viewModel::onFilterChanged,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SuccessContent(
+    state: DraftListUiState.Success,
+    onFilterChanged: (DraftCategory) -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        FilterRow(
+            selected = state.filter,
+            totalCount = state.totalCount,
+            onFilterChanged = onFilterChanged,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        if (state.filtered.isEmpty()) {
+            Box(modifier = Modifier.fillMaxSize().padding(20.dp), contentAlignment = Alignment.Center) {
+                Text(
+                    text = stringResource(MindRecordR.string.mindrecord_draft_list_empty),
+                    style = AfternoteDesign.typography.captionLargeR,
+                    color = AfternoteDesign.colors.gray6,
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(horizontal = 20.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                items(state.filtered, key = { "${it.category.name}-${it.id}" }) { item ->
+                    DraftRow(item)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FilterRow(
+    selected: DraftCategory,
+    totalCount: Int,
+    onFilterChanged: (DraftCategory) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box {
+            Row(
+                modifier =
+                    Modifier
+                        .clip(CircleShape)
+                        .background(AfternoteDesign.colors.gray2)
+                        .clickable { expanded = true }
+                        .padding(horizontal = 16.dp, vertical = 9.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = selected.label(),
+                    style = AfternoteDesign.typography.captionLargeR,
+                    color = AfternoteDesign.colors.gray9,
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Icon(
+                    painter = painterResource(R.drawable.core_ui_arrowdown),
+                    contentDescription = null,
+                    tint = AfternoteDesign.colors.gray9,
+                    modifier = Modifier.size(8.dp),
+                )
+            }
+            if (expanded) {
+                FilterDropdown(
+                    selected = selected,
+                    onSelect = {
+                        onFilterChanged(it)
+                        expanded = false
+                    },
+                    onDismiss = { expanded = false },
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "총 ",
+                style = AfternoteDesign.typography.footnoteCaption,
+                color = AfternoteDesign.colors.gray9,
+            )
+            Text(
+                text = totalCount.toString(),
+                style = AfternoteDesign.typography.footnoteCaption,
+                color = AfternoteDesign.colors.gray6,
+            )
+            Text(
+                text = "개",
+                style = AfternoteDesign.typography.footnoteCaption,
+                color = AfternoteDesign.colors.gray9,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FilterDropdown(
+    selected: DraftCategory,
+    onSelect: (DraftCategory) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Popup(
+        alignment = Alignment.TopStart,
+        onDismissRequest = onDismiss,
+        properties = PopupProperties(focusable = true),
+    ) {
+        Surface(
+            modifier = Modifier.width(132.dp),
+            shape = RoundedCornerShape(8.dp),
+            color = Color.White,
+            shadowElevation = 10.dp,
+        ) {
+            Column {
+                DraftCategory.entries.forEach { category ->
+                    Text(
+                        text = category.label(),
+                        style = AfternoteDesign.typography.bodySmallR,
+                        color = AfternoteDesign.colors.gray9,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable { onSelect(category) }
+                                .padding(16.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DraftRow(item: DraftItem) {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(bottom = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = item.category.label(),
+                style = AfternoteDesign.typography.footnoteCaption,
+                color = AfternoteDesign.colors.gray6,
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Text(
+                text = DateFormatter.format(item.date),
+                style = AfternoteDesign.typography.footnoteCaption,
+                color = AfternoteDesign.colors.gray6,
+            )
+        }
+        Text(
+            text = item.content,
+            style = AfternoteDesign.typography.bodySmallR,
+            color = AfternoteDesign.colors.gray9,
+        )
+        HorizontalDivider(thickness = 0.5.dp, color = AfternoteDesign.colors.gray3)
+    }
+}
+
+private val DateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy. MM. dd.")
+
+@Composable
+private fun DraftCategory.label(): String =
+    when (this) {
+        DraftCategory.All -> stringResource(MindRecordR.string.mindrecord_draft_list_filter_all)
+        DraftCategory.DailyQuestion -> stringResource(MindRecordR.string.mindrecord_draft_list_filter_daily)
+        DraftCategory.Diary -> stringResource(MindRecordR.string.mindrecord_draft_list_filter_diary)
+        DraftCategory.DeepThought -> stringResource(MindRecordR.string.mindrecord_draft_list_filter_deep_thought)
+    }
+
+@Preview(showBackground = true)
+@Composable
+private fun DraftListScreenPreview() {
+    AfternoteTheme {
+        // ViewModel 의존이 있어 Preview는 비워둠
+    }
+}

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DraftListScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DraftListScreen.kt
@@ -45,6 +45,7 @@ import com.afternote.core.ui.asString
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.core.ui.topbar.DetailTopBar
+import com.afternote.feature.mindrecord.presentation.util.htmlToPlainText
 import com.afternote.feature.mindrecord.presentation.viewmodel.DraftCategory
 import com.afternote.feature.mindrecord.presentation.viewmodel.DraftItem
 import com.afternote.feature.mindrecord.presentation.viewmodel.DraftListUiState
@@ -271,7 +272,7 @@ private fun DraftRow(item: DraftItem) {
             )
         }
         Text(
-            text = item.content,
+            text = item.content.htmlToPlainText(),
             style = AfternoteDesign.typography.bodySmallR,
             color = AfternoteDesign.colors.gray9,
         )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/WeeklyReportScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/WeeklyReportScreen.kt
@@ -1,14 +1,14 @@
 package com.afternote.feature.mindrecord.presentation.screen.sender
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
@@ -67,7 +67,13 @@ private fun WeeklyReportContent(
     onWeekSelect: (java.time.LocalDate) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(modifier = modifier) {
+    // Figma 노드 852:11543 — main 컨테이너의 섹션 간 gap=32, 시작 pt=8, 끝 pb=200.
+    // 가로 패딩(20dp)은 호출부(HomeScreen)에서 이미 제공하므로 여기선 추가하지 않는다.
+    LazyColumn(
+        modifier = modifier,
+        contentPadding = PaddingValues(top = 8.dp, bottom = 200.dp),
+        verticalArrangement = Arrangement.spacedBy(32.dp),
+    ) {
         item {
             WeeklyReportReviewCard(
                 selectedMonday = state.selectedMonday,
@@ -78,38 +84,40 @@ private fun WeeklyReportContent(
             )
         }
 
+        // 요약 메시지 + 캘린더 — gap=8, 메시지 좌측 pl=8.
         item {
-            Text(text = recordedSummary(userName = state.userName, recordedDays = state.recordedDays))
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = recordedSummary(userName = state.userName, recordedDays = state.recordedDays),
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+                WeeklyMoodCalendar(days = state.weekDays)
+            }
         }
 
+        // TOP KEYWORDS 섹션 — py=8, gap=12 (divider + 감정 카드 + INSIGHT 카드).
         item {
-            WeeklyMoodCalendar(days = state.weekDays)
+            Column(
+                modifier = Modifier.padding(vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                SectionHeader(title = "TOP KEYWORDS")
+                EmotionKeywordCard(
+                    bubbles = state.emotionBubbles,
+                    descriptionText = state.summaryText,
+                )
+                InsightCard(bodyText = state.summaryText)
+            }
         }
 
+        // HISTORY 섹션 — gap=12 (divider + 다이어리 카드들).
         item {
-            SectionHeader(title = "TOP KEYWORDS")
-            Spacer(modifier = Modifier.height(10.dp))
-        }
-
-        item {
-            EmotionKeywordCard(
-                bubbles = state.emotionBubbles,
-                descriptionText = state.summaryText,
-            )
-        }
-
-        item {
-            InsightCard(bodyText = state.summaryText)
-            Spacer(modifier = Modifier.height(10.dp))
-        }
-
-        item {
-            SectionHeader(title = "HISTORY")
-            Spacer(modifier = Modifier.height(10.dp))
-        }
-
-        items(state.dailyQuestions, key = { it.id to it.date }) { dailyQuestion ->
-            DailyQuestionListCard(answer = dailyQuestion)
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                SectionHeader(title = "HISTORY")
+                state.dailyQuestions.forEach { dailyQuestion ->
+                    DailyQuestionListCard(answer = dailyQuestion)
+                }
+            }
         }
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/WeeklyReportScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/WeeklyReportScreen.kt
@@ -103,8 +103,13 @@ private fun WeeklyReportContent(
             ) {
                 SectionHeader(title = "TOP KEYWORDS")
                 EmotionKeywordCard(
-                    bubbles = state.emotionBubbles,
-                    descriptionText = state.summaryText,
+                    keywords = state.emotionKeywords,
+                    descriptionText =
+                        if (state.emotionKeywords.isEmpty()) {
+                            stringResource(R.string.mindrecord_emotion_card_empty_description, state.userName)
+                        } else {
+                            state.summaryText
+                        },
                 )
                 InsightCard(bodyText = state.summaryText)
             }
@@ -202,7 +207,7 @@ private fun WeeklyReportScreenPreview() {
                     recordedDays = 3,
                     counts = emptyList(),
                     weekDays = emptyList(),
-                    emotionBubbles = emptyList(),
+                    emotionKeywords = emptyList(),
                     summaryText = "이번 주는 차분히 마음을 정리한 한 주였어요.",
                     dailyQuestions = emptyList(),
                 ),

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/util/HtmlText.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/util/HtmlText.kt
@@ -1,0 +1,16 @@
+package com.afternote.feature.mindrecord.presentation.util
+
+import androidx.core.text.HtmlCompat
+
+/**
+ * HTML 직렬화된 본문에서 태그를 제거해 리스트 카드에 노출할 plain text 로 변환.
+ *
+ * 작성 화면(WriteTextField → compose-richeditor)이 `<a href>` / `<img>` / `<b>` 등의 태그로
+ * 본문을 직렬화하기 때문에, 카드 미리보기에선 태그를 제거해야 한다. 원본 HTML 은 도메인/
+ * ViewModel 상태에 그대로 유지되며, 본 함수는 표시 시점에만 변환한다.
+ */
+fun String.htmlToPlainText(): String =
+    HtmlCompat
+        .fromHtml(this, HtmlCompat.FROM_HTML_MODE_COMPACT)
+        .toString()
+        .trim()

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionListViewModel.kt
@@ -43,6 +43,12 @@ class DailyQuestionListViewModel
             load(date)
         }
 
+        fun delete(id: Long) {
+            viewModelScope.launch {
+                repository.delete(id).onSuccess { load() }
+            }
+        }
+
         private fun load(date: String? = null) {
             viewModelScope.launch {
                 internalState.update { it.copy(loadPhase = LoadPhase.Loading) }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DeepThoughtListViewModel.kt
@@ -53,6 +53,12 @@ class DeepThoughtListViewModel
 
         fun refresh() = load()
 
+        fun delete(id: Long) {
+            viewModelScope.launch {
+                repository.delete(id).onSuccess { load() }
+            }
+        }
+
         private fun load() {
             val state = internalState.value
             viewModelScope.launch {

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryListUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryListUiState.kt
@@ -1,6 +1,7 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
 import com.afternote.core.ui.UiText
+import com.afternote.feature.mindrecord.domain.model.TodayMood
 import com.afternote.feature.mindrecord.presentation.model.DailyDiary
 
 sealed interface DiaryListUiState {
@@ -8,6 +9,8 @@ sealed interface DiaryListUiState {
 
     data class Success(
         val diaries: List<DailyDiary>,
+        val monthDiaryCount: Int = 0,
+        val weeklyDominantMood: TodayMood? = null,
     ) : DiaryListUiState
 
     data class Error(

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryListViewModel.kt
@@ -90,13 +90,20 @@ class DiaryListViewModel
 
         private fun InternalState.toUiState(): DiaryListUiState =
             when (val phase = loadPhase) {
-                LoadPhase.Loading -> DiaryListUiState.Loading
-                is LoadPhase.Loaded ->
+                LoadPhase.Loading -> {
+                    DiaryListUiState.Loading
+                }
+
+                is LoadPhase.Loaded -> {
                     DiaryListUiState.Success(
                         diaries = phase.list.diaries.map { it.toUi() },
                         monthDiaryCount = phase.list.monthDiaryCount,
                         weeklyDominantMood = phase.list.weeklyDominantMood,
                     )
-                is LoadPhase.Failed -> DiaryListUiState.Error(phase.message)
+                }
+
+                is LoadPhase.Failed -> {
+                    DiaryListUiState.Error(phase.message)
+                }
             }
     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryListViewModel.kt
@@ -43,6 +43,12 @@ class DiaryListViewModel
             load(yearMonth)
         }
 
+        fun delete(id: Long) {
+            viewModelScope.launch {
+                repository.delete(id).onSuccess { load() }
+            }
+        }
+
         private fun load(yearMonth: YearMonth = YearMonth.now()) {
             viewModelScope.launch {
                 internalState.update { it.copy(loadPhase = LoadPhase.Loading) }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryListViewModel.kt
@@ -3,7 +3,7 @@ package com.afternote.feature.mindrecord.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.afternote.core.ui.UiText
-import com.afternote.feature.mindrecord.domain.model.Diary
+import com.afternote.feature.mindrecord.domain.model.DiaryList
 import com.afternote.feature.mindrecord.domain.repository.DiaryRepository
 import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.mapper.toUi
@@ -54,8 +54,8 @@ class DiaryListViewModel
                 internalState.update { it.copy(loadPhase = LoadPhase.Loading) }
                 repository
                     .getList(yearMonth = yearMonth.toString(), draftOnly = null)
-                    .onSuccess { list ->
-                        internalState.update { it.copy(loadPhase = LoadPhase.Loaded(list)) }
+                    .onSuccess { result ->
+                        internalState.update { it.copy(loadPhase = LoadPhase.Loaded(result)) }
                     }.onFailure { e ->
                         internalState.update {
                             it.copy(
@@ -80,7 +80,7 @@ class DiaryListViewModel
             data object Loading : LoadPhase
 
             data class Loaded(
-                val diaries: List<Diary>,
+                val list: DiaryList,
             ) : LoadPhase
 
             data class Failed(
@@ -91,7 +91,12 @@ class DiaryListViewModel
         private fun InternalState.toUiState(): DiaryListUiState =
             when (val phase = loadPhase) {
                 LoadPhase.Loading -> DiaryListUiState.Loading
-                is LoadPhase.Loaded -> DiaryListUiState.Success(phase.diaries.map { it.toUi() })
+                is LoadPhase.Loaded ->
+                    DiaryListUiState.Success(
+                        diaries = phase.list.diaries.map { it.toUi() },
+                        monthDiaryCount = phase.list.monthDiaryCount,
+                        weeklyDominantMood = phase.list.weeklyDominantMood,
+                    )
                 is LoadPhase.Failed -> DiaryListUiState.Error(phase.message)
             }
     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteUiState.kt
@@ -6,11 +6,11 @@ import java.time.LocalDate
 data class DiaryWriteUiState(
     val title: String = "",
     val content: String = "",
-    val mood: TodayMood = TodayMood.SOSO,
+    val mood: TodayMood? = null,
     val date: LocalDate = LocalDate.now(),
     val imageUrl: String? = null,
     val submitState: SubmitState = SubmitState.Idle,
 ) {
     val canSubmit: Boolean
-        get() = title.isNotBlank() && content.isNotBlank() && submitState != SubmitState.InProgress
+        get() = title.isNotBlank() && content.isNotBlank() && mood != null && submitState != SubmitState.InProgress
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteViewModel.kt
@@ -44,6 +44,7 @@ class DiaryWriteViewModel
         fun submit(isDraft: Boolean = false) {
             val state = _uiState.value
             if (!state.canSubmit) return
+            val mood = state.mood ?: return
 
             viewModelScope.launch {
                 _uiState.update { it.copy(submitState = SubmitState.InProgress) }
@@ -53,7 +54,7 @@ class DiaryWriteViewModel
                             title = state.title,
                             content = state.content,
                             isDraft = isDraft,
-                            todayMood = state.mood,
+                            todayMood = mood,
                             imageUrl = state.imageUrl,
                         ),
                     ).onSuccess {

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DraftListUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DraftListUiState.kt
@@ -1,0 +1,47 @@
+package com.afternote.feature.mindrecord.presentation.viewmodel
+
+import com.afternote.core.ui.UiText
+import java.time.LocalDate
+
+/**
+ * 작성 화면 키보드 툴바 "임시저장 N" 영역에서 진입하는 임시저장 목록 화면 상태.
+ *
+ * 데일리질문 / 일기 / 깊은 생각 3개 카테고리의 isDraft=true 항목을 합쳐 보여준다.
+ * 데일리질문 응답은 isDraft 필드를 노출하지 않아 현재는 분류 불가 — 화면 필터 옵션은 유지하되
+ * 실제 항목은 비어 있게 보인다 (TODO: 백엔드 응답 확장 후 매핑).
+ */
+sealed interface DraftListUiState {
+    data object Loading : DraftListUiState
+
+    data class Success(
+        val items: List<DraftItem>,
+        val filter: DraftCategory,
+    ) : DraftListUiState {
+        val filtered: List<DraftItem>
+            get() =
+                when (filter) {
+                    DraftCategory.All -> items
+                    else -> items.filter { it.category == filter }
+                }
+
+        val totalCount: Int get() = filtered.size
+    }
+
+    data class Error(
+        val message: UiText,
+    ) : DraftListUiState
+}
+
+enum class DraftCategory {
+    All,
+    DailyQuestion,
+    Diary,
+    DeepThought,
+}
+
+data class DraftItem(
+    val id: Long,
+    val category: DraftCategory,
+    val content: String,
+    val date: LocalDate,
+)

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DraftListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DraftListViewModel.kt
@@ -1,0 +1,111 @@
+package com.afternote.feature.mindrecord.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.afternote.core.ui.UiText
+import com.afternote.feature.mindrecord.domain.repository.DeepThoughtRepository
+import com.afternote.feature.mindrecord.domain.repository.DiaryRepository
+import com.afternote.feature.mindrecord.presentation.R
+import com.afternote.feature.mindrecord.presentation.mapper.toUi
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.YearMonth
+import javax.inject.Inject
+
+/**
+ * 임시저장 목록 ViewModel.
+ *
+ * - 일기: 백엔드가 `draftOnly=true` 쿼리를 제공해 그대로 호출 (단, 이번 달 한정).
+ * - 깊은 생각: 전체 리스트를 받아 `isDraft = true` client-side 필터 (전용 쿼리 없음).
+ * - 데일리질문: 응답에 `isDraft` 가 없어 분류 불가 → 0건 처리 (TODO).
+ *
+ * 두 호출은 병렬로 묶고, 어느 한쪽이 실패해도 다른 쪽은 비어 있는 결과로 합쳐 화면이 깨지지 않게 한다.
+ */
+@HiltViewModel
+class DraftListViewModel
+    @Inject
+    constructor(
+        private val diaryRepository: DiaryRepository,
+        private val deepThoughtRepository: DeepThoughtRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow<DraftListUiState>(DraftListUiState.Loading)
+        val uiState: StateFlow<DraftListUiState> = _uiState.asStateFlow()
+
+        init {
+            load()
+        }
+
+        fun refresh() = load()
+
+        fun onFilterChanged(filter: DraftCategory) {
+            _uiState.update {
+                if (it is DraftListUiState.Success) it.copy(filter = filter) else it
+            }
+        }
+
+        private fun load() {
+            viewModelScope.launch {
+                _uiState.value = DraftListUiState.Loading
+                val items = collectDrafts()
+                _uiState.value =
+                    if (items != null) {
+                        DraftListUiState.Success(items = items, filter = DraftCategory.All)
+                    } else {
+                        DraftListUiState.Error(UiText.Resource(R.string.mindrecord_error_generic))
+                    }
+            }
+        }
+
+        private suspend fun collectDrafts(): List<DraftItem>? =
+            runCatching {
+                coroutineScope {
+                    val yearMonth = YearMonth.now().toString()
+                    val diaryDeferred =
+                        async {
+                            diaryRepository
+                                .getList(yearMonth = yearMonth, draftOnly = true)
+                                .getOrNull()
+                                ?.diaries
+                                .orEmpty()
+                        }
+                    val deepThoughtDeferred =
+                        async {
+                            deepThoughtRepository
+                                .getList()
+                                .getOrNull()
+                                ?.items
+                                ?.filter { it.isDraft }
+                                .orEmpty()
+                        }
+
+                    val diaryItems =
+                        diaryDeferred.await().map { diary ->
+                            val ui = diary.toUi()
+                            DraftItem(
+                                id = ui.id,
+                                category = DraftCategory.Diary,
+                                content = ui.content,
+                                date = ui.date,
+                            )
+                        }
+                    val deepThoughtItems =
+                        deepThoughtDeferred.await().map { thought ->
+                            val ui = thought.toUi()
+                            DraftItem(
+                                id = ui.id,
+                                category = DraftCategory.DeepThought,
+                                content = ui.content,
+                                date = ui.date,
+                            )
+                        }
+
+                    (diaryItems + deepThoughtItems).sortedByDescending { it.date }
+                }
+            }.getOrNull()
+    }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportUiState.kt
@@ -1,9 +1,9 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
 import com.afternote.core.ui.UiText
-import com.afternote.feature.mindrecord.presentation.component.EmotionBubble
 import com.afternote.feature.mindrecord.presentation.model.DailyQuestion
 import com.afternote.feature.mindrecord.presentation.model.DayItem
+import com.afternote.feature.mindrecord.presentation.model.EmotionKeyword
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
 import java.time.LocalDate
 
@@ -25,7 +25,7 @@ sealed interface WeeklyReportUiState {
         val recordedDays: Int,
         val counts: List<Pair<Int, MindRecordCategoryUi>>,
         val weekDays: List<DayItem>,
-        val emotionBubbles: List<EmotionBubble>,
+        val emotionKeywords: List<EmotionKeyword>,
         val summaryText: String,
         val dailyQuestions: List<DailyQuestion>,
     ) : WeeklyReportUiState

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportViewModel.kt
@@ -1,8 +1,5 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.afternote.core.domain.repository.UserRepository
@@ -14,11 +11,11 @@ import com.afternote.feature.mindrecord.domain.model.WeeklyReportDay
 import com.afternote.feature.mindrecord.domain.model.WeeklyReportEmotion
 import com.afternote.feature.mindrecord.domain.repository.WeeklyReportRepository
 import com.afternote.feature.mindrecord.presentation.R
-import com.afternote.feature.mindrecord.presentation.component.EmotionBubble
 import com.afternote.feature.mindrecord.presentation.model.DailyQuestion
 import com.afternote.feature.mindrecord.presentation.model.DayBackground
 import com.afternote.feature.mindrecord.presentation.model.DayContent
 import com.afternote.feature.mindrecord.presentation.model.DayItem
+import com.afternote.feature.mindrecord.presentation.model.EmotionKeyword
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
@@ -184,7 +181,7 @@ class WeeklyReportViewModel
                         report.deepThoughtAmount to MindRecordCategoryUi.DeepThought,
                     ),
                 weekDays = mapWeekDays(monday, report.week),
-                emotionBubbles = mapEmotionBubbles(report.emotions),
+                emotionKeywords = mapEmotionKeywords(report.emotions),
                 summaryText = report.summaryText,
                 dailyQuestions = report.dailyQuestions.map { it.toUi() },
             )
@@ -204,31 +201,15 @@ class WeeklyReportViewModel
                     TodayMood.SAD -> "😢"
                 }
 
-            // 4개 슬롯의 크기/위치/색상은 디자인 시안에 맞춰 고정. API 의 emotions 를 percentage
-            // 내림차순으로 정렬해 슬롯에 채워 넣어, 1위가 가장 크고 진한 버블이 되도록 배치.
-            private val BUBBLE_SLOTS: List<BubbleSlot> =
-                listOf(
-                    BubbleSlot(size = 100.dp, bgColor = Color(0xFF212121), offsetX = 0.dp, offsetY = 30.dp),
-                    BubbleSlot(size = 82.dp, bgColor = Color(0xFF424242), offsetX = 88.dp, offsetY = 0.dp),
-                    BubbleSlot(size = 68.dp, bgColor = Color(0xFF616161), offsetX = 158.dp, offsetY = 68.dp),
-                    BubbleSlot(size = 58.dp, bgColor = Color(0xFF9E9E9E), offsetX = 230.dp, offsetY = 42.dp),
-                )
+            // 카드 측에서 키워드 개수(0~4)에 따라 슬롯(size·offset·color)을 결정하므로,
+            // 여기선 percentage 내림차순으로 정렬해 최대 4건만 잘라 키워드·카운트만 노출한다.
+            private const val MAX_EMOTION_KEYWORDS = 4
 
-            private fun mapEmotionBubbles(emotions: List<WeeklyReportEmotion>): List<EmotionBubble> =
+            private fun mapEmotionKeywords(emotions: List<WeeklyReportEmotion>): List<EmotionKeyword> =
                 emotions
                     .sortedByDescending { it.percentage }
-                    .take(BUBBLE_SLOTS.size)
-                    .mapIndexed { index, emotion ->
-                        val slot = BUBBLE_SLOTS[index]
-                        EmotionBubble(
-                            keyword = emotion.keyword,
-                            count = emotion.percentage,
-                            size = slot.size,
-                            bgColor = slot.bgColor,
-                            offsetX = slot.offsetX,
-                            offsetY = slot.offsetY,
-                        )
-                    }
+                    .take(MAX_EMOTION_KEYWORDS)
+                    .map { EmotionKeyword(keyword = it.keyword, count = it.percentage) }
 
             private fun WeeklyReportDailyQuestion.toUi(): DailyQuestion =
                 DailyQuestion(
@@ -252,11 +233,4 @@ class WeeklyReportViewModel
                 return LocalDate.now()
             }
         }
-
-        private data class BubbleSlot(
-            val size: Dp,
-            val bgColor: Color,
-            val offsetX: Dp,
-            val offsetY: Dp,
-        )
     }

--- a/feature/mindrecord/presentation/src/main/res/drawable/mindrecord_ic_mic.xml
+++ b/feature/mindrecord/presentation/src/main/res/drawable/mindrecord_ic_mic.xml
@@ -1,0 +1,38 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,1C11.204,1 10.441,1.316 9.879,1.879C9.316,2.441 9,3.204 9,4V12C9,12.796 9.316,13.559 9.879,14.121C10.441,14.684 11.204,15 12,15C12.796,15 13.559,14.684 14.121,14.121C14.684,13.559 15,12.796 15,12V4C15,3.204 14.684,2.441 14.121,1.879C13.559,1.316 12.796,1 12,1Z"
+      android:strokeAlpha="0.6"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M19,10V12C19,13.856 18.263,15.637 16.95,16.95C15.637,18.263 13.856,19 12,19C10.144,19 8.363,18.263 7.05,16.95C5.738,15.637 5,13.856 5,12V10"
+      android:strokeAlpha="0.6"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M12,19V23"
+      android:strokeAlpha="0.6"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M8,23H16"
+      android:strokeAlpha="0.6"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"
+      android:strokeLineCap="round"/>
+</vector>

--- a/feature/mindrecord/presentation/src/main/res/values/strings.xml
+++ b/feature/mindrecord/presentation/src/main/res/values/strings.xml
@@ -129,6 +129,11 @@
 
     <!-- Keyboard toolbar -->
     <string name="mindrecord_toolbar_link_cd">링크</string>
+
+    <!-- Link bottom sheet (키보드 툴바 링크 버튼) -->
+    <string name="mindrecord_link_sheet_title">링크 추가하기</string>
+    <string name="mindrecord_link_sheet_confirm">완료</string>
+    <string name="mindrecord_link_sheet_placeholder">URL을 입력하세요.</string>
     <string name="mindrecord_toolbar_align_left_cd">왼쪽 정렬</string>
     <string name="mindrecord_toolbar_align_center_cd">가운데 정렬</string>
     <string name="mindrecord_toolbar_align_right_cd">오른쪽 정렬</string>

--- a/feature/mindrecord/presentation/src/main/res/values/strings.xml
+++ b/feature/mindrecord/presentation/src/main/res/values/strings.xml
@@ -22,6 +22,11 @@
     <string name="mindrecord_action_delete">삭제</string>
     <string name="mindrecord_action_rename">이름 수정</string>
 
+    <!-- Record card more-menu -->
+    <string name="mindrecord_record_action_delete">삭제하기</string>
+    <string name="mindrecord_record_action_edit">수정하기</string>
+    <string name="mindrecord_more_menu_cd">더보기 메뉴</string>
+
     <!-- Mind record category meta (MindRecordCategoryUi) -->
     <string name="mindrecord_category_daily_question_title">데일리 질문</string>
     <string name="mindrecord_category_daily_question_description">매일 다른 질문을 남겨 보세요.</string>

--- a/feature/mindrecord/presentation/src/main/res/values/strings.xml
+++ b/feature/mindrecord/presentation/src/main/res/values/strings.xml
@@ -38,8 +38,6 @@
     <string name="mindrecord_diary_write_title">일기 기록하기</string>
     <string name="mindrecord_diary_write_title_placeholder">제목을 입력하세요.</string>
     <string name="mindrecord_diary_write_mood_label">오늘의 기분</string>
-    <string name="mindrecord_diary_write_add_location">위치 추가</string>
-    <string name="mindrecord_diary_write_add_photo">사진 추가</string>
 
     <string name="mindrecord_deep_thought_write_title">깊은 생각 기록하기</string>
     <string name="mindrecord_deep_thought_write_title_label">제목</string>

--- a/feature/mindrecord/presentation/src/main/res/values/strings.xml
+++ b/feature/mindrecord/presentation/src/main/res/values/strings.xml
@@ -130,7 +130,14 @@
     <!-- Keyboard toolbar -->
     <string name="mindrecord_toolbar_link_cd">링크</string>
 
-    <!-- Link bottom sheet (키보드 툴바 링크 버튼) -->
+    <!-- Media select bottom sheet (키보드 툴바 링크 버튼 → 미디어 메인 메뉴) -->
+    <string name="mindrecord_media_sheet_title">미디어 추가하기</string>
+    <string name="mindrecord_media_sheet_image">이미지 추가하기</string>
+    <string name="mindrecord_media_sheet_voice">음성 추가하기</string>
+    <string name="mindrecord_media_sheet_file">파일 추가하기</string>
+    <string name="mindrecord_media_sheet_link">링크 추가하기</string>
+
+    <!-- Link bottom sheet (미디어 시트 → "링크 추가하기") -->
     <string name="mindrecord_link_sheet_title">링크 추가하기</string>
     <string name="mindrecord_link_sheet_confirm">완료</string>
     <string name="mindrecord_link_sheet_placeholder">URL을 입력하세요.</string>

--- a/feature/mindrecord/presentation/src/main/res/values/strings.xml
+++ b/feature/mindrecord/presentation/src/main/res/values/strings.xml
@@ -116,6 +116,16 @@
     <string name="mindrecord_deep_thought_sample_category_today">오늘 떠올린 생각</string>
     <string name="mindrecord_deep_thought_sample_category_retrospective">인생을 되돌아 보며</string>
 
+    <!-- Draft list screen -->
+    <string name="mindrecord_draft_list_title">임시 저장</string>
+    <string name="mindrecord_draft_list_total">총 %d개</string>
+    <string name="mindrecord_draft_list_filter_all">전체</string>
+    <string name="mindrecord_draft_list_filter_daily">데일리질문</string>
+    <string name="mindrecord_draft_list_filter_diary">일기</string>
+    <string name="mindrecord_draft_list_filter_deep_thought">깊은생각</string>
+    <string name="mindrecord_draft_list_edit">수정</string>
+    <string name="mindrecord_draft_list_empty">임시 저장된 항목이 없습니다.</string>
+
     <!-- Keyboard toolbar -->
     <string name="mindrecord_toolbar_link_cd">링크</string>
     <string name="mindrecord_toolbar_align_left_cd">왼쪽 정렬</string>
@@ -123,6 +133,7 @@
     <string name="mindrecord_toolbar_align_right_cd">오른쪽 정렬</string>
     <string name="mindrecord_toolbar_close_cd">닫기</string>
     <string name="mindrecord_toolbar_draft_count">임시저장 %d</string>
+    <string name="mindrecord_toolbar_draft_label">임시저장</string>
     <string name="mindrecord_toolbar_text_settings">텍스트 설정</string>
     <string name="mindrecord_toolbar_style_title">제목</string>
     <string name="mindrecord_toolbar_style_header">머릿말</string>

--- a/feature/mindrecord/presentation/src/main/res/values/strings.xml
+++ b/feature/mindrecord/presentation/src/main/res/values/strings.xml
@@ -100,6 +100,7 @@
     <!-- Emotion keyword card -->
     <string name="mindrecord_emotion_card_title">나의 감정 키워드</string>
     <string name="mindrecord_emotion_card_default_description">이번 주 박서연 님의 기록에서는\n\'가족\'을 위한 \'감사\'의 마음이 엿보입니다.</string>
+    <string name="mindrecord_emotion_card_empty_description">이번 주 %1$s 님의 기록에서는 키워드가 나오지 않았어요.</string>
 
     <!-- Empty state -->
     <string name="mindrecord_empty_state_title">아직 등록된 답변이 없어요.</string>


### PR DESCRIPTION
## Summary

마음의 기록 관련 4가지 변경을 한 번에 묶은 PR.

### 1) 일기 작성 화면 — 감정 이모지 표시 + 위치/사진 버튼 제거
- 감정(HAPPY/SAD/SOSO) 선택 시 "오늘의 기분" 라벨 왼쪽에 선택된 이모지 표시
- `mood` 를 `null` 허용으로 바꾸고 `canSubmit` 에 `mood != null` 조건 추가 → 등록하려면 감정 선택 필수
- 미사용 "위치 추가" / "사진 추가" 버튼 및 관련 문자열 제거

### 2) 깊은 생각 작성 화면 — 카테고리 선택 바텀시트
- Figma 디자인대로 헤더(드래그핸들·뒤로가기·제목) + "새 카테고리 만들기" + 카테고리 리스트(컬러 닷 / 이름 / more)
- `CategorySettingBottomSheet` 에 `onCategoryClick` 콜백 추가 → 선택 시 카테고리 적용 후 시트 닫기
- 디자인 토큰(gray1/gray3/gray6) 정합

### 3) 마음의 기록 카드 — 더보기(...) 메뉴 + 삭제 동작 연결
- 공통 `RecordActionPopup` 컴포저블 신설 (흰 배경 / 8dp radius / hard shadow / width 120dp / "삭제하기"·"수정하기")
- 데일리 질문 / 일기 / 깊은 생각 3개 카드의 ... 버튼에 팝업 anchor 연결
- 삭제 동작은 각 `ListViewModel.delete(id)` → `Repository.delete` → 성공 시 refresh
- 수정(`onEdit`)은 후속 PR 에서 채울 빈 콜백으로 둠

### 4) 일기 리포트 카드 — 이번 달 / 주간 평균 기분 API 값 바인딩
- `/diary` 응답의 `monthDiaryCount`·`weeklyDominantMood` 를 DTO → Domain(`DiaryList`) → Repository → UiState → ViewModel → Card 까지 전 계층 전파
- 그리드 뷰의 `DiaryReportCard` 하드코딩값("18", 😊) 제거 → 실제 값 바인딩
- `GetHomeSummaryUseCase` 의 diary count 도 더 정확한 `monthDiaryCount` 로 보정

## Test plan
- [x] `:feature:mindrecord:presentation` · `:app` `compileDebugKotlin` 통과 (BUILD SUCCESSFUL 확인)
- [ ] 일기 작성 화면 — 감정 미선택 시 등록 버튼 비활성 / 선택 시 이모지 표시
- [ ] 깊은 생각 작성 화면 — 카테고리 행 탭 시 시트 오픈, 항목 탭 시 카테고리 적용 후 시트 닫힘
- [ ] 마음의 기록 4개 탭 — 카드 ... 탭 시 팝업 표시, "삭제하기" 시 항목 사라지고 새로고침
- [ ] 일기 그리드 뷰 — 이번 달 카운트와 주간 평균 기분 이모지가 API 값으로 표시

## Note
초기에 atomic 4개 PR(#371~#374)로 쪼개 올렸으나 단일 PR 요청에 따라 모두 닫고 본 PR로 통합 재구성. 4개 PR의 커밋 메시지 그대로 유지하므로 리뷰 시 커밋 단위로 추적 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)