### PR TITLE
fix(timeletter): 타임레터 삭제 메서드/deliveryMode 스웨거 명세 정합

### DIFF
--- a/feature/timeletter/data/src/debug/kotlin/com/afternote/feature/timeletter/data/network/TimeLetterDebugMockNetworkInterceptor.kt
+++ b/feature/timeletter/data/src/debug/kotlin/com/afternote/feature/timeletter/data/network/TimeLetterDebugMockNetworkInterceptor.kt
@@ -42,7 +42,7 @@ class TimeLetterDebugMockNetworkInterceptor
                         TimeLetterMockFixtures.MOCK_CREATE_JSON
                     }
 
-                    path == "/api/v1/time-letters/delete" && method == "POST" -> {
+                    path == "/api/v1/time-letters" && method == "DELETE" -> {
                         TimeLetterMockFixtures.MOCK_DELETE_JSON
                     }
 

--- a/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/api/TimeLetterApiService.kt
+++ b/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/api/TimeLetterApiService.kt
@@ -9,6 +9,7 @@ import com.afternote.feature.timeletter.data.dto.TimeLetterUpdateRequest
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.HTTP
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -41,8 +42,8 @@ interface TimeLetterApiService {
         @Body request: TimeLetterUpdateRequest,
     ): BaseResponse<TimeLetterResponseDto>
 
-    // 타임레터 단일/다건 삭제
-    @POST("time-letters/delete")
+    // 타임레터 단일/다건 삭제 (body 를 가진 DELETE)
+    @HTTP(method = "DELETE", path = "time-letters", hasBody = true)
     suspend fun deleteTimeLetters(
         @Body request: TimeLetterDeleteRequest,
     ): BaseResponse<Unit>

--- a/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/dto/TimeLetterDto.kt
+++ b/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/dto/TimeLetterDto.kt
@@ -16,6 +16,17 @@ enum class TimeLetterStatusDto {
 }
 
 @Serializable
+enum class TimeLetterDeliveryModeDto {
+    // 날짜 지정 발송
+    @SerialName("DATE")
+    DATE,
+
+    // 사후(死後) 전달
+    @SerialName("POST_DEATH")
+    POST_DEATH,
+}
+
+@Serializable
 enum class TimeLetterBlockTypeDto {
     @SerialName("TEXT")
     TEXT,
@@ -56,6 +67,7 @@ data class TimeLetterBlockResponseDto(
 data class TimeLetterCreateRequest(
     @SerialName("title") val title: String? = null,
     @SerialName("sendAt") val sendAt: String? = null,
+    @SerialName("deliveryMode") val deliveryMode: TimeLetterDeliveryModeDto? = null,
     @SerialName("status") val status: TimeLetterStatusDto,
     @SerialName("blocks") val blocks: List<TimeLetterBlockRequest> = emptyList(),
     @SerialName("receiverIds") val receiverIds: List<Long> = emptyList(),
@@ -65,6 +77,7 @@ data class TimeLetterCreateRequest(
 data class TimeLetterUpdateRequest(
     @SerialName("title") val title: String? = null,
     @SerialName("sendAt") val sendAt: String? = null,
+    @SerialName("deliveryMode") val deliveryMode: TimeLetterDeliveryModeDto? = null,
     @SerialName("status") val status: TimeLetterStatusDto? = null,
     @SerialName("blocks") val blocks: List<TimeLetterBlockRequest> = emptyList(),
 )

--- a/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/mapper/TimeLetterMapper.kt
+++ b/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/mapper/TimeLetterMapper.kt
@@ -3,6 +3,7 @@ package com.afternote.feature.timeletter.data.mapper
 import com.afternote.feature.timeletter.data.dto.TimeLetterBlockRequest
 import com.afternote.feature.timeletter.data.dto.TimeLetterBlockResponseDto
 import com.afternote.feature.timeletter.data.dto.TimeLetterBlockTypeDto
+import com.afternote.feature.timeletter.data.dto.TimeLetterDeliveryModeDto
 import com.afternote.feature.timeletter.data.dto.TimeLetterListResponseDto
 import com.afternote.feature.timeletter.data.dto.TimeLetterResponseDto
 import com.afternote.feature.timeletter.data.dto.TimeLetterStatusDto
@@ -10,6 +11,7 @@ import com.afternote.feature.timeletter.domain.model.NewTimeLetterBlock
 import com.afternote.feature.timeletter.domain.model.TimeLetter
 import com.afternote.feature.timeletter.domain.model.TimeLetterBlock
 import com.afternote.feature.timeletter.domain.model.TimeLetterBlockType
+import com.afternote.feature.timeletter.domain.model.TimeLetterDeliveryMode
 import com.afternote.feature.timeletter.domain.model.TimeLetterList
 import com.afternote.feature.timeletter.domain.model.TimeLetterStatus
 
@@ -25,6 +27,12 @@ fun TimeLetterStatus.toDto(): TimeLetterStatusDto =
         TimeLetterStatus.DRAFT -> TimeLetterStatusDto.DRAFT
         TimeLetterStatus.SCHEDULED -> TimeLetterStatusDto.SCHEDULED
         TimeLetterStatus.SENT -> TimeLetterStatusDto.SENT
+    }
+
+fun TimeLetterDeliveryMode.toDto(): TimeLetterDeliveryModeDto =
+    when (this) {
+        TimeLetterDeliveryMode.DATE -> TimeLetterDeliveryModeDto.DATE
+        TimeLetterDeliveryMode.POST_DEATH -> TimeLetterDeliveryModeDto.POST_DEATH
     }
 
 fun TimeLetterBlockTypeDto.toDomain(): TimeLetterBlockType =

--- a/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/repositoryImpl/TimeLetterRepositoryImpl.kt
+++ b/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/repositoryImpl/TimeLetterRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.afternote.feature.timeletter.data.mapper.toDomain
 import com.afternote.feature.timeletter.data.mapper.toDto
 import com.afternote.feature.timeletter.domain.model.NewTimeLetterBlock
 import com.afternote.feature.timeletter.domain.model.TimeLetter
+import com.afternote.feature.timeletter.domain.model.TimeLetterDeliveryMode
 import com.afternote.feature.timeletter.domain.model.TimeLetterList
 import com.afternote.feature.timeletter.domain.model.TimeLetterStatus
 import com.afternote.feature.timeletter.domain.repository.TimeLetterRepository
@@ -44,12 +45,14 @@ class TimeLetterRepositoryImpl
             sendAt: String?,
             status: TimeLetterStatus,
             receiverIds: List<Long>?,
+            deliveryMode: TimeLetterDeliveryMode?,
         ): TimeLetter =
             timeLetterApiService
                 .createTimeLetter(
                     TimeLetterCreateRequest(
                         title = title,
                         sendAt = sendAt,
+                        deliveryMode = deliveryMode?.toDto(),
                         status = status.toDto(),
                         blocks = blocks.map { it.toDto() },
                         receiverIds = receiverIds ?: emptyList(),
@@ -63,6 +66,7 @@ class TimeLetterRepositoryImpl
             blocks: List<NewTimeLetterBlock>,
             sendAt: String?,
             status: TimeLetterStatus?,
+            deliveryMode: TimeLetterDeliveryMode?,
         ): TimeLetter =
             timeLetterApiService
                 .updateTimeLetter(
@@ -71,6 +75,7 @@ class TimeLetterRepositoryImpl
                         TimeLetterUpdateRequest(
                             title = title,
                             sendAt = sendAt,
+                            deliveryMode = deliveryMode?.toDto(),
                             status = status?.toDto(),
                             blocks = blocks.map { it.toDto() },
                         ),

--- a/feature/timeletter/domain/src/main/kotlin/com/afternote/feature/timeletter/domain/model/TimeLetterModel.kt
+++ b/feature/timeletter/domain/src/main/kotlin/com/afternote/feature/timeletter/domain/model/TimeLetterModel.kt
@@ -48,3 +48,11 @@ enum class TimeLetterBlockType {
     FILE,
     LINK,
 }
+
+enum class TimeLetterDeliveryMode {
+    // 날짜 지정 발송
+    DATE,
+
+    // 사후(死後) 전달
+    POST_DEATH,
+}

--- a/feature/timeletter/domain/src/main/kotlin/com/afternote/feature/timeletter/domain/repository/TimeLetterRepository.kt
+++ b/feature/timeletter/domain/src/main/kotlin/com/afternote/feature/timeletter/domain/repository/TimeLetterRepository.kt
@@ -2,6 +2,7 @@ package com.afternote.feature.timeletter.domain.repository
 
 import com.afternote.feature.timeletter.domain.model.NewTimeLetterBlock
 import com.afternote.feature.timeletter.domain.model.TimeLetter
+import com.afternote.feature.timeletter.domain.model.TimeLetterDeliveryMode
 import com.afternote.feature.timeletter.domain.model.TimeLetterList
 import com.afternote.feature.timeletter.domain.model.TimeLetterStatus
 
@@ -18,6 +19,7 @@ interface TimeLetterRepository {
         sendAt: String?,
         status: TimeLetterStatus,
         receiverIds: List<Long>?,
+        deliveryMode: TimeLetterDeliveryMode? = null,
     ): TimeLetter
 
     suspend fun updateTimeLetter(
@@ -26,6 +28,7 @@ interface TimeLetterRepository {
         blocks: List<NewTimeLetterBlock>,
         sendAt: String?,
         status: TimeLetterStatus?,
+        deliveryMode: TimeLetterDeliveryMode? = null,
     ): TimeLetter
 
     suspend fun deleteTimeLetters(timeLetterIds: List<Long>)


### PR DESCRIPTION
Closes #422

## 변경
- 삭제: `POST /time-letters/delete` → **`DELETE /time-letters`** (body 유지, `@HTTP(hasBody=true)`), debug mock interceptor 동기화
- `deliveryMode`(DATE/POST_DEATH) enum + 요청 필드 추가 및 도메인/repository/mapper 배선

## 검증
- `compileDebugKotlin` / `compileDebugUnitTestKotlin` 통과

## 후속(범위 밖)
- 작성 화면 DATE/POST_DEATH 선택 UI 배선

🤖 Generated with [Claude Code](https://claude.com/claude-code)