### PR TITLE
feat(core): auth/user/app 신규 엔드포인트 스웨거 명세 반영

### DIFF
--- a/core/network/src/main/kotlin/com/afternote/core/network/dto/AppVersionDto.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/dto/AppVersionDto.kt
@@ -1,0 +1,12 @@
+package com.afternote.core.network.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// GET /api/v1/app/version — 앱 버전 확인(강제 업데이트 여부)
+@Serializable
+data class AppVersionCheckResponseDto(
+    @SerialName("updateRequired") val updateRequired: Boolean = false,
+    @SerialName("latestVersionCode") val latestVersionCode: Int = 0,
+    @SerialName("storeUrl") val storeUrl: String? = null,
+)

--- a/core/network/src/main/kotlin/com/afternote/core/network/dto/AuthDto.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/dto/AuthDto.kt
@@ -93,3 +93,31 @@ data class PasswordChangeRequest(
     val currentPassword: String,
     val newPassword: String,
 )
+
+// 아이디/비밀번호 찾기 인증번호 발송 (POST /auth/find/send/code)
+@Serializable
+data class FindSendCodeRequest(
+    val email: String,
+)
+
+// 아이디(이메일) 찾기 (POST /auth/email/find)
+@Serializable
+data class EmailFindRequest(
+    val email: String,
+    @SerialName("certificateCode") val certificateCode: String,
+)
+
+@Serializable
+data class EmailFindData(
+    val name: String,
+    val email: String,
+)
+
+// 비밀번호 찾기/재설정 (POST /auth/password/find)
+@Serializable
+data class PasswordFindRequest(
+    val email: String,
+    @SerialName("certificateCode") val certificateCode: String,
+    val newPassword: String,
+    val confirmPassword: String,
+)

--- a/core/network/src/main/kotlin/com/afternote/core/network/dto/ReceiverDeliveryConditionDto.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/dto/ReceiverDeliveryConditionDto.kt
@@ -1,0 +1,99 @@
+package com.afternote.core.network.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * 사후 전달(사후 관리) — 수신자 × 콘텐츠 단위 전달 조건.
+ *
+ * 스웨거:
+ * - GET  /api/v1/users/me/receivers/{receiverId}/delivery-conditions
+ * - PUT  /api/v1/users/me/receivers/{receiverId}/delivery-conditions
+ *
+ * 구 `users/delivery-condition`(유저 단위, 단일 조건)을 대체한다.
+ */
+
+@Serializable
+enum class DeliveryContentTypeDto {
+    @SerialName("TIME_LETTER")
+    TIME_LETTER,
+
+    @SerialName("AFTERNOTE")
+    AFTERNOTE,
+
+    @SerialName("DAILY_QUESTION")
+    DAILY_QUESTION,
+
+    @SerialName("DIARY")
+    DIARY,
+
+    @SerialName("DEEP_THOUGHT")
+    DEEP_THOUGHT,
+}
+
+@Serializable
+enum class DeliveryConditionTriggerDto {
+    // 미사용 자동 전달
+    @SerialName("INACTIVITY")
+    INACTIVITY,
+
+    // 수신자 요청(서류 승인)
+    @SerialName("RECEIVER_REQUEST")
+    RECEIVER_REQUEST,
+}
+
+@Serializable
+enum class InactivityPeriodDto {
+    @SerialName("THREE_MONTHS")
+    THREE_MONTHS,
+
+    @SerialName("SIX_MONTHS")
+    SIX_MONTHS,
+
+    @SerialName("ONE_YEAR")
+    ONE_YEAR,
+}
+
+@Serializable
+enum class DeliveryConditionStateDto {
+    @SerialName("ACTIVE")
+    ACTIVE,
+
+    @SerialName("PENDING_CONFIRMATION")
+    PENDING_CONFIRMATION,
+
+    @SerialName("WAITING_VERIFICATION")
+    WAITING_VERIFICATION,
+
+    @SerialName("FULFILLED")
+    FULFILLED,
+}
+
+@Serializable
+data class DeliveryConditionItemRequest(
+    @SerialName("contentType") val contentType: DeliveryContentTypeDto,
+    @SerialName("conditionType") val conditionType: DeliveryConditionTriggerDto,
+    @SerialName("inactivityPeriod") val inactivityPeriod: InactivityPeriodDto? = null,
+)
+
+@Serializable
+data class ReceiverDeliveryConditionUpdateRequest(
+    @SerialName("conditions") val conditions: List<DeliveryConditionItemRequest> = emptyList(),
+)
+
+@Serializable
+data class DeliveryConditionItemResponseDto(
+    @SerialName("contentType") val contentType: DeliveryContentTypeDto,
+    @SerialName("conditionType") val conditionType: DeliveryConditionTriggerDto,
+    @SerialName("inactivityPeriod") val inactivityPeriod: InactivityPeriodDto? = null,
+    @SerialName("state") val state: DeliveryConditionStateDto? = null,
+    @SerialName("fulfilled") val fulfilled: Boolean = false,
+    @SerialName("gracePeriodStartedAt") val gracePeriodStartedAt: String? = null,
+    @SerialName("fulfilledAt") val fulfilledAt: String? = null,
+)
+
+@Serializable
+data class ReceiverDeliveryConditionResponseDto(
+    @SerialName("receiverId") val receiverId: Long,
+    @SerialName("conditions") val conditions: List<DeliveryConditionItemResponseDto> = emptyList(),
+)

