### PR TITLE
feat(mindrecord): 마음의 기록 신규 디자인 및 API 스웨거 명세 정합

### DIFF
--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/api/DailyQuestionApiService.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/api/DailyQuestionApiService.kt
@@ -17,6 +17,7 @@ interface DailyQuestionApiService {
     @GET("daily-questions")
     suspend fun getDailyQuestions(
         @Query("date") date: String? = null,
+        @Query("draftOnly") draftOnly: Boolean? = null,
     ): BaseResponse<List<DailyQuestionListItem>>
 
     @GET("daily-questions/today")

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/api/DeepThoughtApiService.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/api/DeepThoughtApiService.kt
@@ -2,7 +2,7 @@ package com.afternote.feature.mindrecord.data.api
 
 import com.afternote.core.network.model.BaseResponse
 import com.afternote.feature.mindrecord.data.dto.DeepThoughtCategoryCreateRequest
-import com.afternote.feature.mindrecord.data.dto.DeepThoughtCategoryItem
+import com.afternote.feature.mindrecord.data.dto.DeepThoughtCategoryListResponse
 import com.afternote.feature.mindrecord.data.dto.DeepThoughtCategoryMutationResponse
 import com.afternote.feature.mindrecord.data.dto.DeepThoughtCategoryUpdateRequest
 import com.afternote.feature.mindrecord.data.dto.DeepThoughtCreateRequest
@@ -23,6 +23,7 @@ interface DeepThoughtApiService {
         @Query("date") date: String? = null,
         @Query("tag") tag: String? = null,
         @Query("category") category: String? = null,
+        @Query("draftOnly") draftOnly: Boolean? = null,
     ): BaseResponse<DeepThoughtListResponse>
 
     @GET("deep-thought/random")
@@ -45,7 +46,7 @@ interface DeepThoughtApiService {
     ): BaseResponse<Unit>
 
     @GET("deep-thought/categories")
-    suspend fun getDeepThoughtCategories(): BaseResponse<List<DeepThoughtCategoryItem>>
+    suspend fun getDeepThoughtCategories(): BaseResponse<DeepThoughtCategoryListResponse>
 
     @POST("deep-thought/categories")
     suspend fun createDeepThoughtCategory(

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DailyQuestionDto.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DailyQuestionDto.kt
@@ -1,7 +1,15 @@
 package com.afternote.feature.mindrecord.data.dto
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
+
+@Serializable
+data class MindRecordReceiverDto(
+    @SerialName("receiverId") val receiverId: Long,
+    @SerialName("name") val name: String,
+)
 
 @Serializable
 data class DailyQuestionCreateRequest(
@@ -9,6 +17,7 @@ data class DailyQuestionCreateRequest(
     @SerialName("isDraft") val isDraft: Boolean,
     @SerialName("questionId") val questionId: Long,
     @SerialName("imageUrl") val imageUrl: String? = null,
+    @SerialName("receiverIds") val receiverIds: List<Long> = emptyList(),
 )
 
 @Serializable
@@ -20,21 +29,31 @@ data class DailyQuestionUpdateRequest(
     @SerialName("imageUrl") val imageUrl: String? = null,
 )
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class DailyQuestionListItem(
     // 서버는 사용자별 답변 레코드 ID 를 `userDailyQuestionId` 로 내려준다.
     // 도메인에서는 그대로 `dailyQuestionId` 로 받지만 와이어 키는 다름에 주의.
-    @SerialName("userDailyQuestionId") val dailyQuestionId: Long,
+    // 명세서 예시는 `dailyQuestionId` 키를 쓰므로 두 키 모두 허용.
+    @SerialName("userDailyQuestionId")
+    @JsonNames("dailyQuestionId")
+    val dailyQuestionId: Long,
     @SerialName("title") val title: String,
     @SerialName("content") val content: String,
     @SerialName("createdAt") val createdAt: String,
     @SerialName("imageUrl") val imageUrl: String? = null,
+    @SerialName("receivers") val receivers: List<MindRecordReceiverDto> = emptyList(),
 )
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class TodayDailyQuestionResponse(
     @SerialName("questionId") val questionId: Long,
-    @SerialName("day") val day: Int,
+    // 명세서 응답 예시에는 없는 필드 — 서버가 생략해도 디코딩되도록 기본값 유지.
+    @SerialName("day") val day: Int = 0,
     @SerialName("content") val content: String,
-    @SerialName("answered") val isAnswered: Boolean,
+    // 명세서 예시 키는 `isAnswered`, 실서버는 `answered` — 두 키 모두 허용.
+    @SerialName("answered")
+    @JsonNames("isAnswered")
+    val isAnswered: Boolean,
 )

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DailyQuestionDto.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DailyQuestionDto.kt
@@ -16,7 +16,6 @@ data class DailyQuestionCreateRequest(
     @SerialName("content") val content: String,
     @SerialName("isDraft") val isDraft: Boolean,
     @SerialName("questionId") val questionId: Long,
-    @SerialName("imageUrl") val imageUrl: String? = null,
     @SerialName("receiverIds") val receiverIds: List<Long> = emptyList(),
 )
 
@@ -24,9 +23,7 @@ data class DailyQuestionCreateRequest(
 data class DailyQuestionUpdateRequest(
     @SerialName("content") val content: String? = null,
     @SerialName("isDraft") val isDraft: Boolean? = null,
-    @SerialName("date") val date: String? = null,
-    @SerialName("questionId") val questionId: Long? = null,
-    @SerialName("imageUrl") val imageUrl: String? = null,
+    @SerialName("receiverIds") val receiverIds: List<Long> = emptyList(),
 )
 
 @OptIn(ExperimentalSerializationApi::class)

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DeepThoughtDto.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DeepThoughtDto.kt
@@ -9,8 +9,8 @@ data class DeepThoughtCreateRequest(
     @SerialName("content") val content: String,
     @SerialName("isDraft") val isDraft: Boolean,
     @SerialName("category") val category: String,
-    @SerialName("tag") val tag: List<String>? = null,
-    @SerialName("imageUrl") val imageUrl: String? = null,
+    @SerialName("tags") val tags: List<String>? = null,
+    @SerialName("receiverIds") val receiverIds: List<Long> = emptyList(),
 )
 
 @Serializable
@@ -19,8 +19,8 @@ data class DeepThoughtUpdateRequest(
     @SerialName("content") val content: String? = null,
     @SerialName("isDraft") val isDraft: Boolean? = null,
     @SerialName("category") val category: String? = null,
-    @SerialName("tag") val tag: List<String>? = null,
-    @SerialName("imageUrl") val imageUrl: String? = null,
+    @SerialName("tags") val tags: List<String>? = null,
+    @SerialName("receiverIds") val receiverIds: List<Long> = emptyList(),
 )
 
 @Serializable
@@ -60,15 +60,20 @@ data class DeepThoughtCategoryItem(
     @SerialName("title") val title: String,
 )
 
+// 서버 응답 `data` 는 배열이 아니라 `{ "categories": [...] }` 객체로 감싸져 있음.
+@Serializable
+data class DeepThoughtCategoryListResponse(
+    @SerialName("categories") val categories: List<DeepThoughtCategoryItem> = emptyList(),
+)
+
 @Serializable
 data class DeepThoughtCategoryCreateRequest(
-    @SerialName("deepThoughtId") val deepThoughtId: Long? = null,
-    @SerialName("category") val category: String,
+    @SerialName("title") val title: String,
 )
 
 @Serializable
 data class DeepThoughtCategoryUpdateRequest(
-    @SerialName("category") val category: String,
+    @SerialName("title") val title: String,
 )
 
 @Serializable

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DiaryDto.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DiaryDto.kt
@@ -1,7 +1,9 @@
 package com.afternote.feature.mindrecord.data.dto
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 
 @Serializable
 enum class TodayMood {
@@ -22,6 +24,7 @@ data class DiaryCreateRequest(
     @SerialName("isDraft") val isDraft: Boolean,
     @SerialName("todayMood") val todayMood: TodayMood,
     @SerialName("imageUrl") val imageUrl: String? = null,
+    @SerialName("receiverIds") val receiverIds: List<Long> = emptyList(),
 )
 
 @Serializable
@@ -34,21 +37,29 @@ data class DiaryUpdateRequest(
     @SerialName("imageUrl") val imageUrl: String? = null,
 )
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class DiaryListItem(
-    @SerialName("diaryId") val diaryId: Long,
+    // 명세서 예시 키는 `id` — 기존 서버 키 `diaryId` 와 함께 허용.
+    @SerialName("diaryId")
+    @JsonNames("id")
+    val diaryId: Long,
     @SerialName("title") val title: String,
     @SerialName("content") val content: String,
+    // 작성일 (`yyyy-MM-dd`). createdAt 은 생성 시각 타임스탬프.
+    @SerialName("date") val date: String? = null,
     @SerialName("createdAt") val createdAt: String,
+    @SerialName("isDraft") val isDraft: Boolean = false,
     @SerialName("imageUrl") val imageUrl: String? = null,
     @SerialName("todayMood") val todayMood: TodayMood,
 )
 
 // `/diary` 응답의 `data` 는 객체 — `diaries` 외에 조회 대상 달의 비-임시 다이어리 수
-// (`monthDiaryCount`)와 최근 7일 최빈 기분(`weeklyDominantMood`)이 함께 내려옴.
+// (`monthDiaryCount`), 최근 7일 최빈 기분(`weeklyDominantMood`), 수신자 목록이 함께 내려옴.
 @Serializable
 data class DiaryListResponse(
     @SerialName("diaries") val diaries: List<DiaryListItem> = emptyList(),
     @SerialName("monthDiaryCount") val monthDiaryCount: Int = 0,
     @SerialName("weeklyDominantMood") val weeklyDominantMood: TodayMood? = null,
+    @SerialName("receivers") val receivers: List<MindRecordReceiverDto> = emptyList(),
 )

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DiaryDto.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DiaryDto.kt
@@ -22,19 +22,17 @@ data class DiaryCreateRequest(
     @SerialName("title") val title: String,
     @SerialName("content") val content: String,
     @SerialName("isDraft") val isDraft: Boolean,
-    @SerialName("todayMood") val todayMood: TodayMood,
-    @SerialName("imageUrl") val imageUrl: String? = null,
+    @SerialName("todayMood") val todayMood: TodayMood? = null,
     @SerialName("receiverIds") val receiverIds: List<Long> = emptyList(),
 )
 
 @Serializable
 data class DiaryUpdateRequest(
-    @SerialName("title") val title: String,
-    @SerialName("content") val content: String,
-    @SerialName("isDraft") val isDraft: Boolean,
-    @SerialName("todayMood") val todayMood: TodayMood,
-    @SerialName("date") val date: String,
-    @SerialName("imageUrl") val imageUrl: String? = null,
+    @SerialName("title") val title: String? = null,
+    @SerialName("content") val content: String? = null,
+    @SerialName("isDraft") val isDraft: Boolean? = null,
+    @SerialName("todayMood") val todayMood: TodayMood? = null,
+    @SerialName("receiverIds") val receiverIds: List<Long> = emptyList(),
 )
 
 @OptIn(ExperimentalSerializationApi::class)

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/WeeklyReportDto.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/WeeklyReportDto.kt
@@ -19,7 +19,7 @@ data class WeeklyReportResponse(
 data class WeeklyReportDayDto(
     @SerialName("diaryId") val diaryId: Long = 0L,
     @SerialName("day") val day: Int = 0,
-    @SerialName("isDiary") val isDiary: Boolean = false,
+    @SerialName("diary") val isDiary: Boolean = false,
     @SerialName("emotion") val emotion: TodayMood? = null,
 )
 

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DailyQuestionMapper.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DailyQuestionMapper.kt
@@ -7,6 +7,7 @@ import com.afternote.feature.mindrecord.data.dto.TodayDailyQuestionResponse
 import com.afternote.feature.mindrecord.domain.model.DailyQuestion
 import com.afternote.feature.mindrecord.domain.model.DailyQuestionCreatePayload
 import com.afternote.feature.mindrecord.domain.model.DailyQuestionUpdatePayload
+import com.afternote.feature.mindrecord.domain.model.MindRecordReceiver
 import com.afternote.feature.mindrecord.domain.model.TodayDailyQuestion
 
 fun DailyQuestionListItem.toDomain(): DailyQuestion =
@@ -16,11 +17,13 @@ fun DailyQuestionListItem.toDomain(): DailyQuestion =
         content = content,
         createdAt = createdAt,
         imageUrl = imageUrl,
+        receivers = receivers.map { MindRecordReceiver(receiverId = it.receiverId, name = it.name) },
     )
 
 fun TodayDailyQuestionResponse.toDomain(): TodayDailyQuestion =
     TodayDailyQuestion(
         questionId = questionId,
+        day = day,
         content = content,
         isAnswered = isAnswered,
     )
@@ -31,6 +34,7 @@ fun DailyQuestionCreatePayload.toRequest(): DailyQuestionCreateRequest =
         isDraft = isDraft,
         questionId = questionId,
         imageUrl = imageUrl,
+        receiverIds = receiverIds,
     )
 
 fun DailyQuestionUpdatePayload.toRequest(): DailyQuestionUpdateRequest =

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DailyQuestionMapper.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DailyQuestionMapper.kt
@@ -33,7 +33,6 @@ fun DailyQuestionCreatePayload.toRequest(): DailyQuestionCreateRequest =
         content = content,
         isDraft = isDraft,
         questionId = questionId,
-        imageUrl = imageUrl,
         receiverIds = receiverIds,
     )
 
@@ -41,7 +40,5 @@ fun DailyQuestionUpdatePayload.toRequest(): DailyQuestionUpdateRequest =
     DailyQuestionUpdateRequest(
         content = content,
         isDraft = isDraft,
-        date = date,
-        questionId = questionId,
-        imageUrl = imageUrl,
+        receiverIds = receiverIds,
     )

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DeepThoughtMapper.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DeepThoughtMapper.kt
@@ -57,8 +57,8 @@ fun DeepThoughtCreatePayload.toRequest(): DeepThoughtCreateRequest =
         content = content,
         isDraft = isDraft,
         category = category,
-        tag = tags,
-        imageUrl = imageUrl,
+        tags = tags,
+        receiverIds = receiverIds,
     )
 
 fun DeepThoughtUpdatePayload.toRequest(): DeepThoughtUpdateRequest =
@@ -67,8 +67,8 @@ fun DeepThoughtUpdatePayload.toRequest(): DeepThoughtUpdateRequest =
         content = content,
         isDraft = isDraft,
         category = category,
-        tag = tags,
-        imageUrl = imageUrl,
+        tags = tags,
+        receiverIds = receiverIds,
     )
 
 fun DeepThoughtCategoryItem.toDomain(): DeepThoughtCategory =
@@ -85,11 +85,10 @@ fun DeepThoughtCategoryMutationResponse.toDomain(): DeepThoughtCategory =
 
 fun DeepThoughtCategoryCreatePayload.toRequest(): DeepThoughtCategoryCreateRequest =
     DeepThoughtCategoryCreateRequest(
-        category = category,
-        deepThoughtId = deepThoughtId,
+        title = category,
     )
 
 fun DeepThoughtCategoryUpdatePayload.toRequest(): DeepThoughtCategoryUpdateRequest =
     DeepThoughtCategoryUpdateRequest(
-        category = category,
+        title = category,
     )

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DiaryMapper.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DiaryMapper.kt
@@ -8,6 +8,7 @@ import com.afternote.feature.mindrecord.domain.model.Diary
 import com.afternote.feature.mindrecord.domain.model.DiaryCreatePayload
 import com.afternote.feature.mindrecord.domain.model.DiaryList
 import com.afternote.feature.mindrecord.domain.model.DiaryUpdatePayload
+import com.afternote.feature.mindrecord.domain.model.MindRecordReceiver
 import com.afternote.feature.mindrecord.domain.model.TodayMood
 import com.afternote.feature.mindrecord.data.dto.TodayMood as TodayMoodDto
 
@@ -16,7 +17,9 @@ fun DiaryListItem.toDomain(): Diary =
         diaryId = diaryId,
         title = title,
         content = content,
+        date = date,
         createdAt = createdAt,
+        isDraft = isDraft,
         todayMood = todayMood.toDomain(),
         imageUrl = imageUrl,
     )
@@ -26,6 +29,7 @@ fun DiaryListResponse.toDomain(): DiaryList =
         diaries = diaries.map { it.toDomain() },
         monthDiaryCount = monthDiaryCount,
         weeklyDominantMood = weeklyDominantMood?.toDomain(),
+        receivers = receivers.map { MindRecordReceiver(receiverId = it.receiverId, name = it.name) },
     )
 
 fun TodayMoodDto.toDomain(): TodayMood =
@@ -49,6 +53,7 @@ fun DiaryCreatePayload.toRequest(): DiaryCreateRequest =
         isDraft = isDraft,
         todayMood = todayMood.toDto(),
         imageUrl = imageUrl,
+        receiverIds = receiverIds,
     )
 
 fun DiaryUpdatePayload.toRequest(): DiaryUpdateRequest =

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DiaryMapper.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DiaryMapper.kt
@@ -52,7 +52,6 @@ fun DiaryCreatePayload.toRequest(): DiaryCreateRequest =
         content = content,
         isDraft = isDraft,
         todayMood = todayMood.toDto(),
-        imageUrl = imageUrl,
         receiverIds = receiverIds,
     )
 
@@ -61,7 +60,6 @@ fun DiaryUpdatePayload.toRequest(): DiaryUpdateRequest =
         title = title,
         content = content,
         isDraft = isDraft,
-        todayMood = todayMood.toDto(),
-        date = date,
-        imageUrl = imageUrl,
+        todayMood = todayMood?.toDto(),
+        receiverIds = receiverIds,
     )

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/repositoryimpl/DeepThoughtRepositoryImpl.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/repositoryimpl/DeepThoughtRepositoryImpl.kt
@@ -57,7 +57,7 @@ class DeepThoughtRepositoryImpl
 
         override suspend fun getCategories(): Result<List<DeepThoughtCategory>> =
             runCatching {
-                api.getDeepThoughtCategories().requireData().map { it.toDomain() }
+                api.getDeepThoughtCategories().requireData().categories.map { it.toDomain() }
             }
 
         override suspend fun createCategory(payload: DeepThoughtCategoryCreatePayload): Result<DeepThoughtCategory> =

