### PR TITLE
fix(afternote): 애프터노트 화면 설정 기어 아이콘 클릭 무반응 (closes 395)

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
@@ -429,6 +429,10 @@ fun rememberAfternoteNavActions(
                     launchSingleTop = true
                 }
             }
+
+            override fun navigateToSetting() {
+                appState.navController.navigate(Route.Setting)
+            }
         }
     }
 }

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/home/AfternoteHomeEntry.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/home/AfternoteHomeEntry.kt
@@ -19,6 +19,7 @@ data class AfternoteHomeEntryActions(
     val navigateToGalleryDetail: (String) -> Unit = {},
     val navigateToMemorialGuidelineDetail: (String) -> Unit = {},
     val navigateToAdd: (AfternoteCategory) -> Unit = {},
+    val onSettingClick: () -> Unit = {},
 )
 
 /**
@@ -63,5 +64,6 @@ fun AfternoteHomeEntry(
             }
         },
         onFabClick = { actions.navigateToAdd(selectedCategory) },
+        onSettingClick = actions.onSettingClick,
     )
 }

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/home/AfternoteHomeScreen.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/home/AfternoteHomeScreen.kt
@@ -39,6 +39,7 @@ fun AfternoteHomeScreen(
     modifier: Modifier = Modifier,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onFabClick: (() -> Unit)? = null,
+    onSettingClick: () -> Unit = {},
 ) {
     val refreshState = items.loadState.refresh
     val isInitialLoading = refreshState is LoadState.Loading && items.itemCount == 0
@@ -50,7 +51,7 @@ fun AfternoteHomeScreen(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             if (items.itemCount > 0) {
-                HomeTopBar()
+                HomeTopBar(onSettingClick = onSettingClick)
             } else {
                 DetailTopBar(title = "애프터노트")
             }

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/navigation/AfternoteNavActions.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/navigation/AfternoteNavActions.kt
@@ -46,4 +46,7 @@ interface AfternoteNavActions {
 
     /** Editor 저장 성공 → Afternote 홈 위 화면(에디터·미디어 등)만 pop. Home 자체는 유지. */
     fun popToAfternoteHome()
+
+    /** Afternote 홈 TopBar 설정 기어 → 설정 화면(Route.Setting) 진입. */
+    fun navigateToSetting()
 }

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/navigation/AfternoteNavGraph.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/navigation/AfternoteNavGraph.kt
@@ -40,6 +40,7 @@ fun NavGraphBuilder.afternoteNavGraph(
                 onNavigateToGalleryDetail = actions::navigateToGalleryDetail,
                 onNavigateToMemorialGuidelineDetail = actions::navigateToMemorialGuidelineDetail,
                 onNavigateToNewEditor = actions::navigateToNewEditor,
+                onNavigateToSetting = actions::navigateToSetting,
             )
         }
 

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/navigation/AfternoteNavGraphHome.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/navigation/AfternoteNavGraphHome.kt
@@ -11,6 +11,7 @@ internal fun AfternoteHomeNavigation(
     onNavigateToGalleryDetail: (itemId: String) -> Unit,
     onNavigateToMemorialGuidelineDetail: (itemId: String) -> Unit,
     onNavigateToNewEditor: (initialCategory: String?) -> Unit,
+    onNavigateToSetting: () -> Unit,
 ) {
     AfternoteHomeEntry(
         actions =
@@ -23,6 +24,7 @@ internal fun AfternoteHomeNavigation(
                         if (selectedTab == AfternoteCategory.ALL) null else selectedTab.navKey
                     onNavigateToNewEditor(initialCategory)
                 },
+                onSettingClick = onNavigateToSetting,
             ),
     )
 }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #395 — fix(afternote): 애프터노트 화면 설정 기어 아이콘 클릭 무반응

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- afternote 화면 우상단 설정 기어 `onClick`이 미연결(`HomeTopBar()` 호출 시 기본 빈 람다)이던 것을 설정 화면(`Route.Setting`)으로 연결
- 콜백 체인 추가: `AfternoteHomeScreen` ← `AfternoteHomeEntry`(`AfternoteHomeEntryActions.onSettingClick`) ← `AfternoteHomeNavigation`(`onNavigateToSetting`) ← `AfternoteNavGraph` ← `AppNavigationActions.navigateToSetting()`
- 홈(`HomeTabScreen`)의 기존 `onSettingClick` 패턴과 동일하게 구성

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 외형 변경 없음 — 기어 아이콘은 그대로이고 클릭 동작(설정 진입)만 연결. 에뮬레이터 QA에서 "홈 기어 정상 / afternote 기어 무반응" 대조 확인 후 수정.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 콜백을 5개 레이어로 전달하는 구조라 파일 6개를 건드렸지만 로직 추가는 없고 전달만 합니다.
- 에뮬레이터 실모드 QA 중 발견한 버그입니다.
- 빌드 검증: `./gradlew :app:compileDebugKotlin` → BUILD SUCCESSFUL
