### PR TITLE
feat(core): 수신자별 전달조건 조회/설정 데이터 계층 추가 (closes 427)

### DIFF
--- a/core/data/src/main/java/com/afternote/core/data/mapper/delivery/DeliveryConditionMapper.kt
+++ b/core/data/src/main/java/com/afternote/core/data/mapper/delivery/DeliveryConditionMapper.kt
@@ -1,0 +1,108 @@
+package com.afternote.core.data.mapper.delivery
+
+import com.afternote.core.model.delivery.ConditionState
+import com.afternote.core.model.delivery.DeliveryConditionItem
+import com.afternote.core.model.delivery.DeliveryConditionType
+import com.afternote.core.model.delivery.DeliveryContentType
+import com.afternote.core.model.delivery.InactivityPeriod
+import com.afternote.core.model.delivery.ReceiverDeliveryConditions
+import com.afternote.core.network.dto.delivery.ConditionStateDto
+import com.afternote.core.network.dto.delivery.DeliveryConditionItemRequest
+import com.afternote.core.network.dto.delivery.DeliveryConditionItemResponse
+import com.afternote.core.network.dto.delivery.DeliveryConditionTypeDto
+import com.afternote.core.network.dto.delivery.DeliveryContentTypeDto
+import com.afternote.core.network.dto.delivery.InactivityPeriodDto
+import com.afternote.core.network.dto.delivery.ReceiverDeliveryConditionResponse
+
+// ========================================
+// Enum Mapper (DTO → Domain)
+// ========================================
+
+fun DeliveryContentTypeDto.toDomain(): DeliveryContentType =
+    when (this) {
+        DeliveryContentTypeDto.TIME_LETTER -> DeliveryContentType.TIME_LETTER
+        DeliveryContentTypeDto.AFTERNOTE -> DeliveryContentType.AFTERNOTE
+        DeliveryContentTypeDto.DAILY_QUESTION -> DeliveryContentType.DAILY_QUESTION
+        DeliveryContentTypeDto.DIARY -> DeliveryContentType.DIARY
+        DeliveryContentTypeDto.DEEP_THOUGHT -> DeliveryContentType.DEEP_THOUGHT
+    }
+
+fun DeliveryConditionTypeDto.toDomain(): DeliveryConditionType =
+    when (this) {
+        DeliveryConditionTypeDto.INACTIVITY -> DeliveryConditionType.INACTIVITY
+        DeliveryConditionTypeDto.RECEIVER_REQUEST -> DeliveryConditionType.RECEIVER_REQUEST
+    }
+
+fun InactivityPeriodDto.toDomain(): InactivityPeriod =
+    when (this) {
+        InactivityPeriodDto.THREE_MONTHS -> InactivityPeriod.THREE_MONTHS
+        InactivityPeriodDto.SIX_MONTHS -> InactivityPeriod.SIX_MONTHS
+        InactivityPeriodDto.ONE_YEAR -> InactivityPeriod.ONE_YEAR
+    }
+
+fun ConditionStateDto.toDomain(): ConditionState =
+    when (this) {
+        ConditionStateDto.ACTIVE -> ConditionState.ACTIVE
+        ConditionStateDto.PENDING_CONFIRMATION -> ConditionState.PENDING_CONFIRMATION
+        ConditionStateDto.WAITING_VERIFICATION -> ConditionState.WAITING_VERIFICATION
+        ConditionStateDto.FULFILLED -> ConditionState.FULFILLED
+    }
+
+// ========================================
+// Enum Mapper (Domain → DTO, 요청용)
+// ========================================
+
+fun DeliveryContentType.toDto(): DeliveryContentTypeDto =
+    when (this) {
+        DeliveryContentType.TIME_LETTER -> DeliveryContentTypeDto.TIME_LETTER
+        DeliveryContentType.AFTERNOTE -> DeliveryContentTypeDto.AFTERNOTE
+        DeliveryContentType.DAILY_QUESTION -> DeliveryContentTypeDto.DAILY_QUESTION
+        DeliveryContentType.DIARY -> DeliveryContentTypeDto.DIARY
+        DeliveryContentType.DEEP_THOUGHT -> DeliveryContentTypeDto.DEEP_THOUGHT
+    }
+
+fun DeliveryConditionType.toDto(): DeliveryConditionTypeDto =
+    when (this) {
+        DeliveryConditionType.INACTIVITY -> DeliveryConditionTypeDto.INACTIVITY
+        DeliveryConditionType.RECEIVER_REQUEST -> DeliveryConditionTypeDto.RECEIVER_REQUEST
+    }
+
+fun InactivityPeriod.toDto(): InactivityPeriodDto =
+    when (this) {
+        InactivityPeriod.THREE_MONTHS -> InactivityPeriodDto.THREE_MONTHS
+        InactivityPeriod.SIX_MONTHS -> InactivityPeriodDto.SIX_MONTHS
+        InactivityPeriod.ONE_YEAR -> InactivityPeriodDto.ONE_YEAR
+    }
+
+// ========================================
+// Response Mapper (DTO → Domain)
+// ========================================
+
+fun DeliveryConditionItemResponse.toDomain(): DeliveryConditionItem =
+    DeliveryConditionItem(
+        contentType = contentType.toDomain(),
+        conditionType = conditionType.toDomain(),
+        inactivityPeriod = inactivityPeriod?.toDomain(),
+        state = state.toDomain(),
+        fulfilled = fulfilled,
+        gracePeriodStartedAt = gracePeriodStartedAt,
+        fulfilledAt = fulfilledAt,
+    )
+
+fun ReceiverDeliveryConditionResponse.toDomain(): ReceiverDeliveryConditions =
+    ReceiverDeliveryConditions(
+        receiverId = receiverId,
+        conditions = conditions.map { it.toDomain() },
+    )
+
+// ========================================
+// Request Mapper (Domain → DTO)
+// ========================================
+
+/** 설정(PUT) 요청 항목으로 변환 — 서버 판정 필드(state/fulfilled/시각)는 보내지 않는다. */
+fun DeliveryConditionItem.toRequestDto(): DeliveryConditionItemRequest =
+    DeliveryConditionItemRequest(
+        contentType = contentType.toDto(),
+        conditionType = conditionType.toDto(),
+        inactivityPeriod = inactivityPeriod?.toDto(),
+    )