--- a/core/network/src/main/kotlin/com/afternote/core/network/service/AccountApiService.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/service/AccountApiService.kt
@@ -1,6 +1,10 @@
 package com.afternote.core.network.service
 
+import com.afternote.core.network.dto.EmailFindData
+import com.afternote.core.network.dto.EmailFindRequest
+import com.afternote.core.network.dto.FindSendCodeRequest
 import com.afternote.core.network.dto.PasswordChangeRequest
+import com.afternote.core.network.dto.PasswordFindRequest
 import com.afternote.core.network.dto.SendEmailCodeRequest
 import com.afternote.core.network.dto.SignUpData
 import com.afternote.core.network.dto.SignUpRequest
@@ -28,5 +32,23 @@ interface AccountApiService {
     @POST("auth/password/change")
     suspend fun passwordChange(
         @Body body: PasswordChangeRequest,
+    ): BaseResponse<Unit>
+
+    // 아이디/비밀번호 찾기 인증번호 발송
+    @POST("auth/find/send/code")
+    suspend fun sendFindCode(
+        @Body body: FindSendCodeRequest,
+    ): BaseResponse<Unit>
+
+    // 아이디(이메일) 찾기
+    @POST("auth/email/find")
+    suspend fun findEmail(
+        @Body body: EmailFindRequest,
+    ): BaseResponse<EmailFindData>
+
+    // 비밀번호 찾기/재설정
+    @POST("auth/password/find")
+    suspend fun findPassword(
+        @Body body: PasswordFindRequest,
     ): BaseResponse<Unit>
 }

--- a/core/network/src/main/kotlin/com/afternote/core/network/service/AppVersionApiService.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/service/AppVersionApiService.kt
@@ -1,0 +1,18 @@
+package com.afternote.core.network.service
+
+import com.afternote.core.network.dto.AppVersionCheckResponseDto
+import com.afternote.core.network.model.BaseResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+/**
+ * 앱 버전 확인 API.
+ * GET /api/v1/app/version — 현재 설치 버전과 서버 최신 버전을 비교해 강제 업데이트 필요 여부를 반환한다.
+ */
+interface AppVersionApiService {
+    @GET("app/version")
+    suspend fun checkVersion(
+        @Query("platform") platform: String,
+        @Query("versionCode") versionCode: Int,
+    ): BaseResponse<AppVersionCheckResponseDto>
+}

--- a/core/network/src/main/kotlin/com/afternote/core/network/service/UserApiService.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/service/UserApiService.kt
@@ -2,6 +2,8 @@ package com.afternote.core.network.service
 
 import com.afternote.core.network.dto.DeliveryConditionRequest
 import com.afternote.core.network.dto.DeliveryConditionResponseDto
