### PR TITLE
feat(onboarding): 환영 화면 시작하기 버튼을 로그인 화면으로 이동 (closes 381)

### DIFF
--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
@@ -40,7 +40,9 @@ fun NavGraphBuilder.onboardingNavGraph(
         // ── Welcome ──
         composable<OnboardingRoute.WelcomeRoute> {
             WelcomeScreen(
-                onStartClick = actions::navigateToSignUp,
+                // #381: "시작하기" 도 "로그인하기" 와 동일하게 로그인 화면으로 이동 (PM 요청).
+                // 신규 회원가입 진입은 로그인 화면 내 회원가입 링크(replaceLoginWithSignUp)로 유지.
+                onStartClick = actions::navigateToLogin,
                 onCheckRecordsClick = actions::navigateToReceivedRecords,
                 onLoginClick = actions::navigateToLogin,
             )


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closed #381

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 온보딩 환영 화면(WelcomeScreen)의 "시작하기" 버튼 이동 대상을 회원가입(SignUpRoute) → 로그인(LoginRoute)으로 변경 (PM 요청).
- 이제 "시작하기"와 "로그인하기" 두 버튼이 동일하게 LoginRoute 로 진입. 신규 회원가입은 로그인 화면 내 회원가입 링크(replaceLoginWithSignUp)로 유지되어 가입 경로는 막히지 않음.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- 네비게이션 목적지 변경만으로 화면 자체의 시각 변화 없음.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 변경 지점은 `OnboardingNavGraph.kt` 의 `onStartClick` 콜백 1줄 (`navigateToSignUp` → `navigateToLogin`).
- `navigateToLogin` 은 `onLoginClick` 이 이미 사용하던 액션이라 신규 네비게이션 경로 추가 없음.
- "시작하기" / "로그인하기" 두 버튼이 동일 목적지가 되는 UX 자체는 PM 확정 사항.