--- a/core/data/src/main/java/com/afternote/core/data/repoimpl/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/afternote/core/data/repoimpl/UserRepositoryImpl.kt
@@ -1,8 +1,11 @@
 package com.afternote.core.data.repoimpl
 
+import com.afternote.core.data.mapper.delivery.toRequestDto
 import com.afternote.core.data.mapper.user.toDomain
 import com.afternote.core.data.mapper.user.toDto
 import com.afternote.core.domain.repository.UserRepository
+import com.afternote.core.model.delivery.DeliveryConditionItem
+import com.afternote.core.model.delivery.ReceiverDeliveryConditions
 import com.afternote.core.model.user.DeliveryCondition
 import com.afternote.core.model.user.DeliveryConditionType
 import com.afternote.core.model.user.Receiver
@@ -18,6 +21,7 @@ import com.afternote.core.network.dto.UserPatchReceiverRequest
 import com.afternote.core.network.dto.UserUpdateProfileRequest
 import com.afternote.core.network.dto.UserUpdatePushSettingRequest
 import com.afternote.core.network.dto.UserUpdateReceiverMessageRequest
+import com.afternote.core.network.dto.delivery.ReceiverDeliveryConditionUpdateRequest
 import com.afternote.core.network.model.requireData
 import com.afternote.core.network.model.requireStatus
 import com.afternote.core.network.service.UserApiService
@@ -27,6 +31,7 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
+import com.afternote.core.data.mapper.delivery.toDomain as toDeliveryConditionsDomain
 
 class UserRepositoryImpl
     @Inject
@@ -202,4 +207,21 @@ class UserRepositoryImpl
                     ),
                 ).requireData()
                 .toDomain()
