### PR TITLE
feat(core): 로그인 확정 시 활동 기록 ping 신설 (closes 429)

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/MainViewModel.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/MainViewModel.kt
@@ -2,13 +2,17 @@ package com.afternote.afternote_fe
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.core.domain.repository.UserRepository
 import com.afternote.core.domain.repository.auth.AuthRepository
 import com.afternote.core.ui.Route
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -16,6 +20,7 @@ class MainViewModel
     @Inject
     constructor(
         authRepository: AuthRepository,
+        private val userRepository: UserRepository,
     ) : ViewModel() {
         /**
          * 초기 진입 시 null(로딩)이며, [AuthRepository.isLoggedIn]이 방출된 뒤 목적지가 확정된다.
@@ -30,4 +35,22 @@ class MainViewModel
                     started = SharingStarted.WhileSubscribed(5_000),
                     initialValue = null,
                 )
+
+        init {
+            // 로그인 상태가 처음 true 로 확정되는 시점에 활동 기록 ping 을 1회 전송 (미사용 타이머 리셋, 이슈 #429).
+            // filter { it } 는 isLoggedIn(Boolean) 이 true(로그인) 인 방출만 통과시킨다 (= filter { it == true },
+            // it 이 이미 Boolean 이라 == true 생략한 관용구). 이어 take(1) 는 그중 첫 1건을 받으면 flow 를
+            // 완료(구독 취소)해 이후 true 재방출(토큰 갱신·DataStore 재방출 등)을 무시 → 중복 ping 을 막는다.
+            // 결과: 프로세스(= MainViewModel 인스턴스)당 한 번만 발화. 앱 진입 Activity 스코프라 사실상 앱 실행당 1회.
+            // WhileSubscribed 재구독으로 인한 중복 방출과 무관하게 최초 로그인 확정 1건만 소비한다.
+            // ping 실패가 스플래시/네비게이션을 막지 않도록 best-effort(runCatching) 처리.
+            viewModelScope.launch {
+                authRepository.isLoggedIn
+                    .filter { it }
+                    .take(1)
+                    .collect {
+                        runCatching { userRepository.logActivity() }
+                    }
+            }
+        }
     }

--- a/core/data/src/main/java/com/afternote/core/data/repoimpl/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/afternote/core/data/repoimpl/UserRepositoryImpl.kt
@@ -138,6 +138,12 @@ class UserRepositoryImpl
                 .requireStatus()
         }
 
+        override suspend fun logActivity() {
+            userApiService
+                .logActivity()
+                .requireStatus()
+        }
+
         override suspend fun getMyPushSettings(): UserPushSetting =
             userApiService
                 .getMyPushSettings()

--- a/core/domain/src/main/java/com/afternote/core/domain/repository/UserRepository.kt
+++ b/core/domain/src/main/java/com/afternote/core/domain/repository/UserRepository.kt
@@ -56,6 +56,9 @@ interface UserRepository {
     // 회원 탈퇴
     suspend fun deleteAccount()
 
+    // 활동 기록(ping) — 앱 실행/로그인 확정 시 미사용(INACTIVITY) 전달조건 타이머를 리셋
+    suspend fun logActivity()
+
     // 푸시 알림 설정 조회
     suspend fun getMyPushSettings(): UserPushSetting
 

--- a/core/network/src/main/kotlin/com/afternote/core/network/service/UserApiService.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/service/UserApiService.kt
@@ -68,6 +68,17 @@ interface UserApiService {
     @DELETE("users/me")
     suspend fun deleteAccount(): BaseResponse<Unit>
 
+    /**
+     * 활동 기록(ping) — 서버에 "이 사용자가 방금 활동했다" 는 **사실만** 알리는 무바디 신호.
+     *
+     * 요청·응답 바디 없음(누구인지는 액세스 토큰으로 서버가 식별). 서버는 이를 받아 그 사용자의
+     * "마지막 활동 시각" 을 갱신한다. 사후 전달의 INACTIVITY(장기 미사용 → 사망 추정 → 자동 전달)
+     * 판정 기준이 이 시각이므로, 앱 실행/로그인 확정 시 1회 호출해 "아직 활동 중" 으로 미사용 타이머를
+     * 리셋한다. 사용자가 앱을 오래 안 열면 ping 이 끊겨 시각이 굳고 → 미사용 기간이 쌓여 조건 충족 (이슈 #429).
+     */
+    @POST("users/me/activity")
+    suspend fun logActivity(): BaseResponse<Unit>
+
     // 푸시 알림 설정 조회
     @GET("users/push-settings")
     suspend fun getMyPushSettings(): BaseResponse<UserPushSettingResponseDto>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #429 — feat(core): 활동 추적 ping(POST users/me/activity) 신설

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `UserApiService.logActivity()` — `@POST users/me/activity` 무바디 ping (`BaseResponse<Unit>` + `requireStatus()`, `deleteAccount()` 선례 복제)
- `UserRepository`/`UserRepositoryImpl` 에 `logActivity()` 배선
- `MainViewModel` 에 `UserRepository` 주입 + `isLoggedIn.filter { it }.take(1)` 로 로그인 확정 첫 1건에만 best-effort(`runCatching`) ping — 프로세스(앱 실행)당 1회 발화, WhileSubscribed 재구독/토큰 갱신 재방출로 인한 중복 차단

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 앱 진입 시 백그라운드 네트워크 호출만 추가됩니다.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 목적: 사후 전달 재설계의 INACTIVITY(장기 미사용 → 자동 전달) 판정 기준인 "마지막 활동 시각" 을 앱 실행 시 갱신합니다.
- 완전 독립 이슈(blocked_by 없음) — delivery-conditions 재설계 코어 스택 중 병렬 진행 가능분입니다.
- 미확인(서버 응답 형태): `POST users/me/activity` 응답이 표준 `BaseResponse` 봉투인지 vs 204 빈 바디인지 실서버 미실측 상태로 `BaseResponse<Unit>` 를 가정했습니다. 레포에 무바디 `@POST` 선례가 없어 정상 전송 실측을 권장합니다.
- 빌드 검증: `./gradlew :app:compileDebugKotlin :core:network:compileDebugKotlin :core:domain:compileDebugKotlin :core:data:compileDebugKotlin` BUILD SUCCESSFUL (Hilt KSP 포함), ktlint 그린