+import com.afternote.core.network.dto.ReceiverDeliveryConditionResponseDto
+import com.afternote.core.network.dto.ReceiverDeliveryConditionUpdateRequest
 import com.afternote.core.network.dto.ReceiverDetailResponseDto
 import com.afternote.core.network.dto.ReceiverListResponseDto
 import com.afternote.core.network.dto.SocialAccountLinkRequest
@@ -22,6 +24,7 @@ import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.PUT
 
 interface UserApiService {
     // 수신자 목록 조회
@@ -95,6 +98,8 @@ interface UserApiService {
         @Path("provider") provider: String,
     ): BaseResponse<UserConnectedAccountResponseDto>
 
+    // [DEPRECATED] 유저 단위 전달 조건 — 스웨거에서 제거됨. 수신자별 delivery-conditions 로 대체 예정.
+    // 사후 관리 재설계(수신자 × 콘텐츠) 마이그레이션 시 이 두 메서드와 관련 화면을 함께 정리해야 한다.
     // 전달 조건 조회
     @GET("users/delivery-condition")
     suspend fun getDeliveryCondition(): BaseResponse<DeliveryConditionResponseDto>
@@ -104,4 +109,21 @@ interface UserApiService {
     suspend fun updateDeliveryCondition(
         @Body request: DeliveryConditionRequest,
     ): BaseResponse<DeliveryConditionResponseDto>
+
+    // 활동 기록(ping) — 앱 실행 시 호출해 미사용 타이머 리셋
+    @POST("users/me/activity")
+    suspend fun recordActivity(): BaseResponse<Unit>
+
+    // 수신자별 전달 조건 조회 (사후 관리)
+    @GET("users/me/receivers/{receiverId}/delivery-conditions")
+    suspend fun getReceiverDeliveryConditions(
+        @Path("receiverId") receiverId: Long,
+    ): BaseResponse<ReceiverDeliveryConditionResponseDto>
+
+    // 수신자별 전달 조건 설정/변경 (사후 관리)
+    @PUT("users/me/receivers/{receiverId}/delivery-conditions")
+    suspend fun updateReceiverDeliveryConditions(
+        @Path("receiverId") receiverId: Long,
+        @Body request: ReceiverDeliveryConditionUpdateRequest,
+    ): BaseResponse<ReceiverDeliveryConditionResponseDto>
 }

--- a/docs/api-notion-vs-swagger.md
+++ b/docs/api-notion-vs-swagger.md
@@ -1,0 +1,57 @@
+# API 명세 정합성 정리 — Notion ↔ Swagger ↔ 코드
+
+- **기준(소스 오브 트루스): Swagger** `https://afternote.kro.kr/v3/api-docs` (AfterNote API 명세서 1.0.0, 64 endpoints)
+- **Notion**: `API 기본 명세서` 허브 문서 (S3 가이드 / 공통 오류 응답 / 명세서 템플릿 / ERD / 사후 관리)
+- 작성일: 2026-07-08
+
+---
+
+## 1. Notion ↔ Swagger 불일치 (Notion 문서가 낡음)
+
+### 1-1. S3 Presigned URL 가이드
+| 항목 | Notion 가이드 | Swagger (실제) | 판정 |
+|---|---|---|---|
+| 엔드포인트 | `POST /images/presigned-url` | `POST /api/v1/files/presigned-url` | ❌ 경로 다름 (이미지 전용 → 파일 범용으로 일반화) |
+| 응답 이미지 필드 | `imageUrl` | `fileUrl` (+ `fileKey` 추가) | ❌ 필드명 다름 |
+| directory 허용값 | profiles, timeletters, afternotes, mindrecords | + `documents` 추가 | ⚠️ Swagger가 더 많음 |
+| extension 허용값 | jpg, jpeg, png, gif, webp | + heic, mp4, mov, mp3, m4a, wav, pdf | ⚠️ Swagger가 더 많음(영상/음성/문서) |
+| 요청 바디 | `{directory, extension}` | `{directory, extension}` | ✅ 일치 |
+
+### 1-2. 마음의 기록 작성
+| 항목 | Notion 가이드 | Swagger (실제) |
+|---|---|---|
+| 엔드포인트 | 통합 `POST /mind-records` | ❌ 없음. 타입별 분리: `POST /diary`, `POST /deep-thought`, `POST /daily-questions` |
+| 요청 필드 | `{type, title, content, date, isDraft, imageList:[{imageUrl}]}` (최대 10장) | 타입별 상이. **이미지 첨부 필드가 아예 없음** (diary/deep-thought/daily-question 요청에 image 없음) |
+
+> Notion의 통합 `/mind-records` + `imageList` 예시는 실제 스웨거와 맞지 않음. 마음의 기록 작성은 이미지 미지원(스웨거 기준).
+
+### 1-3. 에러 응답 봉투
+| 항목 | Notion | Swagger / 코드 | 판정 |
+|---|---|---|---|
+| 「공통 오류 응답」 봉투 | `{status, code, message, data}` | `{status, code, message, data}` | ✅ 일치 (코드 `BaseResponse<T>`도 동일) |
+| 「명세서 템플릿」 봉투 | `{isSuccess, code, message, timestamp, result}` (code 1000/4000) | 미사용 | ❌ 옛 양식 (템플릿 문서만의 잔재) |
+| 도메인별 에러코드(1000~2000번대) | 상세 표 존재 | Swagger엔 개별 코드 미문서화 | ⚠️ 런타임 확인 필요 |
+| S3 에러코드 493/494/495 | 존재 | Swagger 미문서화 | ⚠️ |
+
+---
+
+## 2. Notion 「사후 관리」 ↔ Swagger — **거의 일치** (이름차이만)
+
+Notion 사후관리 설계 문서는 스웨거에 정확히 반영돼 있음.
+
+| Notion | Swagger | 판정 |
+|---|---|---|
+| 신규 GET `/users/me/receivers/{receiverId}/delivery-conditions` | ✅ 존재 | 일치 |
+| 신규 PUT 동일 경로 | ✅ 존재 | 일치 |
+| 신규 POST `/users/me/activity` (활동 ping) | ✅ 존재 | 일치 |
+| 변경 POST/PATCH `/time-letters` + `deliveryMode`(DATE/POST_DEATH) | ✅ 존재 | 일치 |
+| "응답엔 deliveryMode 미포함" | ✅ TimeLetterResponse에 deliveryMode 없음 | 일치 |
+| 제거 GET/PATCH `/users/delivery-condition` | ✅ 스웨거에 없음(제거됨) | 일치 |
+| enum: DeliveryContentType / DeliveryConditionType / InactivityPeriod / **ConditionState** | contentType / conditionType / inactivityPeriod / **state** | ⚠️ 이름차이(값은 동일) |
+
+- contentType: `TIME_LETTER, AFTERNOTE, DAILY_QUESTION, DIARY, DEEP_THOUGHT` ✅
+- conditionType: `INACTIVITY, RECEIVER_REQUEST` ✅
+- inactivityPeriod: `THREE_MONTHS, SIX_MONTHS, ONE_YEAR` ✅
+- state: `ACTIVE, PENDING_CONFIRMATION, WAITING_VERIFICATION, FULFILLED` ✅
+
+---


### PR DESCRIPTION
Closes #423

## 추가 엔드포인트 (network 계층)
- `POST /users/me/activity` (활동 ping)
- `GET/PUT /users/me/receivers/{receiverId}/delivery-conditions` (+ enum 4종)
- `POST /auth/email/find`, `/auth/find/send/code`, `/auth/password/find`
- `GET /app/version`

## 문서
- `docs/api-notion-vs-swagger.md` — Notion↔Swagger↔코드 정합성 정리

## 검증
- `compileDebugKotlin` / `compileDebugUnitTestKotlin` 통과

## 후속(범위 밖)
- 구 `users/delivery-condition` 화면 → 수신자별 조건 마이그레이션 (런타임 404)
- 신규 엔드포인트 usecase/UI 배선

🤖 Generated with [Claude Code](https://claude.com/claude-code)