### PR TITLE
test: Konsist 도입 — domain 레이어 의존 방향 아키텍처 테스트 (closes 385)

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,6 +1,8 @@
 name: Unit Test
 
-# PR 대상 main/develop 일 때 모든 모듈의 JVM unit test (./gradlew testDebugUnitTest) 실행.
+# PR 대상 main/develop 일 때 JVM unit test 실행:
+#   - ./gradlew testDebugUnitTest : Android 모듈 debug unit test
+#   - :konsist:test : 순수 JVM 모듈(testDebugUnitTest 미보유)이라 별도 명시. 레이어 의존 아키텍처 가드.
 # lint.yml 과 setup 이 거의 동일하지만 분리 — lint 실패가 test 결과를 가리지 않도록 fail-fast 독립.
 
 on:
@@ -51,7 +53,7 @@ jobs:
           echo "$GOOGLE_SERVICES_JSON_B64" | base64 -d > app/google-services.json
 
       - name: Run unit tests
-        run: ./gradlew testDebugUnitTest --continue --parallel
+        run: ./gradlew testDebugUnitTest :konsist:test --continue --parallel
         env:
           KAKAO_NATIVE_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
           GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
@@ -65,4 +67,6 @@ jobs:
           path: |
             **/build/reports/tests/testDebugUnitTest
             **/build/test-results/testDebugUnitTest
+            **/build/reports/tests/test
+            **/build/test-results/test
           retention-days: 7

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ paging = "3.5.0"
 screenshot = "0.0.1-alpha15"
 googleServices = "4.4.4"
 firebaseAppDistribution = "5.2.1"
+konsist = "0.17.3"
 
 [libraries]
 androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "biometric" }
@@ -107,6 +108,7 @@ androidx-paging-common = { group = "androidx.paging", name = "paging-common", ve
 androidx-paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.ref = "paging" }
 androidx-paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging" }
 screenshot-validation-api = { group = "com.android.tools.screenshot", name = "screenshot-validation-api", version.ref = "screenshot" }
+konsist = { group = "com.lemonappdev", name = "konsist", version.ref = "konsist" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/konsist/build.gradle.kts
+++ b/konsist/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    id("java-library")
+    alias(libs.plugins.jetbrains.kotlin.jvm)
+}
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
+dependencies {
+    testImplementation(libs.konsist)
+    testImplementation(libs.junit)
+}

--- a/konsist/src/test/kotlin/com/afternote/konsist/LayerDependencyKonsistTest.kt
+++ b/konsist/src/test/kotlin/com/afternote/konsist/LayerDependencyKonsistTest.kt
@@ -1,0 +1,50 @@
+package com.afternote.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.withPackage
+import com.lemonappdev.konsist.api.verify.assertFalse
+import org.junit.Test
+
+/**
+ * 레이어 의존 방향 회귀 가드.
+ *
+ * `presentation(UI) → domain ← data` — UI·data 가 domain 에 의존하고, domain 은 다른 레이어나
+ * 비-`core:model` 코어에 **역의존하지 않는다**(의존 역전). Repository 추상을 domain 에 두는 구조를 보호한다.
+ *
+ * domain 패키지(`com.afternote..domain..`) 파일의 import 만 검사한다.
+ * - 허용: `core:model`(`com.afternote.core.model.*`), 같은 domain 레이어(`com.afternote..domain..`; cross-domain 포함)
+ * - 금지: data·presentation 레이어, 비-`core:model` 코어(network/ui/common/datastore/di/startup)
+ *
+ * 외부 빌드 그래프가 아니라 소스 import 를 스캔하므로, Gradle 사이클 탐지가 못 잡는
+ * `domain → core:network` 같은 위반까지 막는다.
+ */
+class LayerDependencyKonsistTest {
+    private fun domainFiles() = Konsist.scopeFromProject().files.withPackage("com.afternote..domain..")
+
+    @Test
+    fun `domain 은 data 와 presentation 레이어에 의존하지 않는다`() {
+        domainFiles().assertFalse { file ->
+            file.imports.any { import -> FORBIDDEN_LAYER_IMPORT.matches(import.name) }
+        }
+    }
+
+    @Test
+    fun `domain 은 core_model 과 같은 domain 레이어 외 afternote 모듈에 의존하지 않는다`() {
+        domainFiles().assertFalse { file ->
+            file.imports.any { import ->
+                import.name.startsWith(AFTERNOTE_PREFIX) && !ALLOWED_INTERNAL_IMPORT.matches(import.name)
+            }
+        }
+    }
+
+    private companion object {
+        const val AFTERNOTE_PREFIX = "com.afternote."
+
+        /** data / presentation 레이어 패키지. */
+        val FORBIDDEN_LAYER_IMPORT = Regex("""^com\.afternote\..*\.(data|presentation)\..*$""")
+
+        /** core:model 또는 같은 domain 레이어만 허용 (그 외 com.afternote.* 는 위반). */
+        val ALLOWED_INTERNAL_IMPORT =
+            Regex("""^com\.afternote\.core\.model\..*$|^com\.afternote\..*\.domain(\..*)?$""")
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -65,3 +65,6 @@ include(":feature:timeletter:data")
 include(":feature:timeletter:domain")
 include(":feature:timeletter:presentation")
 include(":feature:timeletter:res")
+
+// Architecture test module (Konsist) — 레이어 의존 방향 회귀 가드
+include(":konsist")


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

closed test: Konsist 도입 — domain 레이어 의존 방향(의존 역전) 아키텍처 테스트 추가 #385

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `:konsist` 순수 JVM 모듈(java-library + kotlin.jvm) 신설 — `Konsist.scopeFromProject()` 로 소스 import 를 스캔 (ad5af267)
- `LayerDependencyKonsistTest`: domain 패키지(`com.afternote..domain..`) 파일이 ① data/presentation 레이어 ② `core:model` 외 코어(network/ui/common 등)에 역의존하지 않음을 정규식 2종으로 강제
- 허용: `core:model`, 같은 domain 레이어(cross-domain 포함)
- `settings.gradle.kts` include + `libs.versions.toml` konsist 0.17.3 + CI `unit-test.yml` 에 `:konsist:test` 및 리포트 artifact 경로 추가

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 아키텍처 테스트 모듈 추가.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 현재 코드베이스 위반 0건 — 신규 위반을 막는 회귀 가드 목적
- 빌드 그래프(Gradle 사이클 탐지)가 아니라 소스 import 를 스캔하므로 `domain → core:network` 같은 위반까지 탐지
- 빌드 검증: `./gradlew :konsist:test --rerun-tasks` BUILD SUCCESSFUL (위반 0건). 순수 JVM 모듈이라 `compileDebugKotlin` 대신 `test` task
- CI: `unit-test.yml` 의 `testDebugUnitTest` 에 `:konsist:test` 병행 (순수 JVM 이라 `testDebugUnitTest` 미보유)