--- a/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/DailyQuestionModels.kt
+++ b/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/DailyQuestionModels.kt
@@ -32,7 +32,5 @@ data class DailyQuestionCreatePayload(
 data class DailyQuestionUpdatePayload(
     val content: String? = null,
     val isDraft: Boolean? = null,
-    val date: String? = null,
-    val questionId: Long? = null,
-    val imageUrl: String? = null,
+    val receiverIds: List<Long> = emptyList(),
 )

--- a/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/DailyQuestionModels.kt
+++ b/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/DailyQuestionModels.kt
@@ -1,15 +1,22 @@
 package com.afternote.feature.mindrecord.domain.model
 
+data class MindRecordReceiver(
+    val receiverId: Long,
+    val name: String,
+)
+
 data class DailyQuestion(
     val dailyQuestionId: Long,
     val title: String,
     val content: String,
     val createdAt: String,
     val imageUrl: String? = null,
+    val receivers: List<MindRecordReceiver> = emptyList(),
 )
 
 data class TodayDailyQuestion(
     val questionId: Long,
+    val day: Int,
     val content: String,
     val isAnswered: Boolean,
 )
@@ -19,6 +26,7 @@ data class DailyQuestionCreatePayload(
     val isDraft: Boolean,
     val questionId: Long,
     val imageUrl: String? = null,
+    val receiverIds: List<Long> = emptyList(),
 )
 
 data class DailyQuestionUpdatePayload(

--- a/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/DeepThoughtModels.kt
+++ b/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/DeepThoughtModels.kt
@@ -34,6 +34,7 @@ data class DeepThoughtCreatePayload(
     val category: String,
     val tags: List<String>? = null,
     val imageUrl: String? = null,
+    val receiverIds: List<Long> = emptyList(),
 )
 
 data class DeepThoughtUpdatePayload(
@@ -43,6 +44,7 @@ data class DeepThoughtUpdatePayload(
     val category: String? = null,
     val tags: List<String>? = null,
     val imageUrl: String? = null,
+    val receiverIds: List<Long> = emptyList(),
 )
 
 data class DeepThoughtCategory(

--- a/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/DiaryModels.kt
+++ b/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/DiaryModels.kt
@@ -34,10 +34,9 @@ data class DiaryCreatePayload(
 )
 
 data class DiaryUpdatePayload(
-    val title: String,
-    val content: String,
-    val isDraft: Boolean,
-    val todayMood: TodayMood,
-    val date: String,
-    val imageUrl: String? = null,
+    val title: String? = null,
+    val content: String? = null,
+    val isDraft: Boolean? = null,
+    val todayMood: TodayMood? = null,
+    val receiverIds: List<Long> = emptyList(),
 )

--- a/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/DiaryModels.kt
+++ b/feature/mindrecord/domain/src/main/kotlin/com/afternote/feature/mindrecord/domain/model/DiaryModels.kt
@@ -10,7 +10,9 @@ data class Diary(
     val diaryId: Long,
     val title: String,
     val content: String,
+    val date: String? = null,
     val createdAt: String,
+    val isDraft: Boolean = false,
     val todayMood: TodayMood,
     val imageUrl: String? = null,
 )
@@ -19,6 +21,7 @@ data class DiaryList(
     val diaries: List<Diary>,
     val monthDiaryCount: Int,
     val weeklyDominantMood: TodayMood?,
+    val receivers: List<MindRecordReceiver> = emptyList(),
 )
 
 data class DiaryCreatePayload(
@@ -27,6 +30,7 @@ data class DiaryCreatePayload(
     val isDraft: Boolean,
     val todayMood: TodayMood,
     val imageUrl: String? = null,
+    val receiverIds: List<Long> = emptyList(),
 )
 
 data class DiaryUpdatePayload(

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyCalendar.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyCalendar.kt
@@ -40,8 +40,10 @@ fun DailyCalendar(
     modifier: Modifier = Modifier,
     answeredDays: Set<Int> = emptySet(),
     emotionByDay: Map<Int, String> = emptyMap(),
+    selectedDay: Int? = null,
+    onDayClick: ((Int) -> Unit)? = null,
 ) {
-    val days = buildDays(year, month, answeredDays, emotionByDay)
+    val days = buildDays(year, month, answeredDays, emotionByDay, selectedDay)
 
     Column(
         modifier = modifier,
@@ -82,7 +84,7 @@ fun DailyCalendar(
                 CardDefaults.cardColors(
                     containerColor = Color(0xFFFFFFFF),
                 ),
-            border = BorderStroke(1.dp, color = Color(0xFF000000).copy(alpha = 0.05f)),
+            border = BorderStroke(1.dp, color = AfternoteDesign.colors.gray2),
             modifier = Modifier.fillMaxWidth(),
         ) {
             Column(
@@ -118,7 +120,17 @@ fun DailyCalendar(
                         Row(modifier = Modifier.fillMaxWidth()) {
                             week.forEach { dayModel ->
                                 Box(modifier = Modifier.weight(1f)) {
-                                    DayCell(model = dayModel, type = type)
+                                    val day = dayModel.day
+                                    DayCell(
+                                        model = dayModel,
+                                        type = type,
+                                        onClick =
+                                            if (onDayClick != null && day != null) {
+                                                { onDayClick(day) }
+                                            } else {
+                                                null
+                                            },
+                                    )
                                 }
                             }
                             // 마지막 주가 7개 미만이면 빈 셀로 채우기
@@ -138,6 +150,7 @@ fun buildDays(
     month: Int,
     answeredDays: Set<Int>,
     emotionByDay: Map<Int, String>,
+    selectedDay: Int? = null,
 ): List<DayUiModel> {
     val calendar =
         Calendar.getInstance().apply {
@@ -158,9 +171,11 @@ fun buildDays(
         // 앞 빈 셀
         repeat(firstDayOfWeek) { add(DayUiModel(day = null)) }
         for (day in 1..daysInMonth) {
+            // Figma 2671:16704/16718 — 선택한 날은 검은 원, 오늘은 연회색 원(isToday),
+            // 답변한 날은 점 인디케이터
             val state =
                 when {
-                    day == today -> DayState.TODAY
+                    day == selectedDay -> DayState.SELECTED
                     day in answeredDays -> DayState.ANSWERED
                     else -> DayState.NONE
                 }
@@ -169,6 +184,7 @@ fun buildDays(
                     day = day,
                     state = state,
                     emotion = emotionByDay[day],
+                    isToday = day == today,
                 ),
             )
         }
@@ -186,6 +202,8 @@ private fun DailyCalendarPreview() {
             onNextMonth = {},
             onPrevMonth = {},
             answeredDays = setOf(3, 7, 14),
+            selectedDay = 15,
+            onDayClick = {},
         )
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyQuestionListCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyQuestionListCard.kt
@@ -1,6 +1,8 @@
 package com.afternote.feature.mindrecord.presentation.component
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,9 +12,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,91 +25,190 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.model.DailyQuestion
 import com.afternote.feature.mindrecord.presentation.util.htmlToPlainText
+import java.time.DayOfWeek
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
+private val DateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+
+/**
+ * 데일리 질문 답변 리스트 카드 (Figma 2757:16130 텍스트형 / 2757:16129 이미지형).
+ *
+ * @param recipientNames 받는 사람 이름 목록 텍스트 (예: "박채연, 000,"). null 이면 표시하지 않음
+ * @param imageUrl 첨부 이미지 URL. null 이 아니면 좌측 썸네일이 있는 이미지형 카드로 렌더링
+ */
 @Composable
 fun DailyQuestionListCard(
     answer: DailyQuestion,
     modifier: Modifier = Modifier,
+    recipientNames: String? = null,
+    imageUrl: String? = null,
     onEdit: () -> Unit = {},
     onDelete: () -> Unit = {},
 ) {
-    var menuExpanded by remember { mutableStateOf(false) }
-
     OutlinedCard(
+        shape = RoundedCornerShape(6.dp),
         colors =
             CardDefaults.cardColors(
-                containerColor = Color(0xFFFFFFFF),
+                containerColor = AfternoteDesign.colors.white,
             ),
-        border = BorderStroke(1.dp, color = Color(0xFF000000).copy(alpha = 0.05f)),
+        border = BorderStroke(1.dp, color = AfternoteDesign.colors.gray2),
         modifier = modifier.fillMaxWidth(),
     ) {
-        Column(
-            modifier = Modifier.padding(horizontal = 16.dp).padding(bottom = 16.dp),
-        ) {
+        if (imageUrl != null) {
+            // Figma 2757:16129 — 이미지형: p=12 / 썸네일 85 / gap=8
             Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween,
-                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.padding(12.dp),
             ) {
+                AsyncImage(
+                    model = imageUrl,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier =
+                        Modifier
+                            .size(85.dp)
+                            .clip(RoundedCornerShape(2.dp)),
+                )
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    modifier = Modifier.weight(1f),
+                ) {
+                    CardHeaderRow(
+                        date = answer.date,
+                        recipientNames = recipientNames,
+                        onEdit = onEdit,
+                        onDelete = onDelete,
+                    )
+                    Text(
+                        text = answer.title,
+                        style = AfternoteDesign.typography.bodySmallB,
+                        color = AfternoteDesign.colors.gray9,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = answer.content.htmlToPlainText(),
+                        style = AfternoteDesign.typography.captionLargeR,
+                        color = AfternoteDesign.colors.gray5,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        } else {
+            // Figma 2757:16130 — 텍스트형: p=16 / 날짜·받는사람 → 질문(Bold) → 답변 미리보기
+            Column(
+                modifier = Modifier.padding(16.dp),
+            ) {
+                CardHeaderRow(
+                    date = answer.date,
+                    recipientNames = recipientNames,
+                    onEdit = onEdit,
+                    onDelete = onDelete,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
                 Text(
-                    text = answer.date.toString(),
+                    text = answer.title,
+                    style = AfternoteDesign.typography.bodySmallB,
+                    color = AfternoteDesign.colors.gray9,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = answer.content.htmlToPlainText(),
                     style = AfternoteDesign.typography.captionLargeR,
                     color = AfternoteDesign.colors.gray6,
                 )
-
-                Box {
-                    IconButton(
-                        onClick = { menuExpanded = true },
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.mindrecord_horizontal),
-                            tint = AfternoteDesign.colors.gray5,
-                            contentDescription = stringResource(R.string.mindrecord_more_menu_cd),
-                            modifier = Modifier.size(20.dp),
-                        )
-                    }
-                    if (menuExpanded) {
-                        RecordActionPopup(
-                            onDismiss = { menuExpanded = false },
-                            onDelete = {
-                                menuExpanded = false
-                                onDelete()
-                            },
-                            onEdit = {
-                                menuExpanded = false
-                                onEdit()
-                            },
-                        )
-                    }
-                }
             }
-
-            Text(
-                text = answer.title,
-                style = AfternoteDesign.typography.bodySmallR,
-                color = AfternoteDesign.colors.gray9,
-            )
-
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = answer.content.htmlToPlainText(),
-                style = AfternoteDesign.typography.captionLargeR,
-                color = AfternoteDesign.colors.gray6,
-            )
         }
     }
 }
+
+@Composable
+private fun CardHeaderRow(
+    date: LocalDate,
+    recipientNames: String?,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var menuExpanded by remember { mutableStateOf(false) }
+    val dateText = remember(date) { date.format(DateFormatter) }
+    val dayOfWeekText = stringResource(dayOfWeekLabelRes(date.dayOfWeek))
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = "$dateText $dayOfWeekText",
+            style = AfternoteDesign.typography.captionLargeR,
+            color = AfternoteDesign.colors.gray6,
+        )
+        if (recipientNames != null) {
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = recipientNames,
+                style = AfternoteDesign.typography.captionLargeR,
+                color = AfternoteDesign.colors.gray6,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f, fill = false),
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+
+        Box {
+            Icon(
+                painter = painterResource(R.drawable.mindrecord_horizontal),
+                tint = AfternoteDesign.colors.gray5,
+                contentDescription = stringResource(R.string.mindrecord_more_menu_cd),
+                modifier =
+                    Modifier
+                        .size(20.dp)
+                        .clickable { menuExpanded = true },
+            )
+            if (menuExpanded) {
+                RecordActionPopup(
+                    onDismiss = { menuExpanded = false },
+                    onDelete = {
+                        menuExpanded = false
+                        onDelete()
+                    },
+                    onEdit = {
+                        menuExpanded = false
+                        onEdit()
+                    },
+                )
+            }
+        }
+    }
+}
+
+@StringRes
+private fun dayOfWeekLabelRes(dayOfWeek: DayOfWeek): Int =
+    when (dayOfWeek) {
+        DayOfWeek.MONDAY -> R.string.mindrecord_calendar_day_label_mon
+        DayOfWeek.TUESDAY -> R.string.mindrecord_calendar_day_label_tue
+        DayOfWeek.WEDNESDAY -> R.string.mindrecord_calendar_day_label_wed
+        DayOfWeek.THURSDAY -> R.string.mindrecord_calendar_day_label_thu
+        DayOfWeek.FRIDAY -> R.string.mindrecord_calendar_day_label_fri
+        DayOfWeek.SATURDAY -> R.string.mindrecord_calendar_day_label_sat
+        DayOfWeek.SUNDAY -> R.string.mindrecord_calendar_day_label_sun
+    }
 
 @Preview(showBackground = true)
 @Composable
@@ -115,10 +217,27 @@ private fun DailyQuestionCardPreview() {
         DailyQuestionListCard(
             answer =
                 DailyQuestion(
-                    title = "test",
-                    content = "test for DailyQuestionCardPreview",
+                    title = "오늘 하루, 누구에게 가장 고마웠나요?",
+                    content = "아무 말 없이 그저 나의 곁을 지켜주는 아내가 고맙다.",
                     date = LocalDate.now(),
                 ),
+            recipientNames = "박채연, 000,",
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DailyQuestionCardImagePreview() {
+    AfternoteTheme {
+        DailyQuestionListCard(
+            answer =
+                DailyQuestion(
+                    title = "채연아 20번째 생일을 축하해",
+                    content = "너가 태어난 게 엊그제같은데 벌써 스무살이라니..엄마가 없어도 씩씩하게 컸을 채연이를 상상하면 너무 기특해서 안아주고 싶구나",
+                    date = LocalDate.now(),
+                ),
+            imageUrl = "https://example.com/image.png",
         )
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyQuestionWriteHeaderCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DailyQuestionWriteHeaderCard.kt
@@ -1,6 +1,11 @@
 package com.afternote.feature.mindrecord.presentation.component
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -9,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -19,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -30,6 +37,10 @@ import com.afternote.core.ui.R
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R as MindRecordR
+
+/** 추천 질문 카드 라디얼 그라데이션 (Figma 2372:22138 — 중앙 rgba(183,196,205,0.7) → 가장자리 #ECF0F3). */
+private val RecommendCardGradientCenter = Color(0xFFB7C4CD)
+private val RecommendCardGradientEdge = Color(0xFFECF0F3)
 
 @Composable
 fun DailyQuestionWriteHeaderCard(
@@ -101,10 +112,113 @@ fun DailyQuestionWriteHeaderCard(
     }
 }
 
+/**
+ * 데일리기록 작성 화면의 접었다 펼칠 수 있는 "오늘의 추천 질문" 카드.
+ *
+ * Figma 2372:22329(open) / 2372:22389(close) 의 추천 질문 카드와 1:1 매칭된다.
+ *
+ * @param dayCount "Day N" 카운터. 백엔드에서 아직 내려주지 않으므로 null 이면 숨긴다.
+ */
+@Composable
+fun DailyQuestionRecommendCard(
+    modifier: Modifier = Modifier,
+    questionText: String = stringResource(MindRecordR.string.mindrecord_daily_question_default_thanks),
+    dayCount: Int? = null,
+    expanded: Boolean = true,
+    onExpandToggle: () -> Unit = {},
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(6.dp))
+                .drawWithCache {
+                    val brush =
+                        Brush.radialGradient(
+                            colorStops =
+                                arrayOf(
+                                    0.0f to RecommendCardGradientCenter.copy(alpha = 0.7f),
+                                    1.0f to RecommendCardGradientEdge,
+                                ),
+                            center = Offset(size.width / 2f, size.height / 2f),
+                            radius = size.width / 1.5f,
+                        )
+
+                    onDrawBehind {
+                        drawRect(brush)
+                    }
+                }.animateContentSize()
+                .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = onExpandToggle),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (dayCount != null) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(4.dp)
+                                .clip(CircleShape)
+                                .background(AfternoteDesign.colors.gray6),
+                    )
+                    Text(
+                        text = "Day $dayCount",
+                        style = AfternoteDesign.typography.footnoteCaption,
+                        color = AfternoteDesign.colors.gray7,
+                    )
+                }
+                Text(
+                    text = "오늘의 추천 질문",
+                    style = AfternoteDesign.typography.mono,
+                    color = AfternoteDesign.colors.gray7,
+                )
+            }
+            Icon(
+                painter = painterResource(R.drawable.core_ui_arrowdown),
+                contentDescription = null,
+                tint = AfternoteDesign.colors.gray7,
+                modifier =
+                    Modifier
+                        .size(16.dp)
+                        .rotate(if (expanded) 180f else 0f),
+            )
+        }
+        if (expanded) {
+            Text(
+                text = questionText,
+                style = AfternoteDesign.typography.bodyBase,
+                color = AfternoteDesign.colors.gray9,
+            )
+        }
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 private fun DailyQuestionWriteHeaderCardPreview() {
     AfternoteTheme {
         DailyQuestionWriteHeaderCard()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DailyQuestionRecommendCardPreview() {
+    AfternoteTheme {
+        Column {
+            DailyQuestionRecommendCard(dayCount = 21, expanded = true)
+            Spacer(modifier = Modifier.height(12.dp))
+            DailyQuestionRecommendCard(dayCount = 21, expanded = false)
+        }
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DayCell.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DayCell.kt
@@ -1,6 +1,7 @@
 package com.afternote.feature.mindrecord.presentation.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -14,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.afternote.core.ui.theme.AfternoteDesign
@@ -26,30 +28,30 @@ fun DayCell(
     model: DayUiModel,
     type: MindRecordCategoryUi,
     modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
 ) {
     if (model.day == null) {
         Box(modifier = Modifier.aspectRatio(1f))
         return
     }
 
-    // - TODAY: 검은 원 + 흰 글자
-    // - ANSWERED(작성한 날): 투명 배경 + 진한 글자 + 하단 인디케이터 (diary 는 이모지, 그 외는 점)
-    // - NONE/UNANSWERED: 투명 배경 + 회색 글자, 인디케이터 없음
+    // Figma 2671:16704 / 2671:16718 — 캘린더 셀 상태
+    // - SELECTED(선택한 날)/TODAY(레거시): 검은 원 + 흰 글자 + 그림자
+    // - isToday(선택되지 않은 오늘): 연회색 원 배경
+    // - ANSWERED(작성한 날): 진한 글자 + 하단 인디케이터 (diary 는 이모지, 그 외는 점)
+    // - NONE/UNANSWERED: 회색 글자, 인디케이터 없음
+    val isSelected = model.state == DayState.SELECTED || model.state == DayState.TODAY
     val bgColor =
-        when (model.state) {
-            DayState.TODAY -> Color(0xFF1A1A1A)
+        when {
+            isSelected -> AfternoteDesign.colors.gray9
+            model.isToday -> AfternoteDesign.colors.gray2
             else -> Color.Transparent
         }
     val textColor =
-        when (model.state) {
-            DayState.TODAY -> AfternoteDesign.colors.white
-            DayState.ANSWERED -> AfternoteDesign.colors.gray9
-            DayState.UNANSWERED, DayState.NONE -> AfternoteDesign.colors.gray5
-        }
-    val textStyle =
-        when (model.state) {
-            DayState.TODAY, DayState.ANSWERED -> AfternoteDesign.typography.captionLargeB
-            DayState.UNANSWERED, DayState.NONE -> AfternoteDesign.typography.captionLargeR
+        when {
+            isSelected -> AfternoteDesign.colors.white
+            model.state == DayState.ANSWERED -> AfternoteDesign.colors.gray9
+            else -> AfternoteDesign.colors.gray5
         }
 
     Box(
@@ -63,19 +65,32 @@ fun DayCell(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .clip(CircleShape)
-                    .background(bgColor),
+                    .then(
+                        if (isSelected) {
+                            Modifier.shadow(elevation = 4.dp, shape = CircleShape)
+                        } else {
+                            Modifier
+                        },
+                    ).clip(CircleShape)
+                    .background(bgColor)
+                    .then(
+                        if (onClick != null) {
+                            Modifier.clickable { onClick() }
+                        } else {
+                            Modifier
+                        },
+                    ),
             contentAlignment = Alignment.Center,
         ) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(
                     text = model.day.toString(),
-                    style = textStyle,
+                    style = AfternoteDesign.typography.captionLargeB,
                     color = textColor,
                 )
                 if (model.state == DayState.ANSWERED) {
                     Spacer(modifier = Modifier.height(2.dp))
-                    type.DayIndicator(model = model, textColor = textColor)
+                    type.DayIndicator(model = model, textColor = AfternoteDesign.colors.gray6)
                 }
             }
         }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryCard.kt
@@ -2,120 +2,207 @@ package com.afternote.feature.mindrecord.presentation.component
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.model.DailyDiary
 import com.afternote.feature.mindrecord.presentation.util.htmlToPlainText
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import java.time.format.TextStyle as JavaTextStyle
 
+private val DiaryCardDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+
+/**
+ * 일기 카드 형 그리드 셀. Figma 2671:16748 / 16766 / 16779.
+ *
+ * - 사진이 있으면: 128dp 이미지 + 하단 그라데이션 스크림 + 좌하단 감정 이모지 오버레이
+ * - 사진이 없고 감정만 있으면: 그라데이션 배경에 감정 이모지(32sp) 플레이스홀더
+ * - 둘 다 없으면: 텍스트 전용 카드
+ */
 @Composable
 fun DiaryCard(
     diary: DailyDiary,
     modifier: Modifier = Modifier,
+    onEdit: () -> Unit = {},
+    onDelete: () -> Unit = {},
 ) {
+    var menuExpanded by remember { mutableStateOf(false) }
+
     OutlinedCard(
         colors =
             CardDefaults.cardColors(
                 containerColor = AfternoteDesign.colors.white,
             ),
         border = BorderStroke(1.dp, color = AfternoteDesign.colors.gray2),
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(6.dp)),
+        shape = RoundedCornerShape(6.dp),
+        modifier = modifier.fillMaxWidth(),
     ) {
         Column {
-            Box(
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Image(
-                    painter = painterResource(R.drawable.mindrecord_img),
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
+            val imageUrl = diary.imageUrl
+            val emotion = diary.emotion
+            if (imageUrl != null) {
+                Box(
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .height(130.dp),
-                )
-
-                diary.emotion?.let {
-                    Text(
-                        text = it,
+                            .height(128.dp),
+                ) {
+                    Image(
+                        painter = painterResource(imageUrl),
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                    Box(
                         modifier =
                             Modifier
-                                .align(Alignment.BottomStart)
-                                .padding(8.dp),
+                                .fillMaxSize()
+                                .background(
+                                    Brush.verticalGradient(
+                                        colors =
+                                            listOf(
+                                                Color.Transparent,
+                                                Color(0xFF000000).copy(alpha = 0.4f),
+                                            ),
+                                    ),
+                                ),
+                    )
+                    emotion?.let {
+                        Text(
+                            text = it,
+                            fontSize = 20.sp,
+                            modifier =
+                                Modifier
+                                    .align(Alignment.BottomStart)
+                                    .padding(8.dp),
+                        )
+                    }
+                }
+            } else if (emotion != null) {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(128.dp)
+                            .background(
+                                Brush.linearGradient(
+                                    colors =
+                                        listOf(
+                                            Color(0xFFFAFAF9),
+                                            Color(0xFFF5F5F4),
+                                        ),
+                                ),
+                            ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = emotion,
+                        fontSize = 32.sp,
                     )
                 }
             }
 
-            Row(
+            Column(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .padding(16.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
+                        .padding(12.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
             ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Text(
+                            text = diary.date.format(DiaryCardDateFormatter),
+                            style = AfternoteDesign.typography.footnoteCaption,
+                            color = AfternoteDesign.colors.gray6,
+                        )
+                        Text(
+                            text = diary.date.dayOfWeek.getDisplayName(JavaTextStyle.SHORT, Locale.KOREAN),
+                            style = AfternoteDesign.typography.footnoteCaption,
+                            color = AfternoteDesign.colors.gray6,
+                        )
+                    }
+
+                    Box {
+                        Icon(
+                            painter = painterResource(R.drawable.mindrecord_horizontal),
+                            contentDescription = stringResource(R.string.mindrecord_more_menu_cd),
+                            tint = AfternoteDesign.colors.gray6,
+                            modifier =
+                                Modifier
+                                    .size(20.dp)
+                                    .clickable { menuExpanded = true },
+                        )
+                        if (menuExpanded) {
+                            RecordActionPopup(
+                                onDismiss = { menuExpanded = false },
+                                onDelete = {
+                                    menuExpanded = false
+                                    onDelete()
+                                },
+                                onEdit = {
+                                    menuExpanded = false
+                                    onEdit()
+                                },
+                            )
+                        }
+                    }
+                }
+
                 Text(
-                    text = diary.date.toString(),
-                    style = AfternoteDesign.typography.footnoteCaption,
-                    color = AfternoteDesign.colors.gray6,
+                    text = diary.title,
+                    style = AfternoteDesign.typography.bodySmallB,
+                    color = AfternoteDesign.colors.gray9,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
 
-                Box(
-                    modifier = Modifier.clickable {},
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.mindrecord_horizontal),
-                        contentDescription = null,
-                        tint = AfternoteDesign.colors.gray6,
-                    )
-                }
+                Text(
+                    text = diary.content.htmlToPlainText(),
+                    style = AfternoteDesign.typography.captionLargeR,
+                    color = AfternoteDesign.colors.gray6,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
-
-            Text(
-                text = diary.title,
-                style = AfternoteDesign.typography.bodySmallR,
-                color = AfternoteDesign.colors.gray9,
-                modifier = Modifier.padding(horizontal = 16.dp),
-            )
-
-            Spacer(modifier = Modifier.height(2.5.dp))
-            Text(
-                text = diary.content.htmlToPlainText(),
-                style = AfternoteDesign.typography.captionLargeR,
-                color = AfternoteDesign.colors.gray6,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.padding(horizontal = 16.dp),
-            )
-
-            Spacer(modifier = Modifier.height(17.dp))
         }
     }
 }
@@ -128,9 +215,26 @@ private fun DiaryCardPreview() {
             diary =
                 DailyDiary(
                     title = "가족과 함께한 저녁 식사",
-                    content = "오랜만에 가족들과 testsetsetsetsetset",
+                    content = "오랜만에 가족들과 둘러앉아 이야기를 나누는 시간이 정말 소중했다.",
                     date = LocalDate.now(),
-                    emotion = "\uD83D\uDE0A",
+                    emotion = "😊",
+                    imageUrl = R.drawable.mindrecord_img,
+                ),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DiaryCardNoImagePreview() {
+    AfternoteTheme {
+        DiaryCard(
+            diary =
+                DailyDiary(
+                    title = "새로운 취미 시작",
+                    content = "수채화 그리기를 시작했다. 서툴지만 무언가에 집중하는 시간이 좋다.",
+                    date = LocalDate.now(),
+                    emotion = "😌",
                 ),
         )
     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryComponent.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryComponent.kt
@@ -2,14 +2,14 @@ package com.afternote.feature.mindrecord.presentation.component
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -22,20 +22,33 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.model.DailyDiary
 import com.afternote.feature.mindrecord.presentation.util.htmlToPlainText
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import java.time.format.TextStyle as JavaTextStyle
 
+private val DiaryComponentDateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+
+/**
+ * 일기 캘린더 형 하단 기록 카드. Figma 2671:17691.
+ *
+ * 좌측 85dp 썸네일, 우측 날짜·요일·감정 이모지 + 더보기, 제목, 2줄 말줄임 본문.
+ */
 @Composable
 fun DiaryComponent(
     diary: DailyDiary,
@@ -48,7 +61,7 @@ fun DiaryComponent(
     OutlinedCard(
         colors =
             CardDefaults.cardColors(
-                containerColor = Color(0xFFFFFFFF),
+                containerColor = AfternoteDesign.colors.white,
             ),
         border = BorderStroke(1.dp, color = AfternoteDesign.colors.gray2),
         modifier = modifier.fillMaxWidth(),
@@ -59,31 +72,65 @@ fun DiaryComponent(
                 Modifier
                     .fillMaxWidth()
                     .padding(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Image(
-                painter = painterResource(R.drawable.mindrecord_img),
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier.size(85.dp),
-            )
+            Box(
+                modifier =
+                    Modifier
+                        .size(85.dp)
+                        .clip(RoundedCornerShape(2.5.dp))
+                        .background(AfternoteDesign.colors.gray1),
+            ) {
+                Image(
+                    painter = painterResource(diary.imageUrl ?: R.drawable.mindrecord_img),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
 
-            Column(Modifier.padding(start = 8.dp)) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    diary.emotion?.let {
-                        Text(
-                            text = it,
-                        )
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                            Text(
+                                text = diary.date.format(DiaryComponentDateFormatter),
+                                style = AfternoteDesign.typography.captionLargeR,
+                                color = AfternoteDesign.colors.gray6,
+                            )
+                            Text(
+                                text = diary.date.dayOfWeek.getDisplayName(JavaTextStyle.SHORT, Locale.KOREAN),
+                                style = AfternoteDesign.typography.captionLargeR,
+                                color = AfternoteDesign.colors.gray6,
+                            )
+                        }
+                        diary.emotion?.let {
+                            Text(
+                                text = it,
+                                fontSize = 18.sp,
+                            )
+                        }
                     }
 
-                    Spacer(modifier = Modifier.weight(1f))
                     Box {
                         Icon(
                             painter = painterResource(R.drawable.mindrecord_horizontal),
                             contentDescription = stringResource(R.string.mindrecord_more_menu_cd),
-                            modifier = Modifier.clickable { menuExpanded = true },
+                            tint = AfternoteDesign.colors.gray6,
+                            modifier =
+                                Modifier
+                                    .size(20.dp)
+                                    .clickable { menuExpanded = true },
                         )
                         if (menuExpanded) {
                             RecordActionPopup(
@@ -101,20 +148,20 @@ fun DiaryComponent(
                     }
                 }
 
-                Spacer(modifier = Modifier.height(5.dp))
-
                 Text(
                     text = diary.title,
                     style = AfternoteDesign.typography.bodySmallB,
-                    color = AfternoteDesign.colors.black.copy(alpha = 0.8f),
+                    color = AfternoteDesign.colors.gray9,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
-
-                Spacer(modifier = Modifier.height(5.dp))
 
                 Text(
                     text = diary.content.htmlToPlainText(),
                     style = AfternoteDesign.typography.captionLargeR,
                     color = AfternoteDesign.colors.gray5,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         }
@@ -128,10 +175,10 @@ private fun DiaryComponentPreview() {
         DiaryComponent(
             diary =
                 DailyDiary(
-                    title = "가족과 함께한 저녁 식사",
-                    content = "오랜만에 가족들과 testsetsetsetsetset",
+                    title = "채연아 20번째 생일을 축하해",
+                    content = "너가 태어난 게 엊그제같은데 벌써 스무살이라니.. 엄마가 없어도 씩씩하게 컸을 채연이를 상상하면 너무 기특해서 안아주고 싶구나",
                     date = LocalDate.now(),
-                    emotion = "\uD83D\uDE0A",
+                    emotion = "😊",
                 ),
         )
     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryReportCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/DiaryReportCard.kt
@@ -4,24 +4,30 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R
 
+/**
+ * 일기 카드 형 상단 요약 카드.
+ *
+ * Figma 2671:16734 — 흰 배경 / gray2 1dp 보더 / radius 6.
+ * 좌측 "이번 달" + 카운트, 우측 "주간 평균 기분" + 이모지.
+ */
 @Composable
 fun DiaryReportCard(
     monthDiaryCount: Int,
@@ -31,7 +37,7 @@ fun DiaryReportCard(
     OutlinedCard(
         colors =
             CardDefaults.cardColors(
-                containerColor = AfternoteDesign.colors.gray1,
+                containerColor = AfternoteDesign.colors.white,
             ),
         border = BorderStroke(1.dp, color = AfternoteDesign.colors.gray2),
         modifier =
@@ -39,42 +45,38 @@ fun DiaryReportCard(
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(6.dp)),
     ) {
-        Column(
+        Row(
             modifier =
                 Modifier
                     .fillMaxWidth()
                     .padding(17.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Text(
                     text = stringResource(R.string.mindrecord_weekly_report_this_month),
-                    style = AfternoteDesign.typography.mono,
+                    style = AfternoteDesign.typography.footnoteCaption,
                     color = AfternoteDesign.colors.gray6,
                 )
-
-                Text(
-                    text = stringResource(R.string.mindrecord_weekly_report_avg_mood_weekly),
-                    style = AfternoteDesign.typography.mono,
-                    color = AfternoteDesign.colors.gray6,
-                )
-            }
-
-            Spacer(modifier = Modifier.height(4.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
                 Text(
                     text = monthDiaryCount.toString(),
                     style = AfternoteDesign.typography.h2,
                     color = AfternoteDesign.colors.gray9,
                 )
+            }
 
+            Column(
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                horizontalAlignment = Alignment.End,
+            ) {
+                Text(
+                    text = stringResource(R.string.mindrecord_weekly_report_avg_mood_weekly),
+                    style = AfternoteDesign.typography.footnoteCaption,
+                    color = AfternoteDesign.colors.gray6,
+                )
                 Text(
                     text = weeklyMoodEmoji.orEmpty(),
+                    fontSize = 24.sp,
                 )
             }
         }
@@ -85,6 +87,6 @@ fun DiaryReportCard(
 @Composable
 private fun DiaryCardPreview() {
     AfternoteTheme {
-        DiaryReportCard(monthDiaryCount = 18, weeklyMoodEmoji = "\uD83D\uDE0A")
+        DiaryReportCard(monthDiaryCount = 18, weeklyMoodEmoji = "😊")
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/EmotionKeywordCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/EmotionKeywordCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
@@ -13,14 +14,21 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -32,21 +40,23 @@ import com.afternote.feature.mindrecord.presentation.model.EmotionKeyword
 /**
  * 주간 리포트의 "나의 감정 키워드" 카드.
  *
- * Figma 노드 2249:14059 — 키워드 개수(0~4)별로 버블 layout 이 다르며, 카드 자체에서 슬롯을 결정한다
- * (ViewModel 은 keyword·count 만 넘긴다).
+ * Figma 노드 2249:13964(4)~2249:14023(0) — 키워드 개수(0~4)별로 버블 layout 이 다르며,
+ * 카드 자체에서 슬롯(size·offset·pastel color)을 결정한다 (ViewModel 은 keyword·count 만 넘긴다).
+ * 버블 아래에는 INSIGHTS 섹션(디바이더 + 본문 + 푸터)이 카드 안에 포함된다.
  *
  * - 4건: 가족(96) / 감사(72) / 사랑(56) / 그리움(64)
  * - 3건: 가족(96) / 감사(72) / 사랑(56)
  * - 2건: 가족(96) / 감사(72)
  * - 1건: 가족(96)
- * - 0건: 빈 96dp 검은 원에 "0" 만 표시 + 별도 안내 메시지(호출부 책임)
+ * - 0건: 96dp 점선 원에 "0" 표시
  */
 @Composable
 fun EmotionKeywordCard(
     keywords: List<EmotionKeyword>,
-    descriptionText: String,
+    insightText: String,
     modifier: Modifier = Modifier,
     title: String = stringResource(R.string.mindrecord_emotion_card_title),
+    footerText: String = stringResource(R.string.mindrecord_insight_card_footer),
 ) {
     val capped = keywords.take(MAX_KEYWORDS)
 
@@ -66,7 +76,7 @@ fun EmotionKeywordCard(
                 color = AfternoteDesign.colors.gray9,
             )
 
-            // Figma Frame 128: 320×133, 버블은 그 안에서 absolute offset.
+            // Figma Frame: 320×133, 버블은 그 안에서 absolute offset.
             Box(
                 modifier =
                     Modifier
@@ -83,12 +93,63 @@ fun EmotionKeywordCard(
                 }
             }
 
-            Text(
-                text = descriptionText,
-                style = AfternoteDesign.typography.bodySmallB,
-                color = AfternoteDesign.colors.gray9,
+            InsightSection(
+                insightText = insightText,
+                highlightKeyword = capped.firstOrNull()?.keyword,
+                footerText = footerText,
             )
         }
+    }
+}
+
+@Composable
+private fun InsightSection(
+    insightText: String,
+    highlightKeyword: String?,
+    footerText: String,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "INSIGHTS",
+                style = AfternoteDesign.typography.mono,
+                color = AfternoteDesign.colors.gray6,
+            )
+            HorizontalDivider(
+                modifier = Modifier.weight(1f),
+                color = AfternoteDesign.colors.gray3,
+            )
+        }
+
+        // 본문 — 대표 키워드만 gray9 로 강조, 나머지는 black 70%.
+        val body =
+            buildAnnotatedString {
+                val index = highlightKeyword?.let { insightText.indexOf(it) } ?: -1
+                if (highlightKeyword != null && index >= 0) {
+                    append(insightText.substring(0, index))
+                    withStyle(SpanStyle(color = AfternoteDesign.colors.gray9)) {
+                        append(highlightKeyword)
+                    }
+                    append(insightText.substring(index + highlightKeyword.length))
+                } else {
+                    append(insightText)
+                }
+            }
+        Text(
+            text = body,
+            style = AfternoteDesign.typography.bodySmallB,
+            color = AfternoteDesign.colors.black.copy(alpha = 0.7f),
+        )
+
+        Text(
+            text = footerText,
+            style = AfternoteDesign.typography.captionLargeR,
+            color = AfternoteDesign.colors.gray6,
+        )
     }
 }
 
@@ -115,12 +176,17 @@ private fun Bubble(
                     } else {
                         AfternoteDesign.typography.bodySmallB
                     },
-                color = Color.White,
+                color = AfternoteDesign.colors.gray9,
             )
             Text(
                 text = keyword.count.toString(),
-                style = AfternoteDesign.typography.footnoteCaption,
-                color = AfternoteDesign.colors.gray3,
+                style =
+                    if (slot.size >= LARGE_COUNT_THRESHOLD) {
+                        AfternoteDesign.typography.bodySmallR
+                    } else {
+                        AfternoteDesign.typography.footnoteCaption
+                    },
+                color = AfternoteDesign.colors.gray9,
             )
         }
     }
@@ -128,20 +194,31 @@ private fun Bubble(
 
 @Composable
 private fun EmptyBubble() {
-    val slot = EMPTY_SLOT
+    val borderColor = AfternoteDesign.colors.gray6
     Box(
         modifier =
             Modifier
-                .offset(x = slot.offsetX, y = slot.offsetY)
-                .size(slot.size)
-                .clip(CircleShape)
-                .background(slot.color),
+                .offset(x = EMPTY_OFFSET_X, y = EMPTY_OFFSET_Y)
+                .size(EMPTY_SIZE)
+                .drawBehind {
+                    val strokeWidth = 1.dp.toPx()
+                    val dash = 4.dp.toPx()
+                    drawCircle(
+                        color = borderColor,
+                        radius = (size.minDimension - strokeWidth) / 2f,
+                        style =
+                            Stroke(
+                                width = strokeWidth,
+                                pathEffect = PathEffect.dashPathEffect(floatArrayOf(dash, dash), 0f),
+                            ),
+                    )
+                },
         contentAlignment = Alignment.Center,
     ) {
         Text(
             text = "0",
             style = AfternoteDesign.typography.bodySmallR,
-            color = Color.White,
+            color = AfternoteDesign.colors.gray9,
         )
     }
 }
@@ -158,16 +235,18 @@ private data class BubbleSlot(
 private const val MAX_KEYWORDS = 4
 private val BUBBLE_AREA_HEIGHT = 133.dp
 private val LARGE_TEXT_THRESHOLD = 72.dp
+private val LARGE_COUNT_THRESHOLD = 96.dp
 
-// 색상 순위: 1위(가장 진함) → 4위(가장 옅음)
-private val ColorRank1 = Color(0xFF212121)
-private val ColorRank2 = Color(0xFF424242)
-private val ColorRank3 = Color(0xFF616161)
-private val ColorRank4 = Color(0xFF9E9E9E)
+// 파스텔 색상 순위: 1위(핑크) → 4위(라벤더) — Figma 2249:13964.
+private val ColorRank1 = Color(0xFFFFCFCF)
+private val ColorRank2 = Color(0xFFFFF7CF)
+private val ColorRank3 = Color(0xFFCFEDFF)
+private val ColorRank4 = Color(0xFFFFE0FB)
 
-// 0건 안내용 빈 검은 원.
-private val EMPTY_SLOT =
-    BubbleSlot(size = 96.dp, offsetX = 112.dp, offsetY = 15.dp, color = ColorRank1)
+// 0건 안내용 점선 원 — Figma 2249:14023.
+private val EMPTY_SIZE = 96.dp
+private val EMPTY_OFFSET_X = 112.dp
+private val EMPTY_OFFSET_Y = 15.dp
 
 private fun slotsFor(count: Int): List<BubbleSlot> =
     when (count) {
@@ -217,7 +296,7 @@ private fun EmotionKeywordCardPreview4() {
                     EmotionKeyword("사랑", 8),
                     EmotionKeyword("그리움", 8),
                 ),
-            descriptionText = "이번 주 박서연 님의 기록에서는 '가족'을 위한 '감사'의 마음이 엿보입니다.",
+            insightText = "이번 주는 가족과 함께하는 시간을 가장 많이 기록하셨네요. 일상의 소중함을 느끼는 한 주였던 것 같아요.",
         )
     }
 }
@@ -228,7 +307,7 @@ private fun EmotionKeywordCardPreview1() {
     AfternoteTheme {
         EmotionKeywordCard(
             keywords = listOf(EmotionKeyword("가족", 8)),
-            descriptionText = "이번 주 박서연 님의 기록에서는 '가족'의 마음이 엿보입니다.",
+            insightText = "이번 주는 가족과 함께하는 시간을 가장 많이 기록하셨네요.",
         )
     }
 }
@@ -239,7 +318,7 @@ private fun EmotionKeywordCardPreview0() {
     AfternoteTheme {
         EmotionKeywordCard(
             keywords = emptyList(),
-            descriptionText = "이번 주 박서연 님의 기록에서는 키워드가 나오지 않았어요.",
+            insightText = "이번 주 박서연 님의 기록에서는 키워드가 나오지 않았어요.",
         )
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/KeyBoardToolBar.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/KeyBoardToolBar.kt
@@ -36,6 +36,13 @@ import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.model.TextStyleState
 import com.afternote.feature.mindrecord.presentation.model.TextStyleType
 
+/**
+ * 작성 화면 하단 고정 툴바.
+ *
+ * Figma `nav_daily_write` (2372:22759) 리디자인 반영 — 링크 첨부 아이콘과 임시저장 카운터만 노출한다.
+ * [onTextStyleClick]/[onAlignChange] 는 기존 콜사이트 호환을 위해 시그니처에 유지한다.
+ */
+@Suppress("UNUSED_PARAMETER")
 @Composable
 fun BottomToolbar(
     onTextStyleClick: () -> Unit,
@@ -46,66 +53,46 @@ fun BottomToolbar(
     onDraftCountClick: () -> Unit = {},
     draftCount: Int = 0,
 ) {
-    Row(
+    Column(
         modifier =
             modifier
                 .fillMaxWidth()
-                .background(AfternoteDesign.colors.white)
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-        verticalAlignment = Alignment.CenterVertically,
+                .background(AfternoteDesign.colors.gray1),
     ) {
-        IconButton(onClick = onLinkClick) {
-            Icon(
-                painter = painterResource(com.afternote.core.ui.R.drawable.core_ui_ic_link),
-                contentDescription = stringResource(R.string.mindrecord_toolbar_link_cd),
-            )
-        }
-        Spacer(modifier = Modifier.width(8.dp))
+        HorizontalDivider(thickness = 1.dp, color = AfternoteDesign.colors.gray3)
 
-        IconButton(onClick = onTextStyleClick) {
-            Text(
-                text = "T",
-                style = AfternoteDesign.typography.bodyLargeB,
-                color = AfternoteDesign.colors.gray9,
-            )
-        }
-        Spacer(modifier = Modifier.width(8.dp))
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(onClick = onLinkClick) {
+                Icon(
+                    painter = painterResource(com.afternote.core.ui.R.drawable.core_ui_ic_link),
+                    contentDescription = stringResource(R.string.mindrecord_toolbar_link_cd),
+                    tint = AfternoteDesign.colors.gray9,
+                )
+            }
 
-        IconButton(onClick = { onAlignChange(TextAlign.Start) }) {
-            Icon(
-                painter = painterResource(R.drawable.mindrecord_align_left),
-                contentDescription = stringResource(R.string.mindrecord_toolbar_align_left_cd),
-            )
-        }
-        IconButton(onClick = { onAlignChange(TextAlign.Center) }) {
-            Icon(
-                painter = painterResource(R.drawable.mindrecord_align_center),
-                contentDescription = stringResource(R.string.mindrecord_toolbar_align_center_cd),
-            )
-        }
-        IconButton(onClick = { onAlignChange(TextAlign.End) }) {
-            Icon(
-                painter = painterResource(R.drawable.mindrecord_align_right),
-                contentDescription = stringResource(R.string.mindrecord_toolbar_align_right_cd),
-            )
-        }
+            Spacer(modifier = Modifier.weight(1f))
 
-        Spacer(modifier = Modifier.weight(1f))
-
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                text = stringResource(R.string.mindrecord_toolbar_draft_label),
-                style = AfternoteDesign.typography.captionLargeR,
-                color = AfternoteDesign.colors.gray6,
-                modifier = Modifier.clickable(onClick = onSaveDraftClick),
-            )
-            Spacer(modifier = Modifier.width(4.dp))
-            Text(
-                text = draftCount.toString(),
-                style = AfternoteDesign.typography.captionLargeR,
-                color = AfternoteDesign.colors.gray4,
-                modifier = Modifier.clickable(onClick = onDraftCountClick),
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = stringResource(R.string.mindrecord_toolbar_draft_label),
+                    style = AfternoteDesign.typography.bodySmallB,
+                    color = AfternoteDesign.colors.gray6,
+                    modifier = Modifier.clickable(onClick = onSaveDraftClick),
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    text = draftCount.toString(),
+                    style = AfternoteDesign.typography.bodySmallB,
+                    color = AfternoteDesign.colors.gray4,
+                    modifier = Modifier.clickable(onClick = onDraftCountClick),
+                )
+            }
         }
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/RecipientSelectBottomSheet.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/RecipientSelectBottomSheet.kt
@@ -1,0 +1,207 @@
+package com.afternote.feature.mindrecord.presentation.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateSetOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.afternote.core.model.user.Receiver
+import com.afternote.core.ui.theme.AfternoteDesign
+import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.core.ui.R as CoreUiR
+
+/**
+ * 작성 화면의 "수신자 설정하기" 에서 호출되는 수신자 다중 선택 바텀시트.
+ *
+ * `GET /users/receivers` 로 불러온 수신자 목록에서 기록을 전달할 대상을 고르고,
+ * 선택 결과는 작성 API 의 `receiverIds` 로 전송된다.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RecipientSelectBottomSheet(
+    receivers: List<Receiver>,
+    selectedIds: Set<Long>,
+    onConfirm: (Set<Long>) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val checkedIds = remember { mutableStateSetOf<Long>().apply { addAll(selectedIds) } }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = AfternoteDesign.colors.gray1,
+        modifier = modifier,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .padding(bottom = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = "수신자 선택",
+                style = AfternoteDesign.typography.bodyLargeB,
+                color = AfternoteDesign.colors.gray9,
+            )
+
+            if (receivers.isEmpty()) {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 32.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "등록된 수신자가 없어요.\n설정에서 수신자를 먼저 등록해주세요.",
+                        style = AfternoteDesign.typography.bodySmallR,
+                        color = AfternoteDesign.colors.gray6,
+                    )
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.heightIn(max = 360.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    items(receivers, key = { it.receiverId }) { receiver ->
+                        RecipientSelectRow(
+                            receiver = receiver,
+                            checked = receiver.receiverId in checkedIds,
+                            onToggle = {
+                                if (!checkedIds.add(receiver.receiverId)) {
+                                    checkedIds.remove(receiver.receiverId)
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+
+            Button(
+                onClick = { onConfirm(checkedIds.toSet()) },
+                shape = RoundedCornerShape(6.dp),
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = AfternoteDesign.colors.gray9,
+                        contentColor = AfternoteDesign.colors.white,
+                    ),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(44.dp),
+            ) {
+                Text(
+                    text = "선택 완료",
+                    style = AfternoteDesign.typography.bodySmallB,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecipientSelectRow(
+    receiver: Receiver,
+    checked: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(6.dp))
+                .clickable(onClick = onToggle)
+                .padding(vertical = 12.dp, horizontal = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RecipientCheckCircle(checked = checked)
+        Text(
+            text = receiver.name,
+            style = AfternoteDesign.typography.bodyBase,
+            color = AfternoteDesign.colors.gray9,
+        )
+        Text(
+            text = receiver.relation,
+            style = AfternoteDesign.typography.captionLargeR,
+            color = AfternoteDesign.colors.gray6,
+        )
+    }
+}
+
+@Composable
+private fun RecipientCheckCircle(
+    checked: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .size(20.dp)
+                .clip(CircleShape)
+                .then(
+                    if (checked) {
+                        Modifier.background(AfternoteDesign.colors.gray9)
+                    } else {
+                        Modifier.border(width = 1.5.dp, color = AfternoteDesign.colors.gray4, shape = CircleShape)
+                    },
+                ),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (checked) {
+            Icon(
+                painter = painterResource(CoreUiR.drawable.core_ui_ic_check),
+                contentDescription = null,
+                tint = AfternoteDesign.colors.white,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RecipientSelectBottomSheetRowPreview() {
+    AfternoteTheme {
+        Column {
+            RecipientSelectRow(
+                receiver = Receiver(receiverId = 1L, name = "박채연", relation = "딸", authCode = ""),
+                checked = true,
+                onToggle = {},
+            )
+            RecipientSelectRow(
+                receiver = Receiver(receiverId = 2L, name = "김민수", relation = "아들", authCode = ""),
+                checked = false,
+                onToggle = {},
+            )
+        }
+    }
+}

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyModelCalendar.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyModelCalendar.kt
@@ -1,6 +1,5 @@
 package com.afternote.feature.mindrecord.presentation.component
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -12,27 +11,29 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R
-import com.afternote.feature.mindrecord.presentation.model.DayBackground
 import com.afternote.feature.mindrecord.presentation.model.DayContent
 import com.afternote.feature.mindrecord.presentation.model.DayItem
 import java.time.DayOfWeek
 
-@OptIn(ExperimentalMaterial3Api::class)
+/**
+ * 주간 리포트의 요일별 기록 캘린더 — Figma 852:11580.
+ *
+ * 상단 그라데이션 디바이더(가운데 4dp 핸들) + 요일/날짜 7열.
+ * 날짜 셀: 미기록(gray5 숫자) / 일기 기록(gray9 숫자 + 점) / 감정 기록(gray9 숫자 + 이모지).
+ */
 @Composable
 fun WeeklyMoodCalendar(
     modifier: Modifier = Modifier,
@@ -42,13 +43,39 @@ fun WeeklyMoodCalendar(
         modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        // 상단 슬라이더
-        Image(
-            painter = painterResource(R.drawable.mindrecord_div),
-            contentDescription = null,
-        )
+        // 상단 디바이더 — 양끝 투명 그라데이션 라인 + 가운데 4dp 핸들.
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(4.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .background(
+                            Brush.horizontalGradient(
+                                listOf(
+                                    Color.Transparent,
+                                    AfternoteDesign.colors.black.copy(alpha = 0.1f),
+                                    Color.Transparent,
+                                ),
+                            ),
+                        ),
+            )
+            Box(
+                modifier =
+                    Modifier
+                        .size(4.dp)
+                        .clip(CircleShape)
+                        .background(AfternoteDesign.colors.black.copy(alpha = 0.2f)),
+            )
+        }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
         // 요일 + 날짜 그리드
         Row(
@@ -67,32 +94,21 @@ private fun DayCell(
     dayItem: DayItem,
     modifier: Modifier = Modifier,
 ) {
-    val bgColor =
-        when (dayItem.background) {
-            DayBackground.Green -> Color(0xFFCCE3D3)
-            DayBackground.Pink -> Color(0xFFF5DBDB)
-            DayBackground.None -> Color.Transparent
-        }
-
     Column(
         modifier = modifier.width(40.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        // 요일 텍스트
+        // 요일 텍스트 — 10sp gray8.
         Text(
             text = stringResource(dayOfWeekLabelRes(dayItem.dayOfWeek)),
-            color = AfternoteDesign.colors.gray5,
-            style = AfternoteDesign.typography.captionLargeR,
+            color = AfternoteDesign.colors.gray8,
+            style = AfternoteDesign.typography.footnoteCaption,
         )
 
-        // 날짜/이모지 셀
+        // 날짜 셀 — 40dp 원형 영역 (배경 없음).
         Box(
-            modifier =
-                Modifier
-                    .size(38.dp)
-                    .clip(CircleShape)
-                    .background(bgColor),
+            modifier = Modifier.size(40.dp),
             contentAlignment = Alignment.Center,
         ) {
             when (val content = dayItem.content) {
@@ -100,21 +116,12 @@ private fun DayCell(
                     Text(
                         text = content.day.toString(),
                         style = AfternoteDesign.typography.captionLargeB,
-                        color = AfternoteDesign.colors.gray6,
+                        color = AfternoteDesign.colors.gray5,
                     )
                 }
 
                 is DayContent.NumberWithDot -> {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.Center,
-                    ) {
-                        Text(
-                            text = content.day.toString(),
-                            style = AfternoteDesign.typography.captionLargeB,
-                            color = AfternoteDesign.colors.gray9,
-                        )
-                        Spacer(modifier = Modifier.height(1.dp))
+                    NumberWithBadge(day = content.day) {
                         Box(
                             modifier =
                                 Modifier
@@ -126,33 +133,42 @@ private fun DayCell(
                 }
 
                 is DayContent.EmojiWithDot -> {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.Center,
-                    ) {
+                    NumberWithBadge(day = content.day) {
                         Text(
                             text = content.emoji,
-                            fontSize = 20.sp,
-                        )
-                        Spacer(modifier = Modifier.height(1.dp))
-                        Box(
-                            modifier =
-                                Modifier
-                                    .size(4.dp)
-                                    .clip(CircleShape)
-                                    .background(AfternoteDesign.colors.gray8),
+                            style = AfternoteDesign.typography.footnoteCaption,
                         )
                     }
                 }
 
                 is DayContent.EmojiOnly -> {
-                    Text(
-                        text = content.emoji,
-                        fontSize = 20.sp,
-                    )
+                    NumberWithBadge(day = content.day) {
+                        Text(
+                            text = content.emoji,
+                            style = AfternoteDesign.typography.footnoteCaption,
+                        )
+                    }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun NumberWithBadge(
+    day: Int,
+    badge: @Composable () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(1.dp),
+    ) {
+        Text(
+            text = day.toString(),
+            style = AfternoteDesign.typography.captionLargeB,
+            color = AfternoteDesign.colors.gray9,
+        )
+        badge()
     }
 }
 
@@ -171,12 +187,12 @@ private fun dayOfWeekLabelRes(dayOfWeek: DayOfWeek): Int =
 private fun defaultPreviewDays(): List<DayItem> =
     listOf(
         DayItem(DayOfWeek.MONDAY, DayContent.NumberOnly(10)),
-        DayItem(DayOfWeek.TUESDAY, DayContent.NumberWithDot(2)),
+        DayItem(DayOfWeek.TUESDAY, DayContent.NumberWithDot(11)),
         DayItem(DayOfWeek.WEDNESDAY, DayContent.NumberOnly(12)),
-        DayItem(DayOfWeek.THURSDAY, DayContent.EmojiWithDot("😊"), DayBackground.Green),
-        DayItem(DayOfWeek.FRIDAY, DayContent.EmojiOnly("😊"), DayBackground.Green),
-        DayItem(DayOfWeek.SATURDAY, DayContent.NumberWithDot(2)),
-        DayItem(DayOfWeek.SUNDAY, DayContent.EmojiOnly("🥹"), DayBackground.Pink),
+        DayItem(DayOfWeek.THURSDAY, DayContent.EmojiWithDot(13, "😢")),
+        DayItem(DayOfWeek.FRIDAY, DayContent.EmojiWithDot(14, "😢")),
+        DayItem(DayOfWeek.SATURDAY, DayContent.NumberWithDot(15)),
+        DayItem(DayOfWeek.SUNDAY, DayContent.EmojiOnly(16, "😢")),
     )
 
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyReportReviewCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WeeklyReportReviewCard.kt
@@ -1,16 +1,16 @@
 package com.afternote.feature.mindrecord.presentation.component
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -31,8 +31,10 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R
@@ -40,6 +42,12 @@ import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
 import com.afternote.feature.mindrecord.presentation.viewmodel.WeekOption
 import java.time.LocalDate
 
+/**
+ * 주간 리포트 상단 "WEEKLY SUMMARY" 카드 — Figma 852:11546.
+ *
+ * 라디얼 그라데이션 배경 위에 주차 드롭다운·날짜 범위, 그리고
+ * 그라데이션 디바이더 아래 데일리 질문/일기/깊은 생각 카운트 3열.
+ */
 @Composable
 fun WeeklyReportReviewCard(
     modifier: Modifier = Modifier,
@@ -50,7 +58,7 @@ fun WeeklyReportReviewCard(
     counts: List<Pair<Int, MindRecordCategoryUi>> =
         listOf(
             5 to MindRecordCategoryUi.DailyQuestion,
-            4 to MindRecordCategoryUi.Diary,
+            6 to MindRecordCategoryUi.Diary,
             3 to MindRecordCategoryUi.DeepThought,
         ),
 ) {
@@ -65,118 +73,144 @@ fun WeeklyReportReviewCard(
         modifier =
             modifier
                 .fillMaxWidth()
-                .height(200.dp)
-                .clip(RoundedCornerShape(6.dp)),
+                .clip(RoundedCornerShape(8.dp)),
+        shape = RoundedCornerShape(8.dp),
     ) {
         Column(
             modifier =
                 Modifier
-                    .fillMaxSize()
+                    .fillMaxWidth()
                     .drawWithCache {
                         val brush =
                             Brush.radialGradient(
                                 colorStops =
                                     arrayOf(
-                                        0.0f to Color(0xFFB7C4CD).copy(alpha = 0.9f),
+                                        0.0f to Color(0xFFB7C4CD).copy(alpha = 0.3f),
                                         1.0f to Color(0xFFF8F8F7),
                                     ),
                                 center = Offset(size.width / 2f, size.height / 2f),
-                                radius = size.height * 3f,
+                                radius = size.width * 0.6f,
                             )
                         onDrawBehind { drawRect(brush) }
-                    }.padding(20.dp),
+                    }.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp),
         ) {
             Row(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                Text(
-                    text = "WEEKLY SUMMARY",
-                    style = AfternoteDesign.typography.mono,
-                    color = AfternoteDesign.colors.black.copy(alpha = 0.3f),
-                )
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = "WEEKLY SUMMARY",
+                        style = AfternoteDesign.typography.mono,
+                        color = AfternoteDesign.colors.gray6,
+                    )
+
+                    // Box로 감싸서 DropdownMenu 앵커 잡기
+                    Box {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            modifier = Modifier.clickable { expanded = true },
+                        ) {
+                            Text(
+                                text = selectedLabel,
+                                style = AfternoteDesign.typography.h2.copy(fontWeight = FontWeight.Normal),
+                                color = AfternoteDesign.colors.gray9,
+                            )
+                            Icon(
+                                painter = painterResource(com.afternote.core.ui.R.drawable.core_ui_arrowdown),
+                                contentDescription = null,
+                                tint = AfternoteDesign.colors.black.copy(alpha = 0.3f),
+                            )
+                        }
+
+                        DropdownMenu(
+                            expanded = expanded,
+                            onDismissRequest = { expanded = false },
+                            containerColor = Color.White,
+                        ) {
+                            weekOptions.forEach { option ->
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(
+                                            text = weekLabel(option.monday),
+                                            style = AfternoteDesign.typography.h3,
+                                            color =
+                                                if (option.monday == selectedMonday) {
+                                                    AfternoteDesign.colors.black.copy(alpha = 0.9f)
+                                                } else {
+                                                    AfternoteDesign.colors.black.copy(alpha = 0.3f)
+                                                },
+                                        )
+                                    },
+                                    onClick = {
+                                        expanded = false
+                                        if (option.monday != selectedMonday) {
+                                            onWeekSelect(option.monday)
+                                        }
+                                    },
+                                )
+                            }
+                        }
+                    }
+
+                    Text(
+                        text = dateRange,
+                        style = AfternoteDesign.typography.bodySmallR,
+                        color = AfternoteDesign.colors.gray6,
+                    )
+                }
+
                 Icon(
                     painter = painterResource(R.drawable.mindrecord_up),
                     contentDescription = null,
-                    tint = Color(0xFF000000).copy(0.3f),
+                    tint = AfternoteDesign.colors.black.copy(alpha = 0.3f),
+                    modifier = Modifier.size(24.dp),
                 )
             }
 
-            Spacer(modifier = Modifier.height(10.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                // 양끝 투명 그라데이션 디바이더
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(1.dp)
+                            .background(
+                                Brush.horizontalGradient(
+                                    listOf(
+                                        Color.Transparent,
+                                        AfternoteDesign.colors.black.copy(alpha = 0.1f),
+                                        Color.Transparent,
+                                    ),
+                                ),
+                            ),
+                )
 
-            // ✅ Box로 감싸서 DropdownMenu 앵커 잡기
-            Box {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.clickable { expanded = true },
-                ) {
-                    Text(
-                        text = selectedLabel,
-                        style = AfternoteDesign.typography.h2,
-                        color = AfternoteDesign.colors.black.copy(alpha = 0.9f),
-                    )
-                    Icon(
-                        painter = painterResource(com.afternote.core.ui.R.drawable.core_ui_arrowdown),
-                        contentDescription = null,
-                        tint = Color(0xFF000000).copy(0.3f),
-                    )
-                }
-
-                DropdownMenu(
-                    expanded = expanded,
-                    onDismissRequest = { expanded = false },
-                    containerColor = Color.White,
-                ) {
-                    weekOptions.forEach { option ->
-                        DropdownMenuItem(
-                            text = {
-                                Text(
-                                    text = weekLabel(option.monday),
-                                    style = AfternoteDesign.typography.h3,
-                                    color =
-                                        if (option.monday == selectedMonday) {
-                                            AfternoteDesign.colors.black.copy(alpha = 0.9f)
-                                        } else {
-                                            AfternoteDesign.colors.black.copy(alpha = 0.3f)
-                                        },
-                                )
-                            },
-                            onClick = {
-                                expanded = false
-                                if (option.monday != selectedMonday) {
-                                    onWeekSelect(option.monday)
-                                }
-                            },
-                        )
-                    }
-                }
-            }
-
-            Spacer(modifier = Modifier.height(10.dp))
-
-            Text(
-                text = dateRange,
-                style = AfternoteDesign.typography.bodySmallR,
-                color = AfternoteDesign.colors.gray6,
-            )
-
-            Spacer(modifier = Modifier.height(33.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                counts.forEach { (count, category) ->
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text(
-                            text = count.toString(),
-                            color = AfternoteDesign.colors.black.copy(alpha = 0.9f),
-                        )
-                        Text(
-                            text = stringResource(category.titleRes),
-                            color = AfternoteDesign.colors.black.copy(alpha = 0.4f),
-                            style = AfternoteDesign.typography.captionLargeR,
-                        )
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    counts.forEach { (count, category) ->
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Text(
+                                text = count.toString(),
+                                style =
+                                    AfternoteDesign.typography.inter.copy(
+                                        fontWeight = FontWeight.Light,
+                                        fontSize = 24.sp,
+                                        lineHeight = 36.sp,
+                                    ),
+                                color = AfternoteDesign.colors.gray9,
+                            )
+                            Text(
+                                text = stringResource(category.titleRes),
+                                color = AfternoteDesign.colors.gray6,
+                                style = AfternoteDesign.typography.footnoteCaption,
+                            )
+                        }
                     }
                 }
             }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WriteTextField.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/WriteTextField.kt
@@ -4,15 +4,18 @@ import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -22,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
@@ -48,6 +52,10 @@ import com.mohamedrejeb.richeditor.ui.BasicRichTextEditor
  * - 외부에서 받은 [value] 는 초기 시드 HTML 로만 사용된다 (이후 외부 업데이트는 무시).
  * - 사용자 입력이 발생하면 [onValueChange] 로 직렬화된 HTML 문자열을 emit 한다.
  *   서버 페이로드의 `content` 필드에 그대로 실어 보내면 된다.
+ *
+ * @param contentPadding 에디터 카드 바깥 여백. 화면 좌우 마진(예: 20dp)을 카드에만 적용하고
+ *   하단 툴바는 풀-블리드로 유지하고 싶을 때 사용한다.
+ * @param bottomContent 에디터 카드와 하단 툴바 사이에 렌더링되는 슬롯. 키보드가 올라오면 숨겨진다.
  */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -58,6 +66,8 @@ fun WriteTextField(
     onSaveDraftClick: () -> Unit = {},
     onDraftCountClick: () -> Unit = {},
     draftCount: Int = 0,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    bottomContent: (@Composable () -> Unit)? = null,
 ) {
     val state = rememberRichTextState()
 
@@ -125,8 +135,11 @@ fun WriteTextField(
                 Modifier
                     .weight(1f)
                     .fillMaxWidth()
+                    .padding(contentPadding)
                     .padding(bottom = 16.dp)
-                    .background(color = AfternoteDesign.colors.white),
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(color = AfternoteDesign.colors.white)
+                    .border(1.dp, AfternoteDesign.colors.gray2, RoundedCornerShape(6.dp)),
         ) {
             BasicRichTextEditor(
                 state = state,
@@ -134,23 +147,29 @@ fun WriteTextField(
                     Modifier
                         .fillMaxSize()
                         .focusRequester(editorFocusRequester)
-                        .padding(16.dp),
+                        .padding(horizontal = 16.dp, vertical = 20.dp),
             )
             if (state.annotatedString.text.isEmpty()) {
                 Text(
                     text = stringResource(R.string.mindrecord_write_field_placeholder),
+                    style = AfternoteDesign.typography.textField,
                     color = AfternoteDesign.colors.gray4,
-                    modifier = Modifier.padding(16.dp),
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 20.dp),
                 )
             }
             Text(
                 text = stringResource(R.string.mindrecord_write_field_character_count, state.annotatedString.text.length),
-                color = AfternoteDesign.colors.gray4,
+                style = AfternoteDesign.typography.footnoteCaption,
+                color = AfternoteDesign.colors.gray5,
                 modifier =
                     Modifier
                         .align(Alignment.BottomEnd)
                         .padding(16.dp),
             )
+        }
+
+        if (bottomContent != null && !imeVisible) {
+            bottomContent()
         }
 
         if (showTextStyleToolbar && imeVisible) {

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/hometab/HomeTabDailyQuestionCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/hometab/HomeTabDailyQuestionCard.kt
@@ -1,0 +1,158 @@
+package com.afternote.feature.mindrecord.presentation.component.hometab
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.afternote.core.ui.icon.RightArrowIcon
+import com.afternote.core.ui.theme.AfternoteDesign
+import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R.string.mindrecord_daily_question_default_today
+import com.afternote.feature.mindrecord.presentation.R.string.mindrecord_today_question_answer_cta
+import com.afternote.feature.mindrecord.presentation.R.string.mindrecord_today_question_header
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+private val CardShape = RoundedCornerShape(8.dp)
+private val ButtonShape = RoundedCornerShape(6.dp)
+
+/** 카드 배경 라디얼 그라데이션 — 하단 중앙의 그린 글로우가 가장자리 오프화이트로 퍼진다. */
+private val GradientCenterColor = Color(0xFFB7CDC0)
+private val GradientEdgeColor = Color(0xFFF8F8F7)
+
+/** Figma drop shadow: 0 2 2.5 rgba(0,0,0,0.05) */
+private val CardShadowColor = Color(0x0D000000)
+
+private val DateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+
+/**
+ * 홈 탭 전용 Daily Q&A 카드.
+ * 오늘의 질문·날짜와 함께 데일리질문 답변 CTA 버튼을 보여준다.
+ */
+@Composable
+fun HomeTabDailyQuestionCard(
+    onAnswerClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    dateText: String? = null,
+    questionText: String = stringResource(mindrecord_daily_question_default_today),
+) {
+    val resolvedDateText =
+        dateText ?: remember { LocalDate.now().format(DateFormatter) }
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .shadow(
+                    elevation = 2.dp,
+                    shape = CardShape,
+                    ambientColor = CardShadowColor,
+                    spotColor = CardShadowColor,
+                ).clip(CardShape)
+                .drawBehind {
+                    if (size.width > 0f) {
+                        drawRect(
+                            brush =
+                                Brush.radialGradient(
+                                    colors = listOf(GradientCenterColor, GradientEdgeColor),
+                                    center = Offset(x = size.width / 2f, y = size.height),
+                                    radius = size.width * 0.69f,
+                                ),
+                        )
+                    }
+                }.padding(30.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(mindrecord_today_question_header),
+                style =
+                    AfternoteDesign.typography.mono.copy(
+                        fontSize = 10.sp,
+                        lineHeight = 15.sp,
+                    ),
+                color = AfternoteDesign.colors.gray6,
+            )
+            Text(
+                text = resolvedDateText,
+                style = AfternoteDesign.typography.mono,
+                color = AfternoteDesign.colors.gray6,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = questionText,
+            style =
+                AfternoteDesign.typography.h3.copy(
+                    lineHeight = 30.sp,
+                ),
+            color = AfternoteDesign.colors.gray9,
+        )
+
+        Spacer(modifier = Modifier.height(18.dp))
+
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(44.dp)
+                    .clip(ButtonShape)
+                    .background(AfternoteDesign.colors.gray9)
+                    .clickable(role = Role.Button, onClick = onAnswerClick),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(mindrecord_today_question_answer_cta),
+                style = AfternoteDesign.typography.bodySmallB.copy(fontSize = 13.sp),
+                color = AfternoteDesign.colors.white,
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            RightArrowIcon(
+                modifier = Modifier.size(width = 7.dp, height = 12.dp),
+                tint = AfternoteDesign.colors.white,
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+private fun HomeTabDailyQuestionCardPreview() {
+    AfternoteTheme {
+        HomeTabDailyQuestionCard(
+            modifier = Modifier.padding(16.dp),
+            onAnswerClick = {},
+            dateText = "2026.04.04",
+        )
+    }
+}

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/hometab/RecordCategoryCard.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/component/hometab/RecordCategoryCard.kt
@@ -112,6 +112,7 @@ fun RecordCategoryCard(
         Spacer(modifier = Modifier.height(8.dp))
 
         Text(
+            modifier = Modifier.padding(start = 4.dp),
             text = subtitle,
             style = AfternoteDesign.typography.captionLargeR,
             color = AfternoteDesign.colors.gray5,

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/hometab/HomeTabMindRecordLazyItems.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/hometab/HomeTabMindRecordLazyItems.kt
@@ -23,7 +23,7 @@ import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R.string.mindrecord_home_tab_memories_section_click_label
 import com.afternote.feature.mindrecord.presentation.R.string.mindrecord_home_tab_memories_section_title
 import com.afternote.feature.mindrecord.presentation.component.MemoriesCard
-import com.afternote.feature.mindrecord.presentation.component.TodayQuestionCard
+import com.afternote.feature.mindrecord.presentation.component.hometab.HomeTabDailyQuestionCard
 import com.afternote.feature.mindrecord.presentation.component.hometab.RecordCategoryCard
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
 import com.afternote.core.ui.R as CoreUiR
@@ -38,7 +38,7 @@ fun LazyListScope.homeTabMindRecordQuestionAndCategories(
     isCategoryCountLoading: Boolean = false,
 ) {
     item(key = "mind_record_question") {
-        TodayQuestionCard(
+        HomeTabDailyQuestionCard(
             onAnswerClick = onAnswerClick,
         )
         Spacer(modifier = Modifier.height(8.dp))

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/mapper/MindRecordUiMapper.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/mapper/MindRecordUiMapper.kt
@@ -28,13 +28,16 @@ fun DailyQuestionDomain.toUi(): DailyQuestion =
         title = title,
         date = parseLocalDate(createdAt),
         content = content,
+        receiverNames = receivers.map { it.name },
+        imageUrl = imageUrl,
     )
 
 fun Diary.toUi(): DailyDiary =
     DailyDiary(
         id = diaryId,
         title = title,
-        date = parseLocalDate(createdAt),
+        // 명세의 `date` (작성일) 우선, 없으면 createdAt 으로 폴백.
+        date = parseLocalDate(date ?: createdAt),
         content = content,
         emotion = todayMood.toEmoji(),
     )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/model/DailyQuestion.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/model/DailyQuestion.kt
@@ -7,4 +7,6 @@ data class DailyQuestion(
     val title: String,
     val date: LocalDate,
     val content: String,
+    val receiverNames: List<String> = emptyList(),
+    val imageUrl: String? = null,
 )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/model/DayContent.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/model/DayContent.kt
@@ -12,12 +12,14 @@ sealed class DayContent {
     ) : DayContent() // 숫자 + 하단 점
 
     data class EmojiWithDot(
+        val day: Int,
         val emoji: String,
-    ) : DayContent() // 이모지 + 하단 점
+    ) : DayContent() // 숫자 + 하단 이모지 (일기 기록됨)
 
     data class EmojiOnly(
+        val day: Int,
         val emoji: String,
-    ) : DayContent() // 이모지만 (dot 없음)
+    ) : DayContent() // 숫자 + 하단 이모지 (일기 없음)
 }
 
 // 배경 원형 색상 타입

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/model/DayState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/model/DayState.kt
@@ -2,6 +2,7 @@ package com.afternote.feature.mindrecord.presentation.model
 
 enum class DayState {
     TODAY,
+    SELECTED,
     ANSWERED,
     UNANSWERED,
     NONE,

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/model/DayUiModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/model/DayUiModel.kt
@@ -4,4 +4,5 @@ data class DayUiModel(
     val day: Int?,
     val state: DayState = DayState.NONE,
     val emotion: String? = null,
+    val isToday: Boolean = false,
 )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionAnswerListScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionAnswerListScreen.kt
@@ -2,16 +2,13 @@ package com.afternote.feature.mindrecord.presentation.screen.sender
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -20,7 +17,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -28,16 +24,14 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.asString
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
-import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.component.DailyCalendar
 import com.afternote.feature.mindrecord.presentation.component.DailyQuestionListCard
-import com.afternote.feature.mindrecord.presentation.component.DailyQuestionWriteHeaderCard
 import com.afternote.feature.mindrecord.presentation.component.MindRecordEmptyState
 import com.afternote.feature.mindrecord.presentation.model.DailyQuestion
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
 import com.afternote.feature.mindrecord.presentation.viewmodel.DailyQuestionListUiState
 import com.afternote.feature.mindrecord.presentation.viewmodel.DailyQuestionListViewModel
-import com.afternote.feature.mindrecord.presentation.viewmodel.TodayQuestionUi
+import java.time.LocalDate
 import java.time.YearMonth
 
 @Composable
@@ -61,7 +55,6 @@ fun DailyQuestionAnswerListScreen(
             DailyQuestionListContent(
                 modifier = modifier,
                 isListView = isListView,
-                todayQuestion = state.todayQuestion,
                 answers = state.answers,
                 onDelete = viewModel::delete,
             )
@@ -72,64 +65,74 @@ fun DailyQuestionAnswerListScreen(
 @Composable
 private fun DailyQuestionListContent(
     isListView: Boolean,
-    todayQuestion: TodayQuestionUi?,
     answers: List<DailyQuestion>,
     modifier: Modifier = Modifier,
     onDelete: (Long) -> Unit = {},
 ) {
-    var yearMonth by remember { mutableStateOf(YearMonth.now()) }
-    val onYearMonthChanged: (YearMonth) -> Unit = { yearMonth = it }
+    if (isListView) {
+        // Figma 2757:16116 — 리스트 형: 답변 카드만 8dp 간격으로 나열
+        if (answers.isEmpty()) {
+            MindRecordEmptyState(modifier = modifier)
+            return
+        }
 
-    if (isListView && todayQuestion == null && answers.isEmpty()) {
-        MindRecordEmptyState(modifier = modifier)
-        return
-    }
-
-    val headerText = todayQuestion?.content ?: stringResource(R.string.mindrecord_daily_question_write_none)
-
-    LazyColumn(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        if (isListView) {
-            item { DailyQuestionWriteHeaderCard(questionText = headerText) }
+        LazyColumn(
+            modifier = modifier,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
             items(answers, key = { it.id }) { answer ->
-                DailyQuestionListCard(answer = answer, onDelete = { onDelete(answer.id) })
+                DailyQuestionListCard(
+                    answer = answer,
+                    recipientNames = answer.receiverNames.takeIf { it.isNotEmpty() }?.joinToString(", "),
+                    imageUrl = answer.imageUrl,
+                    onDelete = { onDelete(answer.id) },
+                )
             }
-        } else {
-            val answeredDays =
-                answers
-                    .filter { it.date.year == yearMonth.year && it.date.monthValue == yearMonth.monthValue }
-                    .map { it.date.dayOfMonth }
-                    .toSet()
+        }
+    } else {
+        // Figma 2671:16704 / 2671:16718 — 캘린더 형: 캘린더 + 선택한 날짜의 답변 카드
+        var yearMonth by remember { mutableStateOf(YearMonth.now()) }
+        var selectedDay by remember { mutableStateOf<Int?>(null) }
+
+        val monthAnswers =
+            answers.filter { it.date.year == yearMonth.year && it.date.monthValue == yearMonth.monthValue }
+        val answeredDays = monthAnswers.map { it.date.dayOfMonth }.toSet()
+        val visibleAnswers =
+            selectedDay?.let { day -> monthAnswers.filter { it.date.dayOfMonth == day } } ?: monthAnswers
+
+        LazyColumn(
+            modifier = modifier,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
             item {
                 DailyCalendar(
                     year = yearMonth.year,
                     month = yearMonth.monthValue,
                     type = MindRecordCategoryUi.DailyQuestion,
-                    onPrevMonth = { onYearMonthChanged(yearMonth.minusMonths(1)) },
-                    onNextMonth = { onYearMonthChanged(yearMonth.plusMonths(1)) },
+                    onPrevMonth = {
+                        yearMonth = yearMonth.minusMonths(1)
+                        selectedDay = null
+                    },
+                    onNextMonth = {
+                        yearMonth = yearMonth.plusMonths(1)
+                        selectedDay = null
+                    },
                     answeredDays = answeredDays,
+                    selectedDay = selectedDay,
+                    onDayClick = { day ->
+                        selectedDay = if (selectedDay == day) null else day
+                    },
                 )
+                Spacer(modifier = Modifier.height(24.dp))
             }
 
-            item {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = "DAILY ANSWER",
-                        style = AfternoteDesign.typography.mono,
-                        color = AfternoteDesign.colors.black.copy(alpha = 0.4f),
-                    )
-                    HorizontalDivider(modifier = Modifier.padding(start = 12.dp))
-                }
-                Spacer(modifier = Modifier.height(10.dp))
-            }
-            item { DailyQuestionWriteHeaderCard(questionText = headerText) }
-            items(answers, key = { it.id }) { answer ->
-                DailyQuestionListCard(answer = answer, onDelete = { onDelete(answer.id) })
+            items(visibleAnswers, key = { it.id }) { answer ->
+                DailyQuestionListCard(
+                    answer = answer,
+                    recipientNames = answer.receiverNames.takeIf { it.isNotEmpty() }?.joinToString(", "),
+                    imageUrl = answer.imageUrl,
+                    onDelete = { onDelete(answer.id) },
+                )
             }
         }
     }
@@ -159,8 +162,15 @@ private fun DailyQuestionAnswerListScreenPreviewFalse() {
         DailyQuestionListContent(
             modifier = Modifier,
             isListView = false,
-            todayQuestion = null,
-            answers = emptyList(),
+            answers =
+                listOf(
+                    DailyQuestion(
+                        id = 1L,
+                        title = "오늘 하루, 누구에게 가장 고마웠나요?",
+                        content = "아무 말 없이 그저 나의 곁을 지켜주는 아내가 고맙다.",
+                        date = LocalDate.now(),
+                    ),
+                ),
         )
     }
 }
@@ -172,8 +182,15 @@ private fun DailyQuestionAnswerListScreenPreviewTrue() {
         DailyQuestionListContent(
             modifier = Modifier,
             isListView = true,
-            todayQuestion = null,
-            answers = emptyList(),
+            answers =
+                listOf(
+                    DailyQuestion(
+                        id = 1L,
+                        title = "오늘 하루, 누구에게 가장 고마웠나요?",
+                        content = "아무 말 없이 그저 나의 곁을 지켜주는 아내가 고맙다.",
+                        date = LocalDate.now(),
+                    ),
+                ),
         )
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionWriteScreen.kt
@@ -1,23 +1,40 @@
 package com.afternote.feature.mindrecord.presentation.screen.sender
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -28,12 +45,16 @@ import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.core.ui.theme.Red
 import com.afternote.core.ui.topbar.DetailTopBar
+import com.afternote.feature.mindrecord.domain.model.TodayMood
 import com.afternote.feature.mindrecord.presentation.R
-import com.afternote.feature.mindrecord.presentation.component.DailyQuestionWriteHeaderCard
+import com.afternote.feature.mindrecord.presentation.component.DailyQuestionRecommendCard
+import com.afternote.feature.mindrecord.presentation.component.RecipientSelectBottomSheet
 import com.afternote.feature.mindrecord.presentation.component.WriteTextField
 import com.afternote.feature.mindrecord.presentation.viewmodel.DailyQuestionWriteViewModel
 import com.afternote.feature.mindrecord.presentation.viewmodel.SubmitState
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import com.afternote.core.ui.R as CoreUiR
 
 @Composable
 fun DailyQuestionWriteScreen(
@@ -46,6 +67,12 @@ fun DailyQuestionWriteScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val currentOnSubmitSuccess by rememberUpdatedState(onSubmitSuccess)
 
+    // 백엔드 페이로드에 제목/기분 필드가 아직 없어 화면 로컬 상태로만 유지한다.
+    var title by rememberSaveable { mutableStateOf("") }
+    var selectedMood by rememberSaveable { mutableStateOf<TodayMood?>(null) }
+    var isQuestionExpanded by rememberSaveable { mutableStateOf(true) }
+    var showRecipientSheet by rememberSaveable { mutableStateOf(false) }
+
     LaunchedEffect(uiState.submitState) {
         if (uiState.submitState is SubmitState.Succeeded) {
             currentOnSubmitSuccess()
@@ -53,10 +80,14 @@ fun DailyQuestionWriteScreen(
         }
     }
 
+    val today = remember { LocalDate.now() }
+    val topBarDateText = remember(today) { today.format(DateTimeFormatter.ofPattern("yyyy.MM.dd")) }
+    val koreanDateText = remember(today) { today.format(DateTimeFormatter.ofPattern("yyyy년 M월 d일")) }
+
     Scaffold(
         topBar = {
             DetailTopBar(
-                title = LocalDate.now().toString(),
+                title = topBarDateText,
                 actions = {
                     Button(
                         onClick = { viewModel.submit() },
@@ -64,47 +95,58 @@ fun DailyQuestionWriteScreen(
                         shape = RoundedCornerShape(6.dp),
                         colors =
                             ButtonDefaults.buttonColors(
-                                containerColor = AfternoteDesign.colors.gray2,
+                                containerColor = AfternoteDesign.colors.gray9,
+                                contentColor = AfternoteDesign.colors.white,
+                                disabledContainerColor = AfternoteDesign.colors.gray2,
+                                disabledContentColor = AfternoteDesign.colors.gray5,
                             ),
                     ) {
                         Text(
-                            text = stringResource(R.string.mindrecord_action_register),
+                            text = stringResource(R.string.mindrecord_action_save),
                             style = AfternoteDesign.typography.bodySmallB,
-                            color = AfternoteDesign.colors.gray6,
                         )
                     }
                 },
                 onBackClick = onBackClick,
             )
         },
+        containerColor = AfternoteDesign.colors.gray1,
         modifier = modifier,
     ) { paddingValues ->
-        Column {
-            Column(modifier = Modifier.padding(paddingValues).padding(horizontal = 20.dp)) {
+        Column(modifier = Modifier.padding(paddingValues)) {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                DateSelectorRow(dateText = koreanDateText)
+
+                TitleInputField(
+                    title = title,
+                    onTitleChange = { title = it },
+                )
+
+                MoodSelectorRow(
+                    selectedMood = selectedMood,
+                    onMoodSelect = { selectedMood = it },
+                )
+
                 val questionLoadErrorText = uiState.questionLoadError?.asString()
-                val headerText =
+                val questionText =
                     when {
                         uiState.isQuestionLoading -> stringResource(R.string.mindrecord_daily_question_write_loading)
                         questionLoadErrorText != null -> questionLoadErrorText
                         uiState.questionContent.isNotEmpty() -> uiState.questionContent
                         else -> stringResource(R.string.mindrecord_daily_question_write_none)
                     }
-                DailyQuestionWriteHeaderCard(
-                    questionText = headerText,
+                DailyQuestionRecommendCard(
+                    questionText = questionText,
+                    dayCount = uiState.questionDay,
+                    expanded = isQuestionExpanded,
+                    onExpandToggle = { isQuestionExpanded = !isQuestionExpanded },
                 )
-                Spacer(modifier = Modifier.height(18.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = "YOUR ANSWER",
-                        style = AfternoteDesign.typography.mono,
-                        color = AfternoteDesign.colors.black.copy(alpha = 0.4f),
-                    )
-                    HorizontalDivider(modifier = Modifier.padding(start = 12.dp))
-                }
-                Spacer(modifier = Modifier.height(10.dp))
 
                 val errorMessage = (uiState.submitState as? SubmitState.Failed)?.message?.asString()
                 if (errorMessage != null) {
@@ -115,15 +157,232 @@ fun DailyQuestionWriteScreen(
                     )
                 }
             }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
             WriteTextField(
                 value = uiState.answer,
                 onValueChange = viewModel::onAnswerChanged,
                 onSaveDraftClick = { viewModel.submit(isDraft = true) },
                 onDraftCountClick = onDraftListClick,
+                contentPadding = PaddingValues(horizontal = 20.dp),
+                bottomContent = {
+                    RecipientSection(
+                        onClick = { showRecipientSheet = true },
+                        recipientName = recipientLabel(uiState.selectedReceiverNames),
+                    )
+                },
+            )
+        }
+
+        if (showRecipientSheet) {
+            RecipientSelectBottomSheet(
+                receivers = uiState.receivers,
+                selectedIds = uiState.selectedReceiverIds,
+                onConfirm = { ids ->
+                    viewModel.onReceiversSelected(ids)
+                    showRecipientSheet = false
+                },
+                onDismiss = { showRecipientSheet = false },
             )
         }
     }
 }
+
+/** 선택된 수신자 표기: 1명이면 이름, 여러 명이면 "OO 외 N명". */
+private fun recipientLabel(names: List<String>): String? =
+    when {
+        names.isEmpty() -> null
+        names.size == 1 -> names.first()
+        else -> "${names.first()} 외 ${names.size - 1}명"
+    }
+
+/** 상단 날짜 표시 행. Figma 2372:22352 — 날짜 텍스트 + 화살표 + 하단 구분선. */
+@Composable
+private fun DateSelectorRow(
+    dateText: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = 4.dp, bottom = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = dateText,
+                style = AfternoteDesign.typography.captionLargeR,
+                color = AfternoteDesign.colors.gray9,
+            )
+            Icon(
+                painter = painterResource(CoreUiR.drawable.core_ui_arrowdown),
+                contentDescription = null,
+                tint = AfternoteDesign.colors.gray9,
+                modifier = Modifier.size(16.dp),
+            )
+        }
+        HorizontalDivider(thickness = 0.5.dp, color = AfternoteDesign.colors.gray3)
+    }
+}
+
+/** 제목 입력 필드. Figma 2372:22353 — H3 스타일, 20% 블랙 플레이스홀더. */
+@Composable
+private fun TitleInputField(
+    title: String,
+    onTitleChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BasicTextField(
+        value = title,
+        onValueChange = onTitleChange,
+        textStyle = AfternoteDesign.typography.h3.copy(color = AfternoteDesign.colors.gray9),
+        singleLine = true,
+        cursorBrush = SolidColor(AfternoteDesign.colors.gray9),
+        modifier = modifier.fillMaxWidth(),
+        decorationBox = { innerTextField ->
+            Box(contentAlignment = Alignment.CenterStart) {
+                if (title.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.mindrecord_diary_write_title_placeholder),
+                        style = AfternoteDesign.typography.h3,
+                        color = AfternoteDesign.colors.black.copy(alpha = 0.2f),
+                    )
+                }
+                innerTextField()
+            }
+        },
+    )
+}
+
+/** 오늘의 기분 이모지 선택 행. Figma 2372:22356. */
+@Composable
+private fun MoodSelectorRow(
+    selectedMood: TodayMood?,
+    onMoodSelect: (TodayMood) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(32.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.mindrecord_emotion),
+                contentDescription = null,
+                tint = AfternoteDesign.colors.gray6,
+                modifier = Modifier.size(16.dp),
+            )
+            Text(
+                text = stringResource(R.string.mindrecord_diary_write_mood_label),
+                style = AfternoteDesign.typography.captionLargeR,
+                color = AfternoteDesign.colors.gray6,
+            )
+        }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            listOf(TodayMood.HAPPY, TodayMood.SOSO, TodayMood.SAD).forEach { mood ->
+                DailyMoodChip(
+                    emoji = mood.moodEmoji(),
+                    selected = selectedMood == mood,
+                    onClick = { onMoodSelect(mood) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DailyMoodChip(
+    emoji: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier =
+            Modifier
+                .size(32.dp)
+                .clip(CircleShape)
+                .background(AfternoteDesign.colors.gray2)
+                .then(
+                    if (selected) {
+                        Modifier.border(1.dp, AfternoteDesign.colors.gray9, CircleShape)
+                    } else {
+                        Modifier
+                    },
+                ).clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(text = emoji)
+    }
+}
+
+/** 수신자 설정 영역. Figma 2372:22799 — 안내 문구 + 수신자 설정 진입 행. */
+@Composable
+private fun RecipientSection(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    recipientName: String? = null,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = "오늘의 기록을 전달하고 싶은 사람이 있나요?",
+            style = AfternoteDesign.typography.bodySmallR,
+            color = AfternoteDesign.colors.gray7,
+        )
+        Row(
+            modifier =
+                Modifier
+                    .clip(RoundedCornerShape(6.dp))
+                    .clickable(onClick = onClick),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                painter = painterResource(CoreUiR.drawable.core_ui_user),
+                contentDescription = null,
+                tint = AfternoteDesign.colors.gray6,
+                modifier = Modifier.size(24.dp),
+            )
+            Text(
+                text = recipientName?.let { "$it 님에게" } ?: "수신자 설정하기",
+                style = AfternoteDesign.typography.bodyBase,
+                color = AfternoteDesign.colors.gray9,
+            )
+            Icon(
+                painter = painterResource(CoreUiR.drawable.core_ui_right),
+                contentDescription = null,
+                tint = AfternoteDesign.colors.gray9,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+}
+
+private fun TodayMood.moodEmoji(): String =
+    when (this) {
+        TodayMood.HAPPY -> "😊"
+        TodayMood.SOSO -> "😐"
+        TodayMood.SAD -> "😢"
+    }
 
 @Preview(showBackground = true)
 @Composable

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryScreen.kt
@@ -9,10 +9,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.GridItemSpan
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
@@ -41,7 +41,7 @@ import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
 import com.afternote.feature.mindrecord.presentation.viewmodel.DiaryListUiState
 import com.afternote.feature.mindrecord.presentation.viewmodel.DiaryListViewModel
 import java.time.YearMonth
-import androidx.compose.foundation.lazy.grid.items as gridItems
+import androidx.compose.foundation.lazy.staggeredgrid.items as staggeredItems
 
 @Composable
 fun DiaryScreen(
@@ -116,10 +116,11 @@ private fun DiaryListContent(
                     answeredDays = answeredDays,
                     emotionByDay = emotionByDay,
                 )
-                Spacer(modifier = Modifier.height(10.dp))
+                Spacer(modifier = Modifier.height(24.dp))
             }
 
             item {
+                // Figma 110:16804 — DAILY ANSWER 구분 텍스트 + gray3 라인
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
@@ -127,11 +128,14 @@ private fun DiaryListContent(
                     Text(
                         text = "DAILY ANSWER",
                         style = AfternoteDesign.typography.mono,
-                        color = AfternoteDesign.colors.black.copy(alpha = 0.4f),
+                        color = AfternoteDesign.colors.gray6,
                     )
-                    HorizontalDivider(modifier = Modifier.padding(start = 12.dp))
+                    HorizontalDivider(
+                        modifier = Modifier.padding(start = 12.dp),
+                        color = AfternoteDesign.colors.gray3,
+                    )
                 }
-                Spacer(modifier = Modifier.height(10.dp))
+                Spacer(modifier = Modifier.height(4.dp))
             }
 
             items(diaries, key = { it.id }) { diary ->
@@ -143,21 +147,24 @@ private fun DiaryListContent(
             }
         }
     } else {
-        LazyVerticalGrid(
+        LazyVerticalStaggeredGrid(
             modifier = modifier,
-            columns = GridCells.Fixed(2),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            columns = StaggeredGridCells.Fixed(2),
+            verticalItemSpacing = 8.dp,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            item(span = { GridItemSpan(2) }) {
+            item(span = StaggeredGridItemSpan.FullLine) {
                 DiaryReportCard(
                     monthDiaryCount = monthDiaryCount,
                     weeklyMoodEmoji = weeklyMoodEmoji,
+                    modifier = Modifier.padding(bottom = 16.dp),
                 )
-                Spacer(modifier = Modifier.height(24.dp))
             }
-            gridItems(diaries, key = { it.id }) { diary ->
-                DiaryCard(diary = diary)
+            staggeredItems(diaries, key = { it.id }) { diary ->
+                DiaryCard(
+                    diary = diary,
+                    onDelete = { onDelete(diary.id) },
+                )
             }
         }
     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
@@ -1,27 +1,27 @@
 package com.afternote.feature.mindrecord.presentation.screen.sender
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -32,14 +32,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.afternote.core.ui.R
 import com.afternote.core.ui.asString
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
@@ -47,9 +46,12 @@ import com.afternote.core.ui.theme.Red
 import com.afternote.core.ui.topbar.DetailTopBar
 import com.afternote.feature.mindrecord.domain.model.TodayMood
 import com.afternote.feature.mindrecord.presentation.component.BottomSheetCalendar
+import com.afternote.feature.mindrecord.presentation.component.RecipientSelectBottomSheet
 import com.afternote.feature.mindrecord.presentation.component.WriteTextField
 import com.afternote.feature.mindrecord.presentation.viewmodel.DiaryWriteViewModel
 import com.afternote.feature.mindrecord.presentation.viewmodel.SubmitState
+import java.time.format.DateTimeFormatter
+import com.afternote.core.ui.R as CoreUiR
 import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 
 @Composable
@@ -62,6 +64,7 @@ fun DiaryWriteScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var showPicker by remember { mutableStateOf(false) }
+    var showRecipientSheet by remember { mutableStateOf(false) }
     val currentOnSubmitSuccess by rememberUpdatedState(onSubmitSuccess)
 
     LaunchedEffect(uiState.submitState) {
@@ -70,6 +73,11 @@ fun DiaryWriteScreen(
             viewModel.consumeSubmitResult()
         }
     }
+
+    val dateText =
+        remember(uiState.date) {
+            uiState.date.format(DateTimeFormatter.ofPattern("yyyy년 M월 d일"))
+        }
 
     Scaffold(
         topBar = {
@@ -84,113 +92,68 @@ fun DiaryWriteScreen(
                         colors =
                             ButtonDefaults.buttonColors(
                                 containerColor = AfternoteDesign.colors.gray2,
+                                contentColor = AfternoteDesign.colors.gray6,
+                                disabledContainerColor = AfternoteDesign.colors.gray2,
+                                disabledContentColor = AfternoteDesign.colors.gray6,
                             ),
                     ) {
                         Text(
                             text = stringResource(MindRecordR.string.mindrecord_action_register),
                             style = AfternoteDesign.typography.bodySmallB,
-                            color = AfternoteDesign.colors.gray6,
                         )
                     }
                 },
             )
         },
+        containerColor = AfternoteDesign.colors.gray1,
         modifier = modifier,
     ) { paddingValues ->
-        Column(
-            modifier =
-                Modifier
-                    .padding(paddingValues)
-                    .padding(horizontal = 20.dp),
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
+        Column(modifier = Modifier.padding(paddingValues)) {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                Text(
-                    text = uiState.date.toString(),
-                    style = AfternoteDesign.typography.captionLargeR,
-                    color = AfternoteDesign.colors.gray9,
+                RecipientRow(
+                    onClick = { showRecipientSheet = true },
+                    recipientName = recipientLabel(uiState.selectedReceiverNames),
                 )
-                IconButton(onClick = { showPicker = !showPicker }) {
-                    Icon(
-                        painter = painterResource(R.drawable.core_ui_arrowdown),
-                        contentDescription = null,
-                    )
-                }
-            }
 
-            HorizontalDivider()
+                DateSelectorRow(
+                    dateText = dateText,
+                    onClick = { showPicker = true },
+                )
 
-            TextField(
-                value = uiState.title,
-                onValueChange = viewModel::onTitleChanged,
-                colors =
-                    TextFieldDefaults.colors(
-                        focusedContainerColor = Color.Transparent,
-                        unfocusedContainerColor = Color.Transparent,
-                        focusedIndicatorColor = Color.Transparent,
-                        unfocusedIndicatorColor = Color.Transparent,
-                    ),
-                placeholder = {
+                TitleInputField(
+                    title = uiState.title,
+                    onTitleChange = viewModel::onTitleChanged,
+                )
+
+                MoodSelectorRow(
+                    selectedMood = uiState.mood,
+                    onMoodSelect = viewModel::onMoodSelected,
+                )
+
+                val errorMessage = (uiState.submitState as? SubmitState.Failed)?.message?.asString()
+                if (errorMessage != null) {
                     Text(
-                        text = stringResource(MindRecordR.string.mindrecord_diary_write_title_placeholder),
-                        style = AfternoteDesign.typography.h2,
-                        color = AfternoteDesign.colors.black.copy(alpha = 0.2f),
+                        text = errorMessage,
+                        color = Red,
+                        style = AfternoteDesign.typography.captionLargeR,
                     )
-                },
-            )
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                val selectedMood = uiState.mood
-                if (selectedMood != null) {
-                    Text(text = selectedMood.emoji())
-                } else {
-                    Icon(
-                        painter = painterResource(com.afternote.feature.mindrecord.presentation.R.drawable.mindrecord_emotion),
-                        contentDescription = null,
-                        tint = Color(0xFF000000).copy(0.4f),
-                    )
-                }
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = stringResource(MindRecordR.string.mindrecord_diary_write_mood_label),
-                    style = AfternoteDesign.typography.captionLargeR,
-                    color = AfternoteDesign.colors.black.copy(alpha = 0.4f),
-                )
-                Spacer(modifier = Modifier.width(12.dp))
-
-                MoodChip("😊", selected = uiState.mood == TodayMood.HAPPY) {
-                    viewModel.onMoodSelected(TodayMood.HAPPY)
-                }
-                Spacer(modifier = Modifier.width(8.dp))
-                MoodChip("😐", selected = uiState.mood == TodayMood.SOSO) {
-                    viewModel.onMoodSelected(TodayMood.SOSO)
-                }
-                Spacer(modifier = Modifier.width(8.dp))
-                MoodChip("😢", selected = uiState.mood == TodayMood.SAD) {
-                    viewModel.onMoodSelected(TodayMood.SAD)
                 }
             }
 
-            val errorMessage = (uiState.submitState as? SubmitState.Failed)?.message?.asString()
-            if (errorMessage != null) {
-                Text(
-                    text = errorMessage,
-                    color = Red,
-                    style = AfternoteDesign.typography.captionLargeR,
-                )
-            }
+            Spacer(modifier = Modifier.height(12.dp))
 
             WriteTextField(
                 value = uiState.content,
                 onValueChange = viewModel::onContentChanged,
                 onSaveDraftClick = { viewModel.submit(isDraft = true) },
                 onDraftCountClick = onDraftListClick,
+                contentPadding = PaddingValues(horizontal = 20.dp),
             )
         }
 
@@ -204,6 +167,170 @@ fun DiaryWriteScreen(
                 },
             )
         }
+
+        if (showRecipientSheet) {
+            RecipientSelectBottomSheet(
+                receivers = uiState.receivers,
+                selectedIds = uiState.selectedReceiverIds,
+                onConfirm = { ids ->
+                    viewModel.onReceiversSelected(ids)
+                    showRecipientSheet = false
+                },
+                onDismiss = { showRecipientSheet = false },
+            )
+        }
+    }
+}
+
+/** 선택된 수신자 표기: 1명이면 이름, 여러 명이면 "OO 외 N명". */
+private fun recipientLabel(names: List<String>): String? =
+    when {
+        names.isEmpty() -> null
+        names.size == 1 -> names.first()
+        else -> "${names.first()} 외 ${names.size - 1}명"
+    }
+
+/** 수신자 표시 행. Figma 2671:17923 — 아바타 + `OO님에게` + chevron. */
+@Composable
+private fun RecipientRow(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    recipientName: String? = null,
+) {
+    Row(
+        modifier =
+            modifier
+                .clip(RoundedCornerShape(6.dp))
+                .clickable(onClick = onClick)
+                .padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            painter = painterResource(CoreUiR.drawable.core_ui_user),
+            contentDescription = null,
+            tint = AfternoteDesign.colors.gray6,
+            modifier = Modifier.size(32.dp),
+        )
+        Text(
+            text = recipientName?.let { "${it}님에게" } ?: "수신자 설정하기",
+            style = AfternoteDesign.typography.bodyBase,
+            color = AfternoteDesign.colors.gray9,
+        )
+        Icon(
+            painter = painterResource(CoreUiR.drawable.core_ui_right),
+            contentDescription = null,
+            tint = AfternoteDesign.colors.gray9,
+            modifier = Modifier.size(20.dp),
+        )
+    }
+}
+
+/** 발송 날짜 선택 행. Figma 2671:17930 — 날짜 텍스트 + 아래 화살표 + 하단 0.5dp 구분선. */
+@Composable
+private fun DateSelectorRow(
+    dateText: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clickable(onClick = onClick)
+                    .padding(top = 4.dp, bottom = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = dateText,
+                style = AfternoteDesign.typography.captionLargeR,
+                color = AfternoteDesign.colors.gray9,
+            )
+            Icon(
+                painter = painterResource(CoreUiR.drawable.core_ui_arrowdown),
+                contentDescription = null,
+                tint = AfternoteDesign.colors.gray9,
+                modifier = Modifier.size(16.dp),
+            )
+        }
+        HorizontalDivider(thickness = 0.5.dp, color = AfternoteDesign.colors.gray3)
+    }
+}
+
+/** 제목 입력 필드. Figma 2671:17931 — H2 스타일, 20% 블랙 플레이스홀더. */
+@Composable
+private fun TitleInputField(
+    title: String,
+    onTitleChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BasicTextField(
+        value = title,
+        onValueChange = onTitleChange,
+        textStyle = AfternoteDesign.typography.h2.copy(color = AfternoteDesign.colors.gray9),
+        singleLine = true,
+        cursorBrush = SolidColor(AfternoteDesign.colors.gray9),
+        modifier = modifier.fillMaxWidth(),
+        decorationBox = { innerTextField ->
+            Box(contentAlignment = Alignment.CenterStart) {
+                if (title.isEmpty()) {
+                    Text(
+                        text = stringResource(MindRecordR.string.mindrecord_diary_write_title_placeholder),
+                        style = AfternoteDesign.typography.h2,
+                        color = AfternoteDesign.colors.black.copy(alpha = 0.2f),
+                    )
+                }
+                innerTextField()
+            }
+        },
+    )
+}
+
+/** 오늘의 기분 이모지 선택 행. Figma 2671:18323. */
+@Composable
+private fun MoodSelectorRow(
+    selectedMood: TodayMood?,
+    onMoodSelect: (TodayMood) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(32.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                painter = painterResource(MindRecordR.drawable.mindrecord_emotion),
+                contentDescription = null,
+                tint = AfternoteDesign.colors.gray6,
+                modifier = Modifier.size(16.dp),
+            )
+            Text(
+                text = stringResource(MindRecordR.string.mindrecord_diary_write_mood_label),
+                style = AfternoteDesign.typography.captionLargeR,
+                color = AfternoteDesign.colors.gray6,
+            )
+        }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            listOf(TodayMood.HAPPY, TodayMood.SOSO, TodayMood.SAD).forEach { mood ->
+                MoodChip(
+                    emoji = mood.emoji(),
+                    selected = selectedMood == mood,
+                    onClick = { onMoodSelect(mood) },
+                )
+            }
+        }
     }
 }
 
@@ -216,15 +343,16 @@ private fun MoodChip(
     Box(
         modifier =
             Modifier
+                .size(32.dp)
                 .clip(CircleShape)
-                .background(
+                .background(AfternoteDesign.colors.gray2)
+                .then(
                     if (selected) {
-                        AfternoteDesign.colors.gray2
+                        Modifier.border(1.dp, AfternoteDesign.colors.gray9, CircleShape)
                     } else {
-                        Color(0xFF000000).copy(0.05f)
+                        Modifier
                     },
-                ).size(32.dp)
-                .clickable(onClick = onClick),
+                ).clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
         Text(text = emoji)

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DraftListScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DraftListScreen.kt
@@ -1,12 +1,15 @@
 package com.afternote.feature.mindrecord.presentation.screen.sender
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -21,9 +24,9 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -31,13 +34,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Popup
-import androidx.compose.ui.window.PopupProperties
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.R
@@ -50,11 +50,17 @@ import com.afternote.feature.mindrecord.presentation.viewmodel.DraftCategory
 import com.afternote.feature.mindrecord.presentation.viewmodel.DraftItem
 import com.afternote.feature.mindrecord.presentation.viewmodel.DraftListUiState
 import com.afternote.feature.mindrecord.presentation.viewmodel.DraftListViewModel
+import kotlinx.coroutines.delay
+import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import com.afternote.feature.mindrecord.presentation.R as MindRecordR
 
 /**
- * 임시저장 목록 화면. Figma 노드 1716:13536 — 카테고리 필터 칩 + 총 개수 + 항목 리스트.
+ * 임시저장 목록 화면. Figma 노드 2372:22842 (기본) / 2372:23669 (선택 모드) 리디자인.
+ *
+ * - 상단 우측 "선택"/"완료" 버튼으로 다중 선택 모드 토글
+ * - 선택 모드에서 항목 좌측 체크 서클 + 하단 "전체 삭제 | 선택 삭제" 바 노출
+ * - 삭제 완료 시 상단 토스트("임시 저장된 기록이 삭제 되었습니다") 노출
  */
 @Composable
 fun DraftListScreen(
@@ -63,11 +69,23 @@ fun DraftListScreen(
     viewModel: DraftListViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var showDeletedToast by remember { mutableStateOf(false) }
+
+    LaunchedEffect(viewModel) {
+        viewModel.deletedEvent.collect {
+            showDeletedToast = true
+            delay(DELETED_TOAST_DURATION_MILLIS)
+            showDeletedToast = false
+        }
+    }
+
+    val selectionMode = (uiState as? DraftListUiState.Success)?.selectionMode == true
 
     Scaffold(
+        containerColor = AfternoteDesign.colors.gray1,
         topBar = {
             DetailTopBar(
-                title = stringResource(MindRecordR.string.mindrecord_draft_list_title),
+                title = "임시 저장된 기록",
                 onBackClick = onBackClick,
                 actions = {
                     Box(
@@ -75,10 +93,11 @@ fun DraftListScreen(
                             Modifier
                                 .clip(RoundedCornerShape(6.dp))
                                 .background(AfternoteDesign.colors.gray2)
+                                .clickable { viewModel.onSelectionModeToggled() }
                                 .padding(horizontal = 18.dp, vertical = 8.dp),
                     ) {
                         Text(
-                            text = stringResource(MindRecordR.string.mindrecord_draft_list_edit),
+                            text = if (selectionMode) "완료" else "선택",
                             style = AfternoteDesign.typography.bodySmallB,
                             color = AfternoteDesign.colors.gray6,
                         )
@@ -88,7 +107,7 @@ fun DraftListScreen(
         },
         modifier = modifier,
     ) { paddingValues ->
-        Box(modifier = Modifier.padding(paddingValues)) {
+        Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
             when (val state = uiState) {
                 DraftListUiState.Loading -> {
                     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -105,9 +124,15 @@ fun DraftListScreen(
                 is DraftListUiState.Success -> {
                     SuccessContent(
                         state = state,
-                        onFilterChanged = viewModel::onFilterChanged,
+                        onItemCheckedChanged = viewModel::onItemCheckedChanged,
+                        onDeleteAllClick = viewModel::onDeleteAllClick,
+                        onDeleteSelectedClick = viewModel::onDeleteSelectedClick,
                     )
                 }
+            }
+
+            if (showDeletedToast) {
+                DeletedToast(modifier = Modifier.align(Alignment.TopCenter))
             }
         }
     }
@@ -116,176 +141,275 @@ fun DraftListScreen(
 @Composable
 private fun SuccessContent(
     state: DraftListUiState.Success,
-    onFilterChanged: (DraftCategory) -> Unit,
+    onItemCheckedChanged: (DraftItem) -> Unit,
+    onDeleteAllClick: () -> Unit,
+    onDeleteSelectedClick: () -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxSize()) {
-        FilterRow(
-            selected = state.filter,
-            totalCount = state.totalCount,
-            onFilterChanged = onFilterChanged,
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        if (state.filtered.isEmpty()) {
-            Box(modifier = Modifier.fillMaxSize().padding(20.dp), contentAlignment = Alignment.Center) {
-                Text(
-                    text = stringResource(MindRecordR.string.mindrecord_draft_list_empty),
-                    style = AfternoteDesign.typography.captionLargeR,
-                    color = AfternoteDesign.colors.gray6,
-                )
-            }
-        } else {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize().padding(horizontal = 20.dp),
-                verticalArrangement = Arrangement.spacedBy(10.dp),
-            ) {
-                items(state.filtered, key = { "${it.category.name}-${it.id}" }) { item ->
-                    DraftRow(item)
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Spacer(modifier = Modifier.height(10.dp))
+            TotalCountRow(
+                selectionMode = state.selectionMode,
+                count = if (state.selectionMode) state.selectedCount else state.totalCount,
+            )
+            Spacer(modifier = Modifier.height(10.dp))
+            if (state.items.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize().padding(20.dp), contentAlignment = Alignment.Center) {
+                    Text(
+                        text = stringResource(MindRecordR.string.mindrecord_draft_list_empty),
+                        style = AfternoteDesign.typography.captionLargeR,
+                        color = AfternoteDesign.colors.gray6,
+                    )
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize().padding(horizontal = 20.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                    contentPadding = PaddingValues(bottom = if (state.selectionMode) 84.dp else 20.dp),
+                ) {
+                    items(state.items, key = { it.key }) { item ->
+                        DraftRow(
+                            item = item,
+                            selectionMode = state.selectionMode,
+                            checked = item.key in state.selectedKeys,
+                            onCheckedChanged = onItemCheckedChanged,
+                        )
+                    }
                 }
             }
+        }
+
+        if (state.selectionMode) {
+            DeleteActionBar(
+                onDeleteAllClick = onDeleteAllClick,
+                onDeleteSelectedClick = onDeleteSelectedClick,
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(horizontal = 20.dp)
+                        .padding(bottom = 20.dp),
+            )
         }
     }
 }
 
 @Composable
-private fun FilterRow(
-    selected: DraftCategory,
-    totalCount: Int,
-    onFilterChanged: (DraftCategory) -> Unit,
+private fun TotalCountRow(
+    selectionMode: Boolean,
+    count: Int,
 ) {
-    var expanded by remember { mutableStateOf(false) }
     Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "총",
+            style = AfternoteDesign.typography.footnoteCaption,
+            color = AfternoteDesign.colors.gray9,
+        )
+        Text(
+            text = count.toString(),
+            style = AfternoteDesign.typography.footnoteCaption,
+            color = AfternoteDesign.colors.gray6,
+        )
+        Text(
+            text = if (selectionMode) "개 선택" else "개",
+            style = AfternoteDesign.typography.footnoteCaption,
+            color = AfternoteDesign.colors.gray9,
+        )
+    }
+}
+
+@Composable
+private fun DraftRow(
+    item: DraftItem,
+    selectionMode: Boolean,
+    checked: Boolean,
+    onCheckedChanged: (DraftItem) -> Unit,
+) {
+    Column(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
+                .then(
+                    if (selectionMode) {
+                        Modifier.clickable { onCheckedChanged(item) }
+                    } else {
+                        Modifier
+                    },
+                ),
     ) {
-        Box {
-            Row(
-                modifier =
-                    Modifier
-                        .clip(CircleShape)
-                        .background(AfternoteDesign.colors.gray2)
-                        .clickable { expanded = true }
-                        .padding(horizontal = 16.dp, vertical = 9.dp),
-                verticalAlignment = Alignment.CenterVertically,
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            if (selectionMode) {
+                DraftCheckCircle(checked = checked)
+            }
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
+                Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                        if (item.recipientName != null) {
+                            Text(
+                                text = "수신인",
+                                style = AfternoteDesign.typography.footnoteCaption,
+                                color = AfternoteDesign.colors.gray6,
+                            )
+                            Text(
+                                text = item.recipientName,
+                                style = AfternoteDesign.typography.footnoteCaption,
+                                color = AfternoteDesign.colors.gray6,
+                            )
+                        } else {
+                            Text(
+                                text = item.category.label(),
+                                style = AfternoteDesign.typography.footnoteCaption,
+                                color = AfternoteDesign.colors.gray6,
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.weight(1f))
+                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Text(
+                            text = "작성일",
+                            style = AfternoteDesign.typography.footnoteCaption,
+                            color = AfternoteDesign.colors.gray6,
+                        )
+                        Text(
+                            text = DateFormatter.format(item.date),
+                            style = AfternoteDesign.typography.footnoteCaption,
+                            color = AfternoteDesign.colors.gray6,
+                        )
+                    }
+                }
                 Text(
-                    text = selected.label(),
-                    style = AfternoteDesign.typography.captionLargeR,
+                    text = item.content.htmlToPlainText(),
+                    style = AfternoteDesign.typography.bodySmallR,
                     color = AfternoteDesign.colors.gray9,
                 )
-                Spacer(modifier = Modifier.width(8.dp))
-                Icon(
-                    painter = painterResource(R.drawable.core_ui_arrowdown),
-                    contentDescription = null,
-                    tint = AfternoteDesign.colors.gray9,
-                    modifier = Modifier.size(8.dp),
-                )
-            }
-            if (expanded) {
-                FilterDropdown(
-                    selected = selected,
-                    onSelect = {
-                        onFilterChanged(it)
-                        expanded = false
-                    },
-                    onDismiss = { expanded = false },
-                )
             }
         }
-
-        Spacer(modifier = Modifier.weight(1f))
-
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                text = "총 ",
-                style = AfternoteDesign.typography.footnoteCaption,
-                color = AfternoteDesign.colors.gray9,
-            )
-            Text(
-                text = totalCount.toString(),
-                style = AfternoteDesign.typography.footnoteCaption,
-                color = AfternoteDesign.colors.gray6,
-            )
-            Text(
-                text = "개",
-                style = AfternoteDesign.typography.footnoteCaption,
-                color = AfternoteDesign.colors.gray9,
-            )
-        }
-    }
-}
-
-@Composable
-private fun FilterDropdown(
-    selected: DraftCategory,
-    onSelect: (DraftCategory) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    Popup(
-        alignment = Alignment.TopStart,
-        onDismissRequest = onDismiss,
-        properties = PopupProperties(focusable = true),
-    ) {
-        Surface(
-            modifier = Modifier.width(132.dp),
-            shape = RoundedCornerShape(8.dp),
-            color = Color.White,
-            shadowElevation = 10.dp,
-        ) {
-            Column {
-                DraftCategory.entries.forEach { category ->
-                    Text(
-                        text = category.label(),
-                        style = AfternoteDesign.typography.bodySmallR,
-                        color = AfternoteDesign.colors.gray9,
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .clickable { onSelect(category) }
-                                .padding(16.dp),
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun DraftRow(item: DraftItem) {
-    Column(
-        modifier = Modifier.fillMaxWidth().padding(bottom = 20.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                text = item.category.label(),
-                style = AfternoteDesign.typography.footnoteCaption,
-                color = AfternoteDesign.colors.gray6,
-            )
-            Spacer(modifier = Modifier.weight(1f))
-            Text(
-                text = DateFormatter.format(item.date),
-                style = AfternoteDesign.typography.footnoteCaption,
-                color = AfternoteDesign.colors.gray6,
-            )
-        }
-        Text(
-            text = item.content.htmlToPlainText(),
-            style = AfternoteDesign.typography.bodySmallR,
-            color = AfternoteDesign.colors.gray9,
-        )
+        Spacer(modifier = Modifier.height(20.dp))
         HorizontalDivider(thickness = 0.5.dp, color = AfternoteDesign.colors.gray3)
+    }
+}
+
+@Composable
+private fun DraftCheckCircle(
+    checked: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .size(20.dp)
+                .clip(CircleShape)
+                .then(
+                    if (checked) {
+                        Modifier.background(AfternoteDesign.colors.gray9)
+                    } else {
+                        Modifier.border(width = 1.5.dp, color = AfternoteDesign.colors.gray4, shape = CircleShape)
+                    },
+                ),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (checked) {
+            Icon(
+                painter = painterResource(R.drawable.core_ui_ic_check),
+                contentDescription = null,
+                tint = AfternoteDesign.colors.white,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DeleteActionBar(
+    onDeleteAllClick: () -> Unit,
+    onDeleteSelectedClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(44.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(AfternoteDesign.colors.gray9)
+                .padding(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .clip(RoundedCornerShape(4.dp))
+                    .clickable(onClick = onDeleteAllClick),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "전체 삭제",
+                style = AfternoteDesign.typography.captionLargeB,
+                color = AfternoteDesign.colors.white,
+            )
+        }
+        Box(
+            modifier =
+                Modifier
+                    .width(1.dp)
+                    .height(12.dp)
+                    .background(AfternoteDesign.colors.white),
+        )
+        Box(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .clip(RoundedCornerShape(4.dp))
+                    .clickable(onClick = onDeleteSelectedClick),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "선택 삭제",
+                style = AfternoteDesign.typography.captionLargeB,
+                color = AfternoteDesign.colors.white,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DeletedToast(modifier: Modifier = Modifier) {
+    Box(
+        modifier =
+            modifier
+                .padding(horizontal = 20.dp, vertical = 8.dp)
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(6.dp))
+                .background(AfternoteDesign.colors.gray9)
+                .padding(vertical = 14.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "임시 저장된 기록이 삭제 되었습니다",
+            style = AfternoteDesign.typography.captionLargeR,
+            color = AfternoteDesign.colors.white,
+        )
     }
 }
 
 private val DateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy. MM. dd.")
 
+private const val DELETED_TOAST_DURATION_MILLIS = 2_000L
+
 @Composable
 private fun DraftCategory.label(): String =
     when (this) {
-        DraftCategory.All -> stringResource(MindRecordR.string.mindrecord_draft_list_filter_all)
         DraftCategory.DailyQuestion -> stringResource(MindRecordR.string.mindrecord_draft_list_filter_daily)
         DraftCategory.Diary -> stringResource(MindRecordR.string.mindrecord_draft_list_filter_diary)
         DraftCategory.DeepThought -> stringResource(MindRecordR.string.mindrecord_draft_list_filter_deep_thought)
@@ -293,8 +417,27 @@ private fun DraftCategory.label(): String =
 
 @Preview(showBackground = true)
 @Composable
-private fun DraftListScreenPreview() {
+private fun DraftListSelectionPreview() {
     AfternoteTheme {
-        // ViewModel 의존이 있어 Preview는 비워둠
+        SuccessContent(
+            state =
+                DraftListUiState.Success(
+                    items =
+                        List(4) { index ->
+                            DraftItem(
+                                id = index.toLong(),
+                                category = DraftCategory.Diary,
+                                content = "지은아 결혼을 축하해",
+                                date = LocalDate.of(2029, 11, 20),
+                                recipientName = "김지은",
+                            )
+                        },
+                    selectionMode = true,
+                    selectedKeys = setOf("Diary-0"),
+                ),
+            onItemCheckedChanged = {},
+            onDeleteAllClick = {},
+            onDeleteSelectedClick = {},
+        )
     }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/WeeklyReportScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/WeeklyReportScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
@@ -29,7 +30,6 @@ import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.component.DailyQuestionListCard
 import com.afternote.feature.mindrecord.presentation.component.EmotionKeywordCard
-import com.afternote.feature.mindrecord.presentation.component.InsightCard
 import com.afternote.feature.mindrecord.presentation.component.WeeklyMoodCalendar
 import com.afternote.feature.mindrecord.presentation.component.WeeklyReportReviewCard
 import com.afternote.feature.mindrecord.presentation.viewmodel.WeeklyReportUiState
@@ -89,13 +89,16 @@ private fun WeeklyReportContent(
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(
                     text = recordedSummary(userName = state.userName, recordedDays = state.recordedDays),
+                    style = AfternoteDesign.typography.bodyBase,
+                    color = AfternoteDesign.colors.gray9,
                     modifier = Modifier.padding(start = 8.dp),
                 )
                 WeeklyMoodCalendar(days = state.weekDays)
             }
         }
 
-        // TOP KEYWORDS 섹션 — py=8, gap=12 (divider + 감정 카드 + INSIGHT 카드).
+        // TOP KEYWORDS 섹션 — py=8, gap=12 (divider + 감정 카드).
+        // INSIGHTS 는 감정 키워드 카드 안으로 통합됨 (Figma 2249:13964).
         item {
             Column(
                 modifier = Modifier.padding(vertical = 8.dp),
@@ -104,14 +107,13 @@ private fun WeeklyReportContent(
                 SectionHeader(title = "TOP KEYWORDS")
                 EmotionKeywordCard(
                     keywords = state.emotionKeywords,
-                    descriptionText =
+                    insightText =
                         if (state.emotionKeywords.isEmpty()) {
                             stringResource(R.string.mindrecord_emotion_card_empty_description, state.userName)
                         } else {
                             state.summaryText
                         },
                 )
-                InsightCard(bodyText = state.summaryText)
             }
         }
 
@@ -136,28 +138,17 @@ private fun recordedSummary(
     val middle = stringResource(R.string.mindrecord_weekly_report_recorded_middle)
     val daysText = stringResource(R.string.mindrecord_weekly_report_days_format, recordedDays)
     val suffix = stringResource(R.string.mindrecord_weekly_report_recorded_suffix)
+    // Figma 852:11578 — 16sp Regular, 이름·일수만 b1 컬러 강조.
     return buildAnnotatedString {
-        withStyle(style = AfternoteDesign.typography.bodyLargeB.toSpanStyle()) {
-            append(prefix)
-            withStyle(
-                style =
-                    AfternoteDesign.typography.bodyLargeB
-                        .copy(color = AfternoteDesign.colors.b1)
-                        .toSpanStyle(),
-            ) {
-                append(userName)
-            }
-            append(middle)
-            withStyle(
-                style =
-                    AfternoteDesign.typography.bodyLargeB
-                        .copy(color = AfternoteDesign.colors.b1)
-                        .toSpanStyle(),
-            ) {
-                append(daysText)
-            }
-            append(suffix)
+        append(prefix)
+        withStyle(style = SpanStyle(color = AfternoteDesign.colors.b1)) {
+            append(userName)
         }
+        append(middle)
+        withStyle(style = SpanStyle(color = AfternoteDesign.colors.b1)) {
+            append(daysText)
+        }
+        append(suffix)
     }
 }
 
@@ -170,9 +161,12 @@ private fun SectionHeader(title: String) {
         Text(
             text = title,
             style = AfternoteDesign.typography.mono,
-            color = AfternoteDesign.colors.black.copy(alpha = 0.4f),
+            color = AfternoteDesign.colors.gray6,
         )
-        HorizontalDivider(modifier = Modifier.padding(start = 12.dp))
+        HorizontalDivider(
+            modifier = Modifier.padding(start = 12.dp),
+            color = AfternoteDesign.colors.gray3,
+        )
     }
 }
 

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionWriteUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionWriteUiState.kt
@@ -1,18 +1,26 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
+import com.afternote.core.model.user.Receiver
 import com.afternote.core.ui.UiText
 
 data class DailyQuestionWriteUiState(
     val questionId: Long? = null,
     val questionContent: String = "",
+    // 오늘의 질문이 며칠째인지 ("Day N"). 서버가 안 내려주면 null 로 두고 UI 에서 숨긴다.
+    val questionDay: Int? = null,
     val answer: String = "",
     val imageUrl: String? = null,
+    val receivers: List<Receiver> = emptyList(),
+    val selectedReceiverIds: Set<Long> = emptySet(),
     val isQuestionLoading: Boolean = true,
     val questionLoadError: UiText? = null,
     val submitState: SubmitState = SubmitState.Idle,
 ) {
     val canSubmit: Boolean
         get() = questionId != null && answer.isNotBlank() && submitState != SubmitState.InProgress
+
+    val selectedReceiverNames: List<String>
+        get() = receivers.filter { it.receiverId in selectedReceiverIds }.map { it.name }
 }
 
 sealed interface SubmitState {

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionWriteViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DailyQuestionWriteViewModel.kt
@@ -2,6 +2,7 @@ package com.afternote.feature.mindrecord.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.core.domain.repository.UserRepository
 import com.afternote.core.ui.UiText
 import com.afternote.feature.mindrecord.domain.model.DailyQuestionCreatePayload
 import com.afternote.feature.mindrecord.domain.repository.DailyQuestionRepository
@@ -19,12 +20,25 @@ class DailyQuestionWriteViewModel
     @Inject
     constructor(
         private val repository: DailyQuestionRepository,
+        private val userRepository: UserRepository,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(DailyQuestionWriteUiState())
         val uiState: StateFlow<DailyQuestionWriteUiState> = _uiState.asStateFlow()
 
         init {
             loadTodayQuestion()
+            loadReceivers()
+        }
+
+        private fun loadReceivers() {
+            viewModelScope.launch {
+                val receivers = runCatching { userRepository.getReceivers() }.getOrElse { emptyList() }
+                _uiState.update { it.copy(receivers = receivers) }
+            }
+        }
+
+        fun onReceiversSelected(ids: Set<Long>) {
+            _uiState.update { it.copy(selectedReceiverIds = ids) }
         }
 
         private fun loadTodayQuestion() {
@@ -37,6 +51,7 @@ class DailyQuestionWriteViewModel
                             it.copy(
                                 questionId = today.questionId,
                                 questionContent = today.content,
+                                questionDay = today.day.takeIf { day -> day > 0 },
                                 isQuestionLoading = false,
                             )
                         }
@@ -73,6 +88,7 @@ class DailyQuestionWriteViewModel
                             isDraft = isDraft,
                             questionId = questionId,
                             imageUrl = state.imageUrl,
+                            receiverIds = state.selectedReceiverIds.toList(),
                         ),
                     ).onSuccess {
                         _uiState.update { it.copy(submitState = SubmitState.Succeeded) }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteUiState.kt
@@ -1,5 +1,6 @@
 package com.afternote.feature.mindrecord.presentation.viewmodel
 
+import com.afternote.core.model.user.Receiver
 import com.afternote.feature.mindrecord.domain.model.TodayMood
 import java.time.LocalDate
 
@@ -9,8 +10,13 @@ data class DiaryWriteUiState(
     val mood: TodayMood? = null,
     val date: LocalDate = LocalDate.now(),
     val imageUrl: String? = null,
+    val receivers: List<Receiver> = emptyList(),
+    val selectedReceiverIds: Set<Long> = emptySet(),
     val submitState: SubmitState = SubmitState.Idle,
 ) {
     val canSubmit: Boolean
         get() = title.isNotBlank() && content.isNotBlank() && mood != null && submitState != SubmitState.InProgress
+
+    val selectedReceiverNames: List<String>
+        get() = receivers.filter { it.receiverId in selectedReceiverIds }.map { it.name }
 }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DiaryWriteViewModel.kt
@@ -2,6 +2,7 @@ package com.afternote.feature.mindrecord.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.core.domain.repository.UserRepository
 import com.afternote.core.ui.UiText
 import com.afternote.feature.mindrecord.domain.model.DiaryCreatePayload
 import com.afternote.feature.mindrecord.domain.model.TodayMood
@@ -21,9 +22,25 @@ class DiaryWriteViewModel
     @Inject
     constructor(
         private val repository: DiaryRepository,
+        private val userRepository: UserRepository,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(DiaryWriteUiState())
         val uiState: StateFlow<DiaryWriteUiState> = _uiState.asStateFlow()
+
+        init {
+            loadReceivers()
+        }
+
+        private fun loadReceivers() {
+            viewModelScope.launch {
+                val receivers = runCatching { userRepository.getReceivers() }.getOrElse { emptyList() }
+                _uiState.update { it.copy(receivers = receivers) }
+            }
+        }
+
+        fun onReceiversSelected(ids: Set<Long>) {
+            _uiState.update { it.copy(selectedReceiverIds = ids) }
+        }
 
         fun onTitleChanged(value: String) {
             _uiState.update { it.copy(title = value) }
@@ -56,6 +73,7 @@ class DiaryWriteViewModel
                             isDraft = isDraft,
                             todayMood = mood,
                             imageUrl = state.imageUrl,
+                            receiverIds = state.selectedReceiverIds.toList(),
                         ),
                     ).onSuccess {
                         _uiState.update { it.copy(submitState = SubmitState.Succeeded) }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DraftListUiState.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DraftListUiState.kt
@@ -7,24 +7,22 @@ import java.time.LocalDate
  * 작성 화면 키보드 툴바 "임시저장 N" 영역에서 진입하는 임시저장 목록 화면 상태.
  *
  * 데일리질문 / 일기 / 깊은 생각 3개 카테고리의 isDraft=true 항목을 합쳐 보여준다.
- * 데일리질문 응답은 isDraft 필드를 노출하지 않아 현재는 분류 불가 — 화면 필터 옵션은 유지하되
- * 실제 항목은 비어 있게 보인다 (TODO: 백엔드 응답 확장 후 매핑).
+ * 데일리질문 응답은 isDraft 필드를 노출하지 않아 현재는 분류 불가 — 실제 항목은 비어 있게 보인다
+ * (TODO: 백엔드 응답 확장 후 매핑).
+ *
+ * Figma 2372:22842 리디자인 — 카테고리 필터가 제거되고 선택(다중 선택 삭제) 모드가 추가됐다.
  */
 sealed interface DraftListUiState {
     data object Loading : DraftListUiState
 
     data class Success(
         val items: List<DraftItem>,
-        val filter: DraftCategory,
+        val selectionMode: Boolean = false,
+        val selectedKeys: Set<String> = emptySet(),
     ) : DraftListUiState {
-        val filtered: List<DraftItem>
-            get() =
-                when (filter) {
-                    DraftCategory.All -> items
-                    else -> items.filter { it.category == filter }
-                }
+        val totalCount: Int get() = items.size
 
-        val totalCount: Int get() = filtered.size
+        val selectedCount: Int get() = selectedKeys.size
     }
 
     data class Error(
@@ -33,7 +31,6 @@ sealed interface DraftListUiState {
 }
 
 enum class DraftCategory {
-    All,
     DailyQuestion,
     Diary,
     DeepThought,
@@ -44,4 +41,9 @@ data class DraftItem(
     val category: DraftCategory,
     val content: String,
     val date: LocalDate,
-)
+    /** 수신인 이름. 백엔드 응답에 아직 없어 null이면 카테고리 라벨로 대체 표기한다 (TODO). */
+    val recipientName: String? = null,
+) {
+    /** 카테고리별 id 충돌을 피하기 위한 리스트/선택용 고유 키. */
+    val key: String get() = "${category.name}-$id"
+}

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DraftListViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/DraftListViewModel.kt
@@ -9,9 +9,13 @@ import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.mapper.toUi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -26,6 +30,8 @@ import javax.inject.Inject
  * - 데일리질문: 응답에 `isDraft` 가 없어 분류 불가 → 0건 처리 (TODO).
  *
  * 두 호출은 병렬로 묶고, 어느 한쪽이 실패해도 다른 쪽은 비어 있는 결과로 합쳐 화면이 깨지지 않게 한다.
+ *
+ * 선택 모드에서 전체/선택 삭제 시 항목별 delete API를 병렬 호출하고, 성공한 항목만 목록에서 제거한다.
  */
 @HiltViewModel
 class DraftListViewModel
@@ -37,15 +43,92 @@ class DraftListViewModel
         private val _uiState = MutableStateFlow<DraftListUiState>(DraftListUiState.Loading)
         val uiState: StateFlow<DraftListUiState> = _uiState.asStateFlow()
 
+        /** 삭제 완료 토스트("임시 저장된 기록이 삭제 되었습니다") 노출 이벤트. */
+        private val _deletedEvent = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+        val deletedEvent: SharedFlow<Unit> = _deletedEvent.asSharedFlow()
+
         init {
             load()
         }
 
         fun refresh() = load()
 
-        fun onFilterChanged(filter: DraftCategory) {
-            _uiState.update {
-                if (it is DraftListUiState.Success) it.copy(filter = filter) else it
+        /** 상단 "선택"/"완료" 버튼 — 선택 모드를 토글하고 종료 시 선택을 초기화한다. */
+        fun onSelectionModeToggled() {
+            _uiState.update { state ->
+                if (state is DraftListUiState.Success) {
+                    if (state.selectionMode) {
+                        state.copy(selectionMode = false, selectedKeys = emptySet())
+                    } else {
+                        state.copy(selectionMode = true)
+                    }
+                } else {
+                    state
+                }
+            }
+        }
+
+        fun onItemCheckedChanged(item: DraftItem) {
+            _uiState.update { state ->
+                if (state is DraftListUiState.Success) {
+                    val selected =
+                        if (item.key in state.selectedKeys) {
+                            state.selectedKeys - item.key
+                        } else {
+                            state.selectedKeys + item.key
+                        }
+                    state.copy(selectedKeys = selected)
+                } else {
+                    state
+                }
+            }
+        }
+
+        fun onDeleteAllClick() {
+            val state = _uiState.value as? DraftListUiState.Success ?: return
+            deleteItems(state.items)
+        }
+
+        fun onDeleteSelectedClick() {
+            val state = _uiState.value as? DraftListUiState.Success ?: return
+            deleteItems(state.items.filter { it.key in state.selectedKeys })
+        }
+
+        private fun deleteItems(targets: List<DraftItem>) {
+            if (targets.isEmpty()) return
+            viewModelScope.launch {
+                val deletedKeys =
+                    coroutineScope {
+                        targets
+                            .map { item ->
+                                async {
+                                    val result =
+                                        when (item.category) {
+                                            DraftCategory.Diary -> diaryRepository.delete(item.id)
+
+                                            DraftCategory.DeepThought -> deepThoughtRepository.delete(item.id)
+
+                                            // 데일리질문은 isDraft 미노출로 목록에 없음 — 방어적으로 통과 처리.
+                                            DraftCategory.DailyQuestion -> Result.success(Unit)
+                                        }
+                                    item.key.takeIf { result.isSuccess }
+                                }
+                            }.awaitAll()
+                            .filterNotNull()
+                            .toSet()
+                    }
+                if (deletedKeys.isEmpty()) return@launch
+                _uiState.update { state ->
+                    if (state is DraftListUiState.Success) {
+                        state.copy(
+                            items = state.items.filterNot { it.key in deletedKeys },
+                            selectedKeys = state.selectedKeys - deletedKeys,
+                        )
+                    } else {
+                        state
+                    }
+                }
+                _deletedEvent.tryEmit(Unit)
             }
         }
 
@@ -55,7 +138,7 @@ class DraftListViewModel
                 val items = collectDrafts()
                 _uiState.value =
                     if (items != null) {
-                        DraftListUiState.Success(items = items, filter = DraftCategory.All)
+                        DraftListUiState.Success(items = items)
                     } else {
                         DraftListUiState.Error(UiText.Resource(R.string.mindrecord_error_generic))
                     }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportViewModel.kt
@@ -127,8 +127,8 @@ class WeeklyReportViewModel
                     dayOfWeek = date.dayOfWeek,
                     content =
                         when {
-                            emoji != null && isDiary -> DayContent.EmojiWithDot(emoji)
-                            emoji != null -> DayContent.EmojiOnly(emoji)
+                            emoji != null && isDiary -> DayContent.EmojiWithDot(dayOfMonth, emoji)
+                            emoji != null -> DayContent.EmojiOnly(dayOfMonth, emoji)
                             isDiary -> DayContent.NumberWithDot(dayOfMonth)
                             else -> DayContent.NumberOnly(dayOfMonth)
                         },


### PR DESCRIPTION
## 개요
마음의 기록 신규 디자인 반영 + Swagger(`afternote.kro.kr/v3/api-docs`) 기준 API 정합.

## 스웨거 정합 수정 (c17790ad)
- DeepThought 요청 태그 키 `tag`→`tags`, 카테고리 생성/수정 바디 `{category,deepThoughtId}`/`{category}`→`{title}`
- `deep-thought/categories` 응답 `{categories:[...]}` 래퍼로 디코딩 수정, `deep-thought`/`daily-questions` `draftOnly` 쿼리 추가
- 주간리포트 `isDiary`→`diary` 키 정정
- Diary/DailyQuestion/DeepThought 요청에서 스웨거에 없는 `imageUrl`/`date`/`questionId` 제거, `receiverIds` 추가, 업데이트 필드 nullable화

## 검증
- `compileDebugKotlin` / `compileDebugUnitTestKotlin` 통과

## 후속(논의 중)
- 마음의 기록에서 **DeepThought(깊은 생각) 제거** 범위 확정 후 별도 반영 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)