### PR TITLE
chore: targetSdk 36으로 상향 (Android 16 동작 변경 옵트인) (closes 383)

### DIFF
--- a/build-logic/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -15,7 +15,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 configureAndroidCommon(this) // 기본 뼈대
                 configureCompose(this) // Compose 부품
 
-                defaultConfig.targetSdk = 34
+                defaultConfig.targetSdk = 36
             }
 
             afterNoteDependencies {


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #383 â chore: targetSdk 36으로 상향 (Android 16 동작 변경 옵트인)

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `build-logic/src/main/kotlin/AndroidApplicationConventionPlugin.kt` 의 `defaultConfig.targetSdk` 를 34 → 36 으로 상향 (6a76d1c2)
- compileSdk 는 이미 36 인데 targetSdk 만 34 라 Android 16(API 36) behavior changes 에 미옵트인이던 상태를 해소

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 빌드 설정(targetSdk) 단일 변경.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- behavior-changes 사전점검 결과 추가 수정 불필요(clean):
  - edge-to-edge 강제: `enableEdgeToEdge()` + 인셋 처리(`imePadding`/`statusBarsPadding`/`consumeWindowInsets`) 이미 대응
  - predictive back 강제: `onBackPressed` 오버라이드 0건, Compose `BackHandler` 1개로 호환
  - 대화면 orientation/resize 제한 무시: `screenOrientation`·`setRequestedOrientation`·`resizableActivity` 고정 0건
- Android 16(API 36)은 2025-06-10 stable, compileSdk 이미 36 이라 "Stable only" 기준 위배 없음
- 빌드 검증: `./gradlew :app:processDebugManifestForPackage` BUILD SUCCESSFUL, packaged manifest `targetSdkVersion="36"` 확인
