### PR TITLE
feat(receiver): 수신자 홈 한 마디 작성일(createdAt) 표시 매핑 재상정 (closes 209)

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeViewModel.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeViewModel.kt
@@ -92,6 +92,10 @@ class ReceiverHomeViewModel
                             senderMessage =
                                 senderMessageBody?.let {
                                     // orEmpty(): null 이면 "" — createdAt 미제공(구버전 서버) 시 날짜 슬롯만 비워 보이게.
+                                    // senderMessageInfo 에 ?. 가 없어도 안전: senderMessageBody(= info?.message?…) 가
+                                    // non-null 인 이 블록에선 안전 호출 체인의 대우로 info 도 non-null 이 보장되고,
+                                    // K2 가 이를 smart cast 한다 (Kotlin 2.0+ "Local variables and further scopes").
+                                    // ?. 를 붙이면 "여기서 null 일 수 있다" 는 거짓 신호가 되어 생략.
                                     SenderMessage(date = senderMessageInfo.createdAt.orEmpty(), body = it)
                                 },
                             mindRecord =

--- a/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeViewModel.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeViewModel.kt
@@ -89,8 +89,11 @@ class ReceiverHomeViewModel
                     _uiState.value =
                         ReceiverHomeUiState.Success(
                             senderName = senderName,
-                            // TODO: 백엔드 응답에 date 필드 추가되면 채울 것. 현재 receiver-auth/message 응답은 senderName/message 만.
-                            senderMessage = senderMessageBody?.let { SenderMessage(date = "", body = it) },
+                            senderMessage =
+                                senderMessageBody?.let {
+                                    // orEmpty(): null 이면 "" — createdAt 미제공(구버전 서버) 시 날짜 슬롯만 비워 보이게.
+                                    SenderMessage(date = senderMessageInfo.createdAt.orEmpty(), body = it)
+                                },
                             mindRecord =
                                 MindRecordSummary(
                                     totalCount = mindRecordsCount,

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/ReceiverAuthDto.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/ReceiverAuthDto.kt
@@ -1,5 +1,6 @@
 package com.afternote.feature.afternote.data.dto
 
+import com.afternote.feature.afternote.data.mapper.formatDateFromServer
 import com.afternote.feature.receiver.domain.model.DeliveryVerification
 import com.afternote.feature.receiver.domain.model.DeliveryVerificationStatus
 import com.afternote.feature.receiver.domain.model.ReceiverAuthPresignedUrl
@@ -53,7 +54,8 @@ data class DeliveryVerificationResponse(
 @Serializable
 data class ReceiverMessageResponse(
     @SerialName("senderName") val senderName: String,
-    @SerialName("message") val message: String,
+    @SerialName("message") val message: String? = null,
+    @SerialName("createdAt") val createdAt: String? = null,
 )
 
 fun ReceiverAuthVerifyResponse.toDomain(): ReceiverIdentity =
@@ -86,4 +88,5 @@ fun ReceiverMessageResponse.toDomain(): SenderMessageInfo =
     SenderMessageInfo(
         senderName = senderName,
         message = message,
+        createdAt = createdAt?.let(::formatDateFromServer),
     )

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverAuthDtoMapperTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverAuthDtoMapperTest.kt
@@ -2,19 +2,34 @@ package com.afternote.feature.afternote.data.dto
 
 import com.afternote.feature.receiver.domain.model.DeliveryVerificationStatus
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
  * `ReceiverAuthDto` 의 toDomain 확장 회귀 가드.
- * 단순 전달 매핑(SenderMessageInfo·ReceiverIdentity·ReceiverAuthPresignedUrl)과,
+ * 단순 전달 매핑(SenderMessageInfo·ReceiverIdentity·ReceiverAuthPresignedUrl)과
+ * SenderMessageInfo 의 createdAt 표시 형식 변환,
  * 핵심 로직인 [DeliveryVerificationStatus.fromRaw] 의 대소문자 무시 + UNKNOWN fallback 을 검증.
  */
 class ReceiverAuthDtoMapperTest {
     @Test
     fun `ReceiverMessageResponse toDomain - SenderMessageInfo 매핑`() {
-        val result = ReceiverMessageResponse(senderName = "홍길동", message = "보고싶다").toDomain()
+        val result =
+            ReceiverMessageResponse(
+                senderName = "홍길동",
+                message = "보고싶다",
+                createdAt = "2026-06-08T12:00:53",
+            ).toDomain()
         assertEquals("홍길동", result.senderName)
         assertEquals("보고싶다", result.message)
+        assertEquals("2026.06.08", result.createdAt)
+    }
+
+    @Test
+    fun `ReceiverMessageResponse toDomain - message·createdAt 미제공 시 null 유지`() {
+        val result = ReceiverMessageResponse(senderName = "홍길동").toDomain()
+        assertNull(result.message)
+        assertNull(result.createdAt)
     }
 
     @Test

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverMessageContractTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverMessageContractTest.kt
@@ -1,0 +1,48 @@
+package com.afternote.feature.afternote.data.dto
+
+import com.afternote.core.network.model.BaseResponse
+import com.afternote.core.network.model.requireData
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * `GET /receiver-auth/message` 실서버 응답 계약 회귀 가드 (#209).
+ *
+ * 페이로드는 2026-06-10 라이브 서버(`afternote.kro.kr`) 실응답 캡처 원문 — `createdAt` 은
+ * BE `LocalDateTime` 직렬화라 타임존 표기 없는 마이크로초 포함 형태로 온다 (BE 커밋 5af499c8).
+ * 프로덕션 경로(`ReceiverAuthRepositoryImpl.getSenderMessage`)와 동일하게
+ * Json 디코드 → `requireData()` → `toDomain()` 을 통과시킨다 — Json 설정은
+ * `NetworkModule.provideJson` 과 동일 (ignoreUnknownKeys + coerceInputValues).
+ */
+class ReceiverMessageContractTest {
+    private val json =
+        Json {
+            ignoreUnknownKeys = true
+            coerceInputValues = true
+        }
+
+    @Test
+    fun `라이브 서버 실응답 캡처 - 디코드부터 Hero 카드 date 값까지 도달`() {
+        val payload =
+            """{"status":200,"code":200,"message":"성공","data":{"senderName":"큐에이발신자","message":"실서버 통신 검증용 한 마디입니다. 잘 지내렴.","createdAt":"2026-06-10T15:27:14.141643"}}"""
+
+        val info = json.decodeFromString<BaseResponse<ReceiverMessageResponse>>(payload).requireData().toDomain()
+
+        assertEquals("큐에이발신자", info.senderName)
+        assertEquals("실서버 통신 검증용 한 마디입니다. 잘 지내렴.", info.message)
+        // ReceiverHomeViewModel 이 이 값을 그대로 SenderMessage.date 로 사용한다.
+        assertEquals("2026.06.10", info.createdAt)
+    }
+
+    @Test
+    fun `createdAt·message 없는 구버전 응답 - 디코드 깨지지 않고 null 유지`() {
+        val payload = """{"status":200,"code":200,"data":{"senderName":"김철수"}}"""
+
+        val info = json.decodeFromString<BaseResponse<ReceiverMessageResponse>>(payload).requireData().toDomain()
+
+        assertNull(info.message)
+        assertNull(info.createdAt)
+    }
+}

--- a/feature/receiver/domain/src/main/java/com/afternote/feature/receiver/domain/model/ReceiverAuthModels.kt
+++ b/feature/receiver/domain/src/main/java/com/afternote/feature/receiver/domain/model/ReceiverAuthModels.kt
@@ -20,6 +20,7 @@ data class DeliveryVerification(
     val deathCertificateUrl: String?,
     val familyRelationCertificateUrl: String?,
     val adminNote: String?,
+    // 서버 ISO-8601 raw 전달 — 표시 형식 변환은 presentation 책임. SenderMessageInfo.createdAt(표시형)과 규약이 다름에 주의.
     val createdAt: String?,
 )
 
@@ -35,7 +36,14 @@ enum class DeliveryVerificationStatus {
     }
 }
 
+/**
+ * 고인이 남긴 한 마디 (`receiver-auth/message`) 조회 결과.
+ *
+ * @property message 메시지 본문 — sender 미작성 시 null (서버 스키마 nullable).
+ * @property createdAt 작성일. 서버 ISO-8601 을 data 매퍼에서 `yyyy.MM.dd` 표시 형식으로 변환한 값, 서버 미제공 시 null.
+ */
 data class SenderMessageInfo(
     val senderName: String,
-    val message: String,
+    val message: String?,
+    val createdAt: String?,
 )


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #209 — chore(backend): /receiver-auth/message 응답에 작성일(createdAt) 필드 추가 요청

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- **PR #406 재상정** — #406 이 develop 재타겟 없이 base `feat/403`(#405 로 이미 develop 머지 완료)에 머지되어 develop 에 실반영되지 않았습니다 (`git cherry` 실측: 아래 3커밋 미반영). diff 는 #406 과 동일하며 코드 변경 없이 그대로 재상정합니다.
- `ReceiverMessageResponse` DTO 에 `createdAt` 추가, `message` nullable 화 + `toDomain()` 에서 `yyyy.MM.dd` 변환해 Hero 카드 `SenderMessage(date = ...)` 매핑 (b7e5e9ce)
- Receiver Message API 응답 계약 회귀 테스트 (46a64e0c)
- ReceiverHomeViewModel K2 smart cast 안전 근거 주석 (0ef9a20d — #406 리뷰 대응분)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경은 #406 과 동일 (Hero 카드 우상단 작성일 슬롯). 기존 `SenderMessageHeroCardScreenshotTest` 가 시각 커버, Compose Preview(`2026.04.04` 형식) 기준 검증 — 상세는 #406 참조.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 코드 리뷰는 #406 에서 완료된 동일 diff 의 재상정입니다 (base 오지정 사고 정정). 원 리뷰 스레드·검증 이력은 #406 참조.
- 빌드 검증: #406 시점 compile·test·ktlint·실서버 E2E 완료, diff 무변경이라 재검증 생략 — develop 과의 merge 정합은 본 PR CI 로 확인됩니다.
- 재발 방지 참고: stack PR 은 base PR 머지 시 **base 브랜치가 삭제된 경우에만** develop 으로 자동 재타겟됩니다. #405 머지 때 feat/403 이 남아 있어 자동 전환이 안 됐고, 그 상태로 머지되며 이번 사고가 났습니다.