### PR TITLE
chore(app): 디버그 빌드 런처 아이콘 중복 제거 (closes 396)

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -14,12 +14,12 @@
                 android:roundIcon="@mipmap/ic_launcher_dev"
                 android:taskAffinity=".devsettings"
                 android:excludeFromRecents="true"
-                android:theme="@style/Theme.Afternotefe.Main">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
+                android:theme="@style/Theme.Afternotefe.Main" />
+        <!--
+          LAUNCHER intent-filter를 의도적으로 두지 않습니다.
+          런처 아이콘 중복(.MainActivity와 2개) 방지 — 디버그 mock 설정 화면은
+          `adb shell am start -n com.afternote.afternote_fe/.debug.DebugMockSettingsActivity` 로 진입합니다. (#396)
+        -->
     </application>
 
 </manifest>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #396 — chore(app): 디버그 빌드 런처 아이콘 중복 제거 (DebugMockSettingsActivity LAUNCHER 제거)

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `app/src/debug/AndroidManifest.xml`의 `DebugMockSettingsActivity`에서 `MAIN` + `LAUNCHER` intent-filter 제거 → 디버그 빌드 런처 아이콘을 1개로
- `android:exported="true"`는 유지 → mock 설정 화면은 `adb shell am start -n com.afternote.afternote_fe/.debug.DebugMockSettingsActivity`로 진입
- 진입 방법 안내 주석 추가

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

디버그 빌드 한정 — 런처 앱 아이콘이 2개(`.MainActivity` + `DebugMockSettingsActivity`)에서 1개로 줄어듭니다. 릴리스 빌드는 영향 없음. (UI 화면 캡처 무관)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- debug 소스셋만 변경이라 릴리스 빌드에 영향 없습니다.
- mock 설정 화면은 이제 런처 아이콘이 아니라 `adb am start`로 진입합니다(주석 명시). 앱 아이콘 진입을 유지해야 한다면 알려주세요.
- 빌드 검증: `./gradlew :app:processDebugMainManifest` → BUILD SUCCESSFUL