+
+        override suspend fun getReceiverDeliveryConditions(receiverId: Long): ReceiverDeliveryConditions =
+            userApiService
+                .getReceiverDeliveryConditions(receiverId)
+                .requireData()
+                .toDeliveryConditionsDomain()
+
+        override suspend fun updateReceiverDeliveryConditions(
+            receiverId: Long,
+            conditions: List<DeliveryConditionItem>,
+        ): ReceiverDeliveryConditions =
+            userApiService
+                .updateReceiverDeliveryConditions(
+                    receiverId = receiverId,
+                    request = ReceiverDeliveryConditionUpdateRequest(conditions.map { it.toRequestDto() }),
+                ).requireData()
+                .toDeliveryConditionsDomain()
     }

--- a/core/data/src/test/java/com/afternote/core/data/mapper/delivery/DeliveryConditionMapperTest.kt
+++ b/core/data/src/test/java/com/afternote/core/data/mapper/delivery/DeliveryConditionMapperTest.kt
@@ -1,0 +1,112 @@
+package com.afternote.core.data.mapper.delivery
+
+import com.afternote.core.model.delivery.ConditionState
+import com.afternote.core.model.delivery.DeliveryConditionItem
+import com.afternote.core.model.delivery.DeliveryConditionType
+import com.afternote.core.model.delivery.DeliveryContentType
+import com.afternote.core.model.delivery.InactivityPeriod
+import com.afternote.core.network.dto.delivery.ConditionStateDto
+import com.afternote.core.network.dto.delivery.DeliveryConditionItemResponse
+import com.afternote.core.network.dto.delivery.DeliveryConditionTypeDto
+import com.afternote.core.network.dto.delivery.DeliveryContentTypeDto
+import com.afternote.core.network.dto.delivery.InactivityPeriodDto
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * [DeliveryConditionMapper] enum·응답 매핑 회귀 가드 (이슈 #427).
+ *
+ * 서버 enum 추가/누락 시 `when` 분기 누락이 도메인에 조용히 반영되는 사고를 막는다.
+ * 검증 방식은 [com.afternote.core.data.mapper.user.UserMapperTest] 와 동일 — DTO/Domain 의
+ * 동일 이름 상수를 `valueOf` 로 독립 조회해 매퍼 결과와 대조(자기검증 아님).
+ */
+class DeliveryConditionMapperTest {
+    @Test
+    fun `DeliveryContentType 매핑 - 양방향 전체 케이스 + round-trip + 개수 동기화`() {
+        DeliveryContentTypeDto.entries.forEach { dto ->
+            assertEquals(DeliveryContentType.valueOf(dto.name), dto.toDomain())
+        }
+        DeliveryContentType.entries.forEach { domain ->
+            assertEquals(DeliveryContentTypeDto.valueOf(domain.name), domain.toDto())
+            assertEquals(domain, domain.toDto().toDomain())
+        }
+        assertEquals(DeliveryContentTypeDto.entries.size, DeliveryContentType.entries.size)
+    }
+
+    @Test
+    fun `DeliveryConditionType 매핑 - 양방향 전체 케이스 + round-trip + 개수 동기화`() {
+        DeliveryConditionTypeDto.entries.forEach { dto ->
+            assertEquals(DeliveryConditionType.valueOf(dto.name), dto.toDomain())
+        }
+        DeliveryConditionType.entries.forEach { domain ->
+            assertEquals(DeliveryConditionTypeDto.valueOf(domain.name), domain.toDto())
+            assertEquals(domain, domain.toDto().toDomain())
+        }
+        assertEquals(DeliveryConditionTypeDto.entries.size, DeliveryConditionType.entries.size)
+    }
+
+    @Test
+    fun `InactivityPeriod 매핑 - 양방향 전체 케이스 + round-trip + 개수 동기화`() {
+        InactivityPeriodDto.entries.forEach { dto ->
+            assertEquals(InactivityPeriod.valueOf(dto.name), dto.toDomain())
+        }
+        InactivityPeriod.entries.forEach { domain ->
+            assertEquals(InactivityPeriodDto.valueOf(domain.name), domain.toDto())
+            assertEquals(domain, domain.toDto().toDomain())
+        }
+        assertEquals(InactivityPeriodDto.entries.size, InactivityPeriod.entries.size)
+    }
+
+    @Test
+    fun `ConditionState 매핑 - 응답 전용 전체 케이스 + 개수 동기화`() {
+        // ConditionState 는 서버 판정 값이라 응답(toDomain)만 존재 — 요청 방향(toDto) 없음.
+        ConditionStateDto.entries.forEach { dto ->
+            assertEquals(ConditionState.valueOf(dto.name), dto.toDomain())
+        }
+        assertEquals(ConditionStateDto.entries.size, ConditionState.entries.size)
+    }
+
+    @Test
+    fun `DeliveryConditionItemResponse toDomain - 필드 보존 + INACTIVITY 기간 매핑`() {
+        val dto =
+            DeliveryConditionItemResponse(
+                contentType = DeliveryContentTypeDto.AFTERNOTE,
+                conditionType = DeliveryConditionTypeDto.INACTIVITY,
+                inactivityPeriod = InactivityPeriodDto.ONE_YEAR,
+                state = ConditionStateDto.PENDING_CONFIRMATION,
+                fulfilled = false,
+                gracePeriodStartedAt = "2026-07-08T00:00:00Z",
+                fulfilledAt = null,
+            )
+
+        val domain = dto.toDomain()
+
+        assertEquals(DeliveryContentType.AFTERNOTE, domain.contentType)
+        assertEquals(DeliveryConditionType.INACTIVITY, domain.conditionType)
+        assertEquals(InactivityPeriod.ONE_YEAR, domain.inactivityPeriod)
+        assertEquals(ConditionState.PENDING_CONFIRMATION, domain.state)
+        assertEquals(false, domain.fulfilled)
+        assertEquals("2026-07-08T00:00:00Z", domain.gracePeriodStartedAt)
+        assertEquals(null, domain.fulfilledAt)
+    }
+
+    @Test
+    fun `DeliveryConditionItem toRequestDto - RECEIVER_REQUEST 는 기간 null 유지`() {
+        val item =
+            DeliveryConditionItem(
+                contentType = DeliveryContentType.DIARY,
+                conditionType = DeliveryConditionType.RECEIVER_REQUEST,
+                inactivityPeriod = null,
+                state = ConditionState.ACTIVE,
+                fulfilled = false,
+                gracePeriodStartedAt = null,
+                fulfilledAt = null,
+            )
+
+        val req = item.toRequestDto()
+
+        assertEquals(DeliveryContentTypeDto.DIARY, req.contentType)
+        assertEquals(DeliveryConditionTypeDto.RECEIVER_REQUEST, req.conditionType)
+        assertEquals(null, req.inactivityPeriod)
+    }
+}

--- a/core/domain/src/main/java/com/afternote/core/domain/repository/UserRepository.kt
+++ b/core/domain/src/main/java/com/afternote/core/domain/repository/UserRepository.kt
@@ -1,5 +1,7 @@
 package com.afternote.core.domain.repository
 
+import com.afternote.core.model.delivery.DeliveryConditionItem
+import com.afternote.core.model.delivery.ReceiverDeliveryConditions
 import com.afternote.core.model.user.DeliveryCondition
 import com.afternote.core.model.user.DeliveryConditionType
 import com.afternote.core.model.user.Receiver
@@ -87,4 +89,13 @@ interface UserRepository {
         inactivityPeriodDays: Int?,
         specificDate: String?,
     ): DeliveryCondition
+
+    // 수신자별 전달조건 조회 (콘텐츠별)
+    suspend fun getReceiverDeliveryConditions(receiverId: Long): ReceiverDeliveryConditions
+
+    // 수신자별 전달조건 설정/변경 (보낸 conditions 로 저장)
+    suspend fun updateReceiverDeliveryConditions(
+        receiverId: Long,
+        conditions: List<DeliveryConditionItem>,
+    ): ReceiverDeliveryConditions
 }

--- a/core/model/src/main/kotlin/com/afternote/core/model/delivery/DeliveryConditionModels.kt
+++ b/core/model/src/main/kotlin/com/afternote/core/model/delivery/DeliveryConditionModels.kt
@@ -1,0 +1,79 @@
+package com.afternote.core.model.delivery
+
+/**
+ * 전달 대상 콘텐츠 유형. 세 도메인(타임레터·애프터노트·마인드레코드)의 콘텐츠를 아우른다.
+ *
+ * 이 패키지(수신자별 전달조건 도메인, 이슈 #427)는 서버가 전달조건을 유저단위 → (수신자 × 콘텐츠) 단위로
+ * 재설계하며 신설된 축이다. 기존 유저단위 [com.afternote.core.model.user.DeliveryConditionType]
+ * (NONE/INACTIVITY/SPECIFIC_DATE) 은 값·의미가 달라 재사용 불가(이슈 #428 에서 제거 예정)해 별도 패키지에 둔다.
+ */
+enum class DeliveryContentType {
+    TIME_LETTER,
+    AFTERNOTE,
+    DAILY_QUESTION,
+    DIARY,
+    DEEP_THOUGHT,
+}
+
+/** 전달 조건 충족 방식. */
+enum class DeliveryConditionType {
+    /** 일정 기간 미활동 → 본인확인 유예 → 자동 전달. */
+    INACTIVITY,
+
+    /** 수신자가 서류를 제출하고 운영자가 승인 → 전달. */
+    RECEIVER_REQUEST,
+}
+
+/** 미사용 자동 전달(INACTIVITY)의 기준 기간. RECEIVER_REQUEST 조건에서는 사용하지 않는다(null). */
+enum class InactivityPeriod {
+    THREE_MONTHS,
+    SIX_MONTHS,
+    ONE_YEAR,
+}
+
+/** 단일 조건의 진행 상태. */
+enum class ConditionState {
+    /** 조건이 걸려 있으나 아직 트리거 전. */
+    ACTIVE,
+
+    /**
+     * INACTIVITY 안전장치 — 미사용이 감지됐지만 곧장 전달하지 않고 "정말 부재/사망이 맞는지"
+     * 확인하는 유예 대기 상태. 이 기간(문서상 7일, [DeliveryConditionItem.gracePeriodStartedAt] 부터 카운트)
+     * 에 사용자가 앱을 열면(활동 ping) 본인 생존이 확인돼 조건이 취소·리셋되고, 무반응이면 부재 확정 →
+     * FULFILLED. 잠깐 앱을 안 썼을 뿐인 산 사람의 유산이 열리는 오발동을 막는 완충 단계.
+     */
+    PENDING_CONFIRMATION,
+
+    /** 수신자 요청 서류의 운영자 승인 대기. */
+    WAITING_VERIFICATION,
+
+    /** 조건 충족 완료 → 열람 가능. */
+    FULFILLED,
+}
+
+/** 수신자 1인의 콘텐츠별 전달조건 묶음. */
+data class ReceiverDeliveryConditions(
+    val receiverId: Long,
+    val conditions: List<DeliveryConditionItem>,
+)
+
+/**
+ * 단일 (콘텐츠 × 조건) 항목.
+ *
+ * @property inactivityPeriod [DeliveryConditionType.INACTIVITY] 일 때만 채워진다.
+ * @property state 조회 시점의 진행 상태. 설정(PUT) 요청에는 포함하지 않는다(서버 판정 값).
+ * @property gracePeriodStartedAt 본인확인 유예 **시작** 시각(ISO-8601), 없으면 null. 전달 확정 시점은
+ *   이 시각 + 유예 기간이다. 주의: 유예 기간(재설계 문서상 7일)은 응답에 없다 — "유예 D-N" 같은 남은
+ *   시간을 표시하려면 그 상수가 필요한데 서버가 안 주므로 FE 하드코딩에 의존하게 된다(인증번호 TTL #421 과
+ *   동일 패턴). UI 붙일 때 7일 확정 + 응답 포함 여부를 서버에 확인할 것.
+ * @property fulfilledAt 조건 충족 확정 시각(ISO-8601), 없으면 null.
+ */
+data class DeliveryConditionItem(
+    val contentType: DeliveryContentType,
+    val conditionType: DeliveryConditionType,
+    val inactivityPeriod: InactivityPeriod?,
+    val state: ConditionState,
+    val fulfilled: Boolean,
+    val gracePeriodStartedAt: String?,
+    val fulfilledAt: String?,
+)

--- a/core/network/src/main/kotlin/com/afternote/core/network/dto/delivery/DeliveryConditionDto.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/dto/delivery/DeliveryConditionDto.kt
@@ -1,0 +1,116 @@
+package com.afternote.core.network.dto.delivery
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * `GET/PUT /users/me/receivers/{receiverId}/delivery-conditions` DTO (이슈 #427).
+ *
+ * Swagger 실측(2026-07-08, afternote.kro.kr/v3/api-docs) 스키마와 1:1. 유저단위(구)
+ * [com.afternote.core.network.dto.DeliveryConditionTypeDto] 와 값이 달라 별도 패키지에 둔다.
+ */
+
+@Serializable
+enum class DeliveryContentTypeDto {
+    @SerialName("TIME_LETTER")
+    TIME_LETTER,
+
+    @SerialName("AFTERNOTE")
+    AFTERNOTE,
+
+    @SerialName("DAILY_QUESTION")
+    DAILY_QUESTION,
+
+    @SerialName("DIARY")
+    DIARY,
+
+    @SerialName("DEEP_THOUGHT")
+    DEEP_THOUGHT,
+}
+
+@Serializable
+enum class DeliveryConditionTypeDto {
+    @SerialName("INACTIVITY")
+    INACTIVITY,
+
+    @SerialName("RECEIVER_REQUEST")
+    RECEIVER_REQUEST,
+}
+
+@Serializable
+enum class InactivityPeriodDto {
+    @SerialName("THREE_MONTHS")
+    THREE_MONTHS,
+
+    @SerialName("SIX_MONTHS")
+    SIX_MONTHS,
+
+    @SerialName("ONE_YEAR")
+    ONE_YEAR,
+}
+
+@Serializable
+enum class ConditionStateDto {
+    @SerialName("ACTIVE")
+    ACTIVE,
+
+    @SerialName("PENDING_CONFIRMATION")
+    PENDING_CONFIRMATION,
+
+    @SerialName("WAITING_VERIFICATION")
+    WAITING_VERIFICATION,
+
+    @SerialName("FULFILLED")
+    FULFILLED,
+}
+
+// ========================================
+// Request (PUT)
+// ========================================
+
+@Serializable
+data class DeliveryConditionItemRequest(
+    @SerialName("contentType") val contentType: DeliveryContentTypeDto,
+    @SerialName("conditionType") val conditionType: DeliveryConditionTypeDto,
+    @SerialName("inactivityPeriod") val inactivityPeriod: InactivityPeriodDto? = null,
+)
+
+@Serializable
+data class ReceiverDeliveryConditionUpdateRequest(
+    @SerialName("conditions") val conditions: List<DeliveryConditionItemRequest>,
+)
+
+// ========================================
+// Response (GET/PUT)
+// ========================================
+
+/**
+ * 수신자별 전달조건 1건의 조회 응답. 요청([DeliveryConditionItemRequest])엔 없는 4개 필드
+ * (state·fulfilled·gracePeriodStartedAt·fulfilledAt)는 **서버가 판정해 내려주는 값**이라 응답에만 있다.
+ *
+ * @property state 조건 진행 상태 — ACTIVE(대기) / PENDING_CONFIRMATION(미사용 감지 후 본인확인 유예 중) /
+ *   WAITING_VERIFICATION(수신자 요청 서류의 운영자 승인 대기) / FULFILLED(충족 완료). 값 정의는 [ConditionStateDto].
+ * @property fulfilled 충족(열람 가능) 여부. 열람 잠금/열림 판정은 이 boolean 하나로 충분하고, state 는
+ *   "왜 아직 안 열렸나(유예 중/승인 대기)" 진행 단계를 보여준다 — 결과(fulfilled) vs 과정(state) 로 역할이 갈린다.
+ *   대체로 state==FULFILLED 와 동치로 보이나, "조건 변경 시 서류/검증 유지" 규칙에서 state 가 리셋돼도
+ *   fulfilled 가 남을 여지가 있어 **완전 파생인지는 실서버 미확인** — 항상 동치로 단정하지 말 것.
+ * @property gracePeriodStartedAt INACTIVITY 경로에서 미사용 감지 후 본인확인 유예가 시작된 시각(ISO-8601).
+ *   이 시점부터 유예 카운트다운. 유예 진입 전이면 null.
+ * @property fulfilledAt 조건이 충족(전달 확정)된 시각(ISO-8601). 아직 미충족이면 null.
+ */
+@Serializable
+data class DeliveryConditionItemResponse(
+    @SerialName("contentType") val contentType: DeliveryContentTypeDto,
+    @SerialName("conditionType") val conditionType: DeliveryConditionTypeDto,
+    @SerialName("inactivityPeriod") val inactivityPeriod: InactivityPeriodDto? = null,
+    @SerialName("state") val state: ConditionStateDto,
+    @SerialName("fulfilled") val fulfilled: Boolean,
+    @SerialName("gracePeriodStartedAt") val gracePeriodStartedAt: String? = null,
+    @SerialName("fulfilledAt") val fulfilledAt: String? = null,
+)
+
+@Serializable
+data class ReceiverDeliveryConditionResponse(
+    @SerialName("receiverId") val receiverId: Long,
+    @SerialName("conditions") val conditions: List<DeliveryConditionItemResponse>,
+)

--- a/core/network/src/main/kotlin/com/afternote/core/network/service/UserApiService.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/service/UserApiService.kt
@@ -15,12 +15,15 @@ import com.afternote.core.network.dto.UserResponseDto
 import com.afternote.core.network.dto.UserUpdateProfileRequest
 import com.afternote.core.network.dto.UserUpdatePushSettingRequest
 import com.afternote.core.network.dto.UserUpdateReceiverMessageRequest
+import com.afternote.core.network.dto.delivery.ReceiverDeliveryConditionResponse
+import com.afternote.core.network.dto.delivery.ReceiverDeliveryConditionUpdateRequest
 import com.afternote.core.network.model.BaseResponse
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Path
 
 interface UserApiService {
@@ -104,4 +107,35 @@ interface UserApiService {
     suspend fun updateDeliveryCondition(
         @Body request: DeliveryConditionRequest,
     ): BaseResponse<DeliveryConditionResponseDto>
+
+    /**
+     * 수신자별 전달조건 조회 — 특정 수신자(receiverId)에게 **콘텐츠 종류마다** 다르게 건 전달 조건 목록.
+     *
+     * 사후 전달을 (수신자 × 콘텐츠) 단위로 쪼갠 재설계의 핵심 축 (이슈 #427). 유저 전체에 조건 1개였던
+     * 구조를 대체한다. 예: 엄마에겐 애프터노트를 "1년 미사용 시"(INACTIVITY), 다이어리를 "본인이 사망증빙
+     * 후 요청 시"(RECEIVER_REQUEST) 로 각각 걸 수 있다. 조건 1건 = contentType + conditionType +
+     * inactivityPeriod(INACTIVITY 한정) + state(진행 상태).
+     */
+    @GET("users/me/receivers/{receiverId}/delivery-conditions")
+    suspend fun getReceiverDeliveryConditions(
+        @Path("receiverId") receiverId: Long,
+    ): BaseResponse<ReceiverDeliveryConditionResponse>
+
+    /**
+     * 수신자별 전달조건 설정/변경 — 보낸 conditions[] 로 저장하고, **변경이 반영된 최신 전체 목록**을
+     * [getReceiverDeliveryConditions] 와 동일한 구조로 응답한다.
+     *
+     * **응답을 받아 쓰는 이유**: 요청 바디엔 조건 3필드(contentType·conditionType·inactivityPeriod)만
+     * 담기지만, 화면에 필요한 state·fulfilled·gracePeriodStartedAt 은 서버만 계산할 수 있는 판정값이다
+     * (기존 서류/검증 DB 를 봐야 승인 대기인지 이미 충족인지 판단). 응답이 이 값들을 채워 주므로 그대로
+     * 화면에 반영하면 되고, 저장 후 상태 갱신용 GET 재조회가 불필요하다(왕복 1회 절약 + 로컬/서버 즉시 일치).
+     *
+     * 서버 규칙(Swagger): INACTIVITY 는 inactivityPeriod(3/6/12개월) 필수, RECEIVER_REQUEST 는 서류
+     * 제출 후 운영자 승인. **조건을 바꿔도 이미 제출된 서류/검증 상태는 유지**되어 응답의 state 에 반영된다.
+     */
+    @PUT("users/me/receivers/{receiverId}/delivery-conditions")
+    suspend fun updateReceiverDeliveryConditions(
+        @Path("receiverId") receiverId: Long,
+        @Body request: ReceiverDeliveryConditionUpdateRequest,
+    ): BaseResponse<ReceiverDeliveryConditionResponse>
 }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #427 — feat(core): 수신자별 전달조건(delivery-conditions) 조회/설정 데이터 계층 추가

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- 신규 패키지 `core.model.delivery` — enum 4종(`DeliveryContentType`·`DeliveryConditionType`·`InactivityPeriod`·`ConditionState`) + `ReceiverDeliveryConditions`·`DeliveryConditionItem`
- 신규 패키지 `core.network.dto.delivery` — 요청/응답 DTO + 대응 enum
- 신규 패키지 `core.data.mapper.delivery` — DTO↔Domain 매퍼(+ 매퍼 단위테스트 6건, enum 이름 기반 독립 검증 + round-trip)
- `UserApiService` 에 `GET/PUT users/me/receivers/{receiverId}/delivery-conditions` 추가 + `UserRepository`/`UserRepositoryImpl` 확장
- UI 제외 — 데이터 계층만 (수신자 상세 조건 설정 화면은 `feature:setting` 몫)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — core 데이터 계층(모델/DTO/매퍼/API) 신설.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 아키텍처 결정(합의 시 조정 가능): (1) 전용 스택 신설 대신 `UserApiService`/`UserRepository` 확장 — `users/me` 계열 일관성 (2) 신규 enum 이 기존 `user.DeliveryConditionType`(NONE/INACTIVITY/SPECIFIC_DATE)와 이름·값이 충돌해 `delivery` 서브패키지로 격리 (3) 매퍼 `toDomain` 이 `user.toDomain` 과 충돌해 `UserRepositoryImpl` 에서 `as toDeliveryConditionsDomain` alias 사용
- `inactivityPeriod` 는 nullable(RECEIVER_REQUEST 는 null), `ConditionState`/`fulfilled`/시각 필드는 서버 판정값이라 응답 전용
- 미확인: 본인확인 유예 기간(재설계 문서상 7일)이 응답에 없음 — `gracePeriodStartedAt`(시작 시각)만 옴. 향후 UI 에서 "유예 D-N" 표시 시 서버 확인 필요(#421 인증번호 유효시간과 동일 패턴)
- 후속: **#428(유저단위 delivery-condition 제거)이 이 PR 을 blocked_by** — 머지 후 진행. 박경민 `feature:setting` UI 마이그레이션과 제거 순서 조율 필요
- 빌드 검증: `./gradlew :core:model:compileDebugKotlin :core:network:compileDebugKotlin :core:domain:compileDebugKotlin :core:data:compileDebugKotlin` BUILD SUCCESSFUL, `:core:data:testDebugUnitTest`(매퍼 6건)·ktlint 그린
