### PR TITLE
refactor(data): wire 모델 명명 -Dto 통일 (closes 444)

### DIFF
--- a/core/data/src/main/java/com/afternote/core/data/mapper/auth/AuthMapper.kt
+++ b/core/data/src/main/java/com/afternote/core/data/mapper/auth/AuthMapper.kt
@@ -3,29 +3,29 @@ package com.afternote.core.data.mapper.auth
 import com.afternote.core.model.AccountRegistration
 import com.afternote.core.model.Session
 import com.afternote.core.model.TokenBundle
-import com.afternote.core.network.dto.LoginData
-import com.afternote.core.network.dto.ReissueData
-import com.afternote.core.network.dto.SignUpData
+import com.afternote.core.network.dto.LoginDto
+import com.afternote.core.network.dto.ReissueDto
+import com.afternote.core.network.dto.SignUpDto
 
 /**
  * Auth DTO를 Domain 모델로 변환. (스웨거 기준)
  */
 object AuthMapper {
-    fun toSignUpResult(dto: SignUpData): AccountRegistration = AccountRegistration(userId = dto.userId, email = dto.email)
+    fun toSignUpResult(dto: SignUpDto): AccountRegistration = AccountRegistration(userId = dto.userId, email = dto.email)
 
-    fun toDefaultLoginResult(dto: LoginData.DefaultLoginData): Session.DefaultSession =
+    fun toDefaultLoginResult(dto: LoginDto.DefaultLoginDto): Session.DefaultSession =
         Session.DefaultSession(
             accessToken = dto.accessToken,
             refreshToken = dto.refreshToken,
         )
 
-    fun toSocialLoginResult(dto: LoginData.SocialLoginData): Session.SocialSession =
+    fun toSocialLoginResult(dto: LoginDto.SocialLoginDto): Session.SocialSession =
         Session.SocialSession(
             accessToken = dto.accessToken,
             refreshToken = dto.refreshToken,
             isNewUser = dto.isNewUser,
         )
 
-    fun toRotateTokenResult(dto: ReissueData): TokenBundle =
+    fun toRotateTokenResult(dto: ReissueDto): TokenBundle =
         TokenBundle(accessToken = dto.accessToken, refreshToken = dto.refreshToken, expiresIn = dto.expiresIn)
 }

--- a/core/data/src/main/java/com/afternote/core/data/mapper/delivery/DeliveryConditionMapper.kt
+++ b/core/data/src/main/java/com/afternote/core/data/mapper/delivery/DeliveryConditionMapper.kt
@@ -7,12 +7,12 @@ import com.afternote.core.model.delivery.DeliveryContentType
 import com.afternote.core.model.delivery.InactivityPeriod
 import com.afternote.core.model.delivery.ReceiverDeliveryConditions
 import com.afternote.core.network.dto.delivery.ConditionStateDto
-import com.afternote.core.network.dto.delivery.DeliveryConditionItemRequest
-import com.afternote.core.network.dto.delivery.DeliveryConditionItemResponse
+import com.afternote.core.network.dto.delivery.DeliveryConditionItemDto
+import com.afternote.core.network.dto.delivery.DeliveryConditionItemRequestDto
 import com.afternote.core.network.dto.delivery.DeliveryConditionTypeDto
 import com.afternote.core.network.dto.delivery.DeliveryContentTypeDto
 import com.afternote.core.network.dto.delivery.InactivityPeriodDto
-import com.afternote.core.network.dto.delivery.ReceiverDeliveryConditionResponse
+import com.afternote.core.network.dto.delivery.ReceiverDeliveryConditionDto
 
 // ========================================
 // Enum Mapper (DTO → Domain)
@@ -78,7 +78,7 @@ fun InactivityPeriod.toDto(): InactivityPeriodDto =
 // Response Mapper (DTO → Domain)
 // ========================================
 
-fun DeliveryConditionItemResponse.toDomain(): DeliveryConditionItem =
+fun DeliveryConditionItemDto.toDomain(): DeliveryConditionItem =
     DeliveryConditionItem(
         contentType = contentType.toDomain(),
         conditionType = conditionType.toDomain(),
@@ -89,7 +89,7 @@ fun DeliveryConditionItemResponse.toDomain(): DeliveryConditionItem =
         fulfilledAt = fulfilledAt,
     )
 
-fun ReceiverDeliveryConditionResponse.toDomain(): ReceiverDeliveryConditions =
+fun ReceiverDeliveryConditionDto.toDomain(): ReceiverDeliveryConditions =
     ReceiverDeliveryConditions(
         receiverId = receiverId,
         conditions = conditions.map { it.toDomain() },
@@ -100,8 +100,8 @@ fun ReceiverDeliveryConditionResponse.toDomain(): ReceiverDeliveryConditions =
 // ========================================
 
 /** 설정(PUT) 요청 항목으로 변환 — 서버 판정 필드(state/fulfilled/시각)는 보내지 않는다. */
-fun DeliveryConditionItem.toRequestDto(): DeliveryConditionItemRequest =
-    DeliveryConditionItemRequest(
+fun DeliveryConditionItem.toRequestDto(): DeliveryConditionItemRequestDto =
+    DeliveryConditionItemRequestDto(
         contentType = contentType.toDto(),
         conditionType = conditionType.toDto(),
         inactivityPeriod = inactivityPeriod?.toDto(),

--- a/core/data/src/main/java/com/afternote/core/data/mapper/user/UserMapper.kt
+++ b/core/data/src/main/java/com/afternote/core/data/mapper/user/UserMapper.kt
@@ -8,15 +8,15 @@ import com.afternote.core.model.user.ReceiverDetail
 import com.afternote.core.model.user.User
 import com.afternote.core.model.user.UserConnectedAccount
 import com.afternote.core.model.user.UserPushSetting
-import com.afternote.core.network.dto.DeliveryConditionResponseDto
+import com.afternote.core.network.dto.DeliveryConditionDto
 import com.afternote.core.network.dto.DeliveryConditionTypeDto
-import com.afternote.core.network.dto.ReceiverDetailResponseDto
-import com.afternote.core.network.dto.ReceiverListResponseDto
-import com.afternote.core.network.dto.UserConnectedAccountResponseDto
-import com.afternote.core.network.dto.UserCreateReceiverResponseDto
-import com.afternote.core.network.dto.UserPatchReceiverResponseDto
-import com.afternote.core.network.dto.UserPushSettingResponseDto
-import com.afternote.core.network.dto.UserResponseDto
+import com.afternote.core.network.dto.ReceiverDetailDto
+import com.afternote.core.network.dto.ReceiverListDto
+import com.afternote.core.network.dto.UserConnectedAccountDto
+import com.afternote.core.network.dto.UserCreateReceiverDto
+import com.afternote.core.network.dto.UserDto
+import com.afternote.core.network.dto.UserPatchReceiverDto
+import com.afternote.core.network.dto.UserPushSettingDto
 
 // ========================================
 // Enum Mapper
@@ -40,7 +40,7 @@ fun DeliveryConditionType.toDto(): DeliveryConditionTypeDto =
 // Response Mapper (DTO → Domain)
 // ========================================
 
-fun UserResponseDto.toDomain(): User =
+fun UserDto.toDomain(): User =
     User(
         name = name,
         email = email,
@@ -48,7 +48,7 @@ fun UserResponseDto.toDomain(): User =
         profileImageUrl = profileImageUrl,
     )
 
-fun ReceiverListResponseDto.toDomain(): Receiver =
+fun ReceiverListDto.toDomain(): Receiver =
     Receiver(
         receiverId = receiverId,
         name = name,
@@ -56,7 +56,7 @@ fun ReceiverListResponseDto.toDomain(): Receiver =
         authCode = authCode,
     )
 
-fun ReceiverDetailResponseDto.toDomain(): ReceiverDetail =
+fun ReceiverDetailDto.toDomain(): ReceiverDetail =
     ReceiverDetail(
         receiverId = receiverId,
         name = name,
@@ -70,13 +70,13 @@ fun ReceiverDetailResponseDto.toDomain(): ReceiverDetail =
         authCode = authCode,
     )
 
-fun UserCreateReceiverResponseDto.toDomain(): ReceiverCreated =
+fun UserCreateReceiverDto.toDomain(): ReceiverCreated =
     ReceiverCreated(
         receiverId = receiverId,
         authCode = authCode,
     )
 
-fun UserPatchReceiverResponseDto.toDomain(): Receiver =
+fun UserPatchReceiverDto.toDomain(): Receiver =
     Receiver(
         receiverId = receiverId,
         name = name,
@@ -84,14 +84,14 @@ fun UserPatchReceiverResponseDto.toDomain(): Receiver =
         authCode = "",
     )
 
-fun UserPushSettingResponseDto.toDomain(): UserPushSetting =
+fun UserPushSettingDto.toDomain(): UserPushSetting =
     UserPushSetting(
         timeLetter = timeLetter,
         mindRecord = mindRecord,
         afterNote = afterNote,
     )
 
-fun UserConnectedAccountResponseDto.toDomain(): UserConnectedAccount =
+fun UserConnectedAccountDto.toDomain(): UserConnectedAccount =
     UserConnectedAccount(
         local = local,
         google = google,
@@ -105,7 +105,7 @@ fun UserConnectedAccountResponseDto.toDomain(): UserConnectedAccount =
         appleEmail = appleEmail,
     )
 
-fun DeliveryConditionResponseDto.toDomain(): DeliveryCondition =
+fun DeliveryConditionDto.toDomain(): DeliveryCondition =
     DeliveryCondition(
         conditionType = conditionType.toDomain(),
         inactivityPeriodDays = inactivityPeriodDays,

--- a/core/data/src/main/java/com/afternote/core/data/repoimpl/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/afternote/core/data/repoimpl/UserRepositoryImpl.kt
@@ -14,14 +14,14 @@ import com.afternote.core.model.user.ReceiverDetail
 import com.afternote.core.model.user.User
 import com.afternote.core.model.user.UserConnectedAccount
 import com.afternote.core.model.user.UserPushSetting
-import com.afternote.core.network.dto.DeliveryConditionRequest
-import com.afternote.core.network.dto.SocialAccountLinkRequest
-import com.afternote.core.network.dto.UserCreateReceiverRequest
-import com.afternote.core.network.dto.UserPatchReceiverRequest
-import com.afternote.core.network.dto.UserUpdateProfileRequest
-import com.afternote.core.network.dto.UserUpdatePushSettingRequest
-import com.afternote.core.network.dto.UserUpdateReceiverMessageRequest
-import com.afternote.core.network.dto.delivery.ReceiverDeliveryConditionUpdateRequest
+import com.afternote.core.network.dto.DeliveryConditionRequestDto
+import com.afternote.core.network.dto.SocialAccountLinkRequestDto
+import com.afternote.core.network.dto.UserCreateReceiverRequestDto
+import com.afternote.core.network.dto.UserPatchReceiverRequestDto
+import com.afternote.core.network.dto.UserUpdateProfileRequestDto
+import com.afternote.core.network.dto.UserUpdatePushSettingRequestDto
+import com.afternote.core.network.dto.UserUpdateReceiverMessageRequestDto
+import com.afternote.core.network.dto.delivery.ReceiverDeliveryConditionUpdateRequestDto
 import com.afternote.core.network.model.requireData
 import com.afternote.core.network.model.requireStatus
 import com.afternote.core.network.service.UserApiService
@@ -66,7 +66,7 @@ class UserRepositoryImpl
             val result =
                 userApiService
                     .createReceiver(
-                        UserCreateReceiverRequest(
+                        UserCreateReceiverRequestDto(
                             name = name,
                             relation = relation,
                             phone = phone,
@@ -96,7 +96,7 @@ class UserRepositoryImpl
                 .updateReceiver(
                     receiverId = receiverId,
                     request =
-                        UserPatchReceiverRequest(
+                        UserPatchReceiverRequestDto(
                             name = name,
                             phone = phone,
                             relation = relation,
@@ -112,7 +112,7 @@ class UserRepositoryImpl
             userApiService
                 .updateReceiverMessage(
                     receiverId = receiverId,
-                    request = UserUpdateReceiverMessageRequest(message = message),
+                    request = UserUpdateReceiverMessageRequestDto(message = message),
                 ).requireStatus()
         }
 
@@ -129,7 +129,7 @@ class UserRepositoryImpl
         ): User =
             userApiService
                 .updateMyProfile(
-                    UserUpdateProfileRequest(
+                    UserUpdateProfileRequestDto(
                         name = name,
                         phone = phone,
                         profileImageUrl = profileImageUrl,
@@ -162,7 +162,7 @@ class UserRepositoryImpl
         ): UserPushSetting =
             userApiService
                 .updateMyPushSettings(
-                    UserUpdatePushSettingRequest(
+                    UserUpdatePushSettingRequestDto(
                         timeLetter = timeLetter,
                         mindRecord = mindRecord,
                         afterNote = afterNote,
@@ -183,7 +183,7 @@ class UserRepositoryImpl
             userApiService
                 .linkConnectedAccount(
                     provider = provider,
-                    request = SocialAccountLinkRequest(accessToken = accessToken),
+                    request = SocialAccountLinkRequestDto(accessToken = accessToken),
                 ).requireData()
                 .toDomain()
 
@@ -206,7 +206,7 @@ class UserRepositoryImpl
         ): DeliveryCondition =
             userApiService
                 .updateDeliveryCondition(
-                    DeliveryConditionRequest(
+                    DeliveryConditionRequestDto(
                         conditionType = conditionType.toDto(),
                         inactivityPeriodDays = inactivityPeriodDays,
                         specificDate = specificDate,
@@ -227,7 +227,7 @@ class UserRepositoryImpl
             userApiService
                 .updateReceiverDeliveryConditions(
                     receiverId = receiverId,
-                    request = ReceiverDeliveryConditionUpdateRequest(conditions.map { it.toRequestDto() }),
+                    request = ReceiverDeliveryConditionUpdateRequestDto(conditions.map { it.toRequestDto() }),
                 ).requireData()
                 .toDeliveryConditionsDomain()
     }

--- a/core/data/src/main/java/com/afternote/core/data/repoimpl/account/AccountRepositoryImpl.kt
+++ b/core/data/src/main/java/com/afternote/core/data/repoimpl/account/AccountRepositoryImpl.kt
@@ -3,10 +3,10 @@ package com.afternote.core.data.repoimpl.account
 import com.afternote.core.data.mapper.auth.AuthMapper
 import com.afternote.core.domain.repository.account.AccountRepository
 import com.afternote.core.model.AccountRegistration
-import com.afternote.core.network.dto.PasswordChangeRequest
-import com.afternote.core.network.dto.SendEmailCodeRequest
-import com.afternote.core.network.dto.SignUpRequest
-import com.afternote.core.network.dto.VerifyEmailRequest
+import com.afternote.core.network.dto.PasswordChangeRequestDto
+import com.afternote.core.network.dto.SendEmailCodeRequestDto
+import com.afternote.core.network.dto.SignUpRequestDto
+import com.afternote.core.network.dto.VerifyEmailRequestDto
 import com.afternote.core.network.model.requireData
 import com.afternote.core.network.model.requireStatus
 import com.afternote.core.network.service.AccountApiService
@@ -20,7 +20,7 @@ class AccountRepositoryImpl
     ) : AccountRepository {
         override suspend fun sendEmailCode(email: String): Result<Unit> =
             runCatching {
-                accountApiService.sendEmailCode(SendEmailCodeRequest(email))
+                accountApiService.sendEmailCode(SendEmailCodeRequestDto(email))
             }
 
         override suspend fun verifyEmail(
@@ -30,7 +30,7 @@ class AccountRepositoryImpl
             runCatching {
                 accountApiService
                     .verifyEmail(
-                        VerifyEmailRequest(
+                        VerifyEmailRequestDto(
                             email,
                             certificateCode,
                         ),
@@ -46,7 +46,7 @@ class AccountRepositoryImpl
             runCatching {
                 val response =
                     accountApiService.signUp(
-                        SignUpRequest(
+                        SignUpRequestDto(
                             email,
                             password,
                             name,
@@ -63,7 +63,7 @@ class AccountRepositoryImpl
             runCatching {
                 accountApiService
                     .passwordChange(
-                        PasswordChangeRequest(
+                        PasswordChangeRequestDto(
                             currentPassword,
                             newPassword,
                         ),

--- a/core/data/src/main/java/com/afternote/core/data/repoimpl/auth/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/afternote/core/data/repoimpl/auth/AuthRepositoryImpl.kt
@@ -5,10 +5,10 @@ import com.afternote.core.datastore.TokenDataSource
 import com.afternote.core.domain.repository.auth.AuthRepository
 import com.afternote.core.model.Session
 import com.afternote.core.model.TokenBundle
-import com.afternote.core.network.dto.LoginRequest
-import com.afternote.core.network.dto.LogoutRequest
-import com.afternote.core.network.dto.ReissueRequest
-import com.afternote.core.network.dto.SocialLoginRequest
+import com.afternote.core.network.dto.LoginRequestDto
+import com.afternote.core.network.dto.LogoutRequestDto
+import com.afternote.core.network.dto.ReissueRequestDto
+import com.afternote.core.network.dto.SocialLoginRequestDto
 import com.afternote.core.network.model.requireData
 import com.afternote.core.network.service.AuthApiService
 import com.afternote.core.network.service.TokenApiService
@@ -70,7 +70,7 @@ class AuthRepositoryImpl
             password: String,
         ): Result<Session.DefaultSession> =
             runCatching {
-                val data = authApiService.login(LoginRequest(email, password)).requireData()
+                val data = authApiService.login(LoginRequestDto(email, password)).requireData()
                 recordIssuedExpiresIn(data.expiresIn)
                 AuthMapper.toDefaultLoginResult(data)
             }
@@ -80,7 +80,7 @@ class AuthRepositoryImpl
                 val data =
                     authApiService
                         .socialLogin(
-                            SocialLoginRequest(
+                            SocialLoginRequestDto(
                                 provider = "KAKAO",
                                 accessToken = oauthToken,
                             ),
@@ -94,7 +94,7 @@ class AuthRepositoryImpl
                 val data =
                     authApiService
                         .socialLogin(
-                            SocialLoginRequest(
+                            SocialLoginRequestDto(
                                 provider = "GOOGLE",
                                 accessToken = idToken,
                             ),
@@ -108,7 +108,7 @@ class AuthRepositoryImpl
                 val refreshToken =
                     getRefreshToken().getOrNull()
                         ?: error("리프레시 토큰이 존재하지 않습니다.")
-                val response = tokenApiService.reissue(ReissueRequest(refreshToken))
+                val response = tokenApiService.reissue(ReissueRequestDto(refreshToken))
                 val tokenBundleResult = AuthMapper.toRotateTokenResult(response.requireData())
                 updateTokens(
                     accessToken = tokenBundleResult.accessToken,
@@ -125,7 +125,7 @@ class AuthRepositoryImpl
             runCatching {
                 val refreshToken = getRefreshToken().getOrNull()
                 if (refreshToken != null) {
-                    runCatching { authApiService.logout(LogoutRequest(refreshToken)) }
+                    runCatching { authApiService.logout(LogoutRequestDto(refreshToken)) }
                 }
                 tokenDataSource.clearTokens()
                 // deadline 은 방금 지운 액세스 토큰의 잔여 수명 기록 — 토큰이 사라지는 순간 의미를 잃으므로

--- a/core/data/src/test/java/com/afternote/core/data/mapper/auth/AuthMapperTest.kt
+++ b/core/data/src/test/java/com/afternote/core/data/mapper/auth/AuthMapperTest.kt
@@ -3,9 +3,9 @@ package com.afternote.core.data.mapper.auth
 import com.afternote.core.model.AccountRegistration
 import com.afternote.core.model.Session
 import com.afternote.core.model.TokenBundle
-import com.afternote.core.network.dto.LoginData
-import com.afternote.core.network.dto.ReissueData
-import com.afternote.core.network.dto.SignUpData
+import com.afternote.core.network.dto.LoginDto
+import com.afternote.core.network.dto.ReissueDto
+import com.afternote.core.network.dto.SignUpDto
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -19,7 +19,7 @@ import org.junit.Test
 class AuthMapperTest {
     @Test
     fun `toSignUpResult - userId·email 매핑`() {
-        val result = AuthMapper.toSignUpResult(SignUpData(userId = 42L, email = "user@example.com"))
+        val result = AuthMapper.toSignUpResult(SignUpDto(userId = 42L, email = "user@example.com"))
 
         assertEquals(AccountRegistration(userId = 42L, email = "user@example.com"), result)
     }
@@ -28,7 +28,7 @@ class AuthMapperTest {
     fun `toDefaultLoginResult - 토큰 매핑 (자리 바뀜 가드)`() {
         val result =
             AuthMapper.toDefaultLoginResult(
-                LoginData.DefaultLoginData(accessToken = "access-1", refreshToken = "refresh-1"),
+                LoginDto.DefaultLoginDto(accessToken = "access-1", refreshToken = "refresh-1"),
             )
 
         assertEquals(
@@ -44,7 +44,7 @@ class AuthMapperTest {
         listOf(true, false, null).forEach { newUser ->
             val result =
                 AuthMapper.toSocialLoginResult(
-                    LoginData.SocialLoginData(
+                    LoginDto.SocialLoginDto(
                         accessToken = "access-1",
                         refreshToken = "refresh-1",
                         isNewUser = newUser,
@@ -63,7 +63,7 @@ class AuthMapperTest {
     fun `toRotateTokenResult - 토큰·expiresIn 매핑 (자리 바뀜 가드)`() {
         val result =
             AuthMapper.toRotateTokenResult(
-                ReissueData(accessToken = "access-1", refreshToken = "refresh-1", expiresIn = 3599),
+                ReissueDto(accessToken = "access-1", refreshToken = "refresh-1", expiresIn = 3599),
             )
 
         assertEquals(

--- a/core/data/src/test/java/com/afternote/core/data/mapper/delivery/DeliveryConditionMapperTest.kt
+++ b/core/data/src/test/java/com/afternote/core/data/mapper/delivery/DeliveryConditionMapperTest.kt
@@ -6,7 +6,7 @@ import com.afternote.core.model.delivery.DeliveryConditionType
 import com.afternote.core.model.delivery.DeliveryContentType
 import com.afternote.core.model.delivery.InactivityPeriod
 import com.afternote.core.network.dto.delivery.ConditionStateDto
-import com.afternote.core.network.dto.delivery.DeliveryConditionItemResponse
+import com.afternote.core.network.dto.delivery.DeliveryConditionItemDto
 import com.afternote.core.network.dto.delivery.DeliveryConditionTypeDto
 import com.afternote.core.network.dto.delivery.DeliveryContentTypeDto
 import com.afternote.core.network.dto.delivery.InactivityPeriodDto
@@ -67,9 +67,9 @@ class DeliveryConditionMapperTest {
     }
 
     @Test
-    fun `DeliveryConditionItemResponse toDomain - 필드 보존 + INACTIVITY 기간 매핑`() {
+    fun `DeliveryConditionItemDto toDomain - 필드 보존 + INACTIVITY 기간 매핑`() {
         val dto =
-            DeliveryConditionItemResponse(
+            DeliveryConditionItemDto(
                 contentType = DeliveryContentTypeDto.AFTERNOTE,
                 conditionType = DeliveryConditionTypeDto.INACTIVITY,
                 inactivityPeriod = InactivityPeriodDto.ONE_YEAR,

--- a/core/data/src/test/java/com/afternote/core/data/repoimpl/auth/AuthRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/afternote/core/data/repoimpl/auth/AuthRepositoryImplTest.kt
@@ -4,12 +4,12 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.emptyPreferences
 import com.afternote.core.datastore.TokenDataSource
-import com.afternote.core.network.dto.LoginData
-import com.afternote.core.network.dto.LoginRequest
-import com.afternote.core.network.dto.LogoutRequest
-import com.afternote.core.network.dto.ReissueData
-import com.afternote.core.network.dto.ReissueRequest
-import com.afternote.core.network.dto.SocialLoginRequest
+import com.afternote.core.network.dto.LoginDto
+import com.afternote.core.network.dto.LoginRequestDto
+import com.afternote.core.network.dto.LogoutRequestDto
+import com.afternote.core.network.dto.ReissueDto
+import com.afternote.core.network.dto.ReissueRequestDto
+import com.afternote.core.network.dto.SocialLoginRequestDto
 import com.afternote.core.network.model.ApiException
 import com.afternote.core.network.model.BaseResponse
 import com.afternote.core.network.service.AuthApiService
@@ -51,7 +51,7 @@ class AuthRepositoryImplTest {
         val repository =
             repository(
                 FakeAuthApiService(
-                    onLogin = { success(LoginData.DefaultLoginData("access", "refresh", expiresIn = 30)) },
+                    onLogin = { success(LoginDto.DefaultLoginDto("access", "refresh", expiresIn = 30)) },
                 ),
             )
 
@@ -67,7 +67,7 @@ class AuthRepositoryImplTest {
         val repository =
             repository(
                 FakeAuthApiService(
-                    onLogin = { success(LoginData.DefaultLoginData("access", "refresh")) },
+                    onLogin = { success(LoginDto.DefaultLoginDto("access", "refresh")) },
                 ),
             )
 
@@ -83,7 +83,7 @@ class AuthRepositoryImplTest {
         val repository =
             repository(
                 FakeAuthApiService(
-                    onSocialLogin = { success(LoginData.SocialLoginData("access", "refresh")) },
+                    onSocialLogin = { success(LoginDto.SocialLoginDto("access", "refresh")) },
                 ),
             )
 
@@ -102,7 +102,7 @@ class AuthRepositoryImplTest {
         val result = runBlocking { repository(authApiService).logout() }
 
         assertTrue(result.isSuccess)
-        assertEquals(listOf(LogoutRequest("stored-refresh")), authApiService.logoutRequests)
+        assertEquals(listOf(LogoutRequestDto("stored-refresh")), authApiService.logoutRequests)
         assertNull(runBlocking { tokenDataSource.getRefreshToken() })
         assertFalse(tracker.isExpiringSoon())
     }
@@ -143,28 +143,28 @@ private fun <T> success(data: T) = BaseResponse(status = 200, code = 200, messag
  * (core:network 의 FakeAuthRepository 와 같은 규칙).
  */
 private class FakeAuthApiService(
-    private val onLogin: () -> BaseResponse<LoginData.DefaultLoginData> = {
+    private val onLogin: () -> BaseResponse<LoginDto.DefaultLoginDto> = {
         error("login 은 이 시나리오에서 호출되면 안 됨")
     },
-    private val onSocialLogin: () -> BaseResponse<LoginData.SocialLoginData> = {
+    private val onSocialLogin: () -> BaseResponse<LoginDto.SocialLoginDto> = {
         error("socialLogin 은 이 시나리오에서 호출되면 안 됨")
     },
     private val onLogout: () -> BaseResponse<Unit> = { success(Unit) },
 ) : AuthApiService {
-    val logoutRequests = mutableListOf<LogoutRequest>()
+    val logoutRequests = mutableListOf<LogoutRequestDto>()
 
-    override suspend fun login(body: LoginRequest): BaseResponse<LoginData.DefaultLoginData> = onLogin()
+    override suspend fun login(body: LoginRequestDto): BaseResponse<LoginDto.DefaultLoginDto> = onLogin()
 
-    override suspend fun socialLogin(body: SocialLoginRequest): BaseResponse<LoginData.SocialLoginData> = onSocialLogin()
+    override suspend fun socialLogin(body: SocialLoginRequestDto): BaseResponse<LoginDto.SocialLoginDto> = onSocialLogin()
 
-    override suspend fun logout(body: LogoutRequest): BaseResponse<Unit> {
+    override suspend fun logout(body: LogoutRequestDto): BaseResponse<Unit> {
         logoutRequests += body
         return onLogout()
     }
 }
 
 private class FakeTokenApiService : TokenApiService {
-    override suspend fun reissue(body: ReissueRequest): BaseResponse<ReissueData> = error("reissue 는 이 시나리오에서 호출되면 안 됨")
+    override suspend fun reissue(body: ReissueRequestDto): BaseResponse<ReissueDto> = error("reissue 는 이 시나리오에서 호출되면 안 됨")
 }
 
 /** 단위 테스트용 in-memory `DataStore<Preferences>` — 디스크 없이 [TokenDataSource] 실물을 구동한다. */

--- a/core/model/src/main/kotlin/com/afternote/core/model/SocialProvider.kt
+++ b/core/model/src/main/kotlin/com/afternote/core/model/SocialProvider.kt
@@ -7,7 +7,7 @@ package com.afternote.core.model
  *
  * 표현 형식이 endpoint 마다 달라 변환 함수를 분리:
  * - [toPath]: `/users/connected-accounts/{provider}` 같은 URL path 용 (lowercase)
- * - [toBody]: `SocialLoginRequest.provider` 같은 request body 용 (uppercase)
+ * - [toBody]: `SocialLoginRequestDto.provider` 같은 request body 용 (uppercase)
  */
 enum class SocialProvider {
     GOOGLE,

--- a/core/network/src/main/kotlin/com/afternote/core/network/dto/AuthDto.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/dto/AuthDto.kt
@@ -4,18 +4,18 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class SendEmailCodeRequest(
+data class SendEmailCodeRequestDto(
     val email: String,
 )
 
 @Serializable
-data class VerifyEmailRequest(
+data class VerifyEmailRequestDto(
     val email: String,
     @SerialName("certificateCode") val certificateCode: String,
 )
 
 @Serializable
-data class SignUpRequest(
+data class SignUpRequestDto(
     val email: String,
     val password: String,
     val name: String,
@@ -23,25 +23,25 @@ data class SignUpRequest(
 )
 
 @Serializable
-data class SignUpData(
+data class SignUpDto(
     @SerialName("userId") val userId: Long,
     val email: String,
 )
 
 @Serializable
-data class LoginRequest(
+data class LoginRequestDto(
     val email: String,
     val password: String,
 )
 
 /** Request for unified social login (POST /auth/social/login). */
 @Serializable
-data class SocialLoginRequest(
+data class SocialLoginRequestDto(
     val provider: String,
     @SerialName("accessToken") val accessToken: String,
 )
 
-sealed class LoginData {
+sealed class LoginDto {
     abstract val accessToken: String
     abstract val refreshToken: String
 
@@ -55,41 +55,41 @@ sealed class LoginData {
     abstract val expiresIn: Long?
 
     @Serializable
-    data class DefaultLoginData(
+    data class DefaultLoginDto(
         override val accessToken: String,
         override val refreshToken: String,
         override val expiresIn: Long? = null,
-    ) : LoginData()
+    ) : LoginDto()
 
     @Serializable
-    data class SocialLoginData(
+    data class SocialLoginDto(
         override val accessToken: String,
         override val refreshToken: String,
         @SerialName("newUser") val isNewUser: Boolean? = null,
         override val expiresIn: Long? = null,
-    ) : LoginData()
+    ) : LoginDto()
 }
 
 @Serializable
-data class ReissueRequest(
+data class ReissueRequestDto(
     val refreshToken: String,
 )
 
 @Serializable
-data class ReissueData(
+data class ReissueDto(
     val accessToken: String,
     val refreshToken: String,
-    /** 재발급된 액세스 토큰의 잔여 수명(초). BE #410 으로 reissue 응답 `data` 에 포함. [LoginData.expiresIn] 참고. */
+    /** 재발급된 액세스 토큰의 잔여 수명(초). BE #410 으로 reissue 응답 `data` 에 포함. [LoginDto.expiresIn] 참고. */
     val expiresIn: Long? = null,
 )
 
 @Serializable
-data class LogoutRequest(
+data class LogoutRequestDto(
     val refreshToken: String,
 )
 
 @Serializable
-data class PasswordChangeRequest(
+data class PasswordChangeRequestDto(
     val currentPassword: String,
     val newPassword: String,
 )

--- a/core/network/src/main/kotlin/com/afternote/core/network/dto/PresignedUrlDto.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/dto/PresignedUrlDto.kt
@@ -9,7 +9,7 @@ data class PresignedUrlRequestDto(
 )
 
 @Serializable
-data class PresignedUrlResponseDto(
+data class PresignedUrlDto(
     val presignedUrl: String,
     val fileKey: String,
     val fileUrl: String,

--- a/core/network/src/main/kotlin/com/afternote/core/network/dto/UserDto.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/dto/UserDto.kt
@@ -20,7 +20,7 @@ enum class DeliveryConditionTypeDto {
 // ========================================
 
 @Serializable
-data class UserCreateReceiverRequest(
+data class UserCreateReceiverRequestDto(
     @SerialName("name") val name: String,
     @SerialName("relation") val relation: String,
     @SerialName("phone") val phone: String? = null,
@@ -29,7 +29,7 @@ data class UserCreateReceiverRequest(
 )
 
 @Serializable
-data class UserPatchReceiverRequest(
+data class UserPatchReceiverRequestDto(
     @SerialName("name") val name: String,
     @SerialName("phone") val phone: String,
     @SerialName("relation") val relation: String,
@@ -37,31 +37,31 @@ data class UserPatchReceiverRequest(
 )
 
 @Serializable
-data class UserUpdateReceiverMessageRequest(
+data class UserUpdateReceiverMessageRequestDto(
     @SerialName("message") val message: String,
 )
 
 @Serializable
-data class UserUpdateProfileRequest(
+data class UserUpdateProfileRequestDto(
     @SerialName("name") val name: String? = null,
     @SerialName("phone") val phone: String? = null,
     @SerialName("profileImageUrl") val profileImageUrl: String? = null,
 )
 
 @Serializable
-data class UserUpdatePushSettingRequest(
+data class UserUpdatePushSettingRequestDto(
     @SerialName("timeLetter") val timeLetter: Boolean? = null,
     @SerialName("mindRecord") val mindRecord: Boolean? = null,
     @SerialName("afterNote") val afterNote: Boolean? = null,
 )
 
 @Serializable
-data class SocialAccountLinkRequest(
+data class SocialAccountLinkRequestDto(
     @SerialName("accessToken") val accessToken: String,
 )
 
 @Serializable
-data class DeliveryConditionRequest(
+data class DeliveryConditionRequestDto(
     @SerialName("conditionType") val conditionType: DeliveryConditionTypeDto,
     @SerialName("inactivityPeriodDays") val inactivityPeriodDays: Int? = null,
     @SerialName("specificDate") val specificDate: String? = null,
@@ -72,7 +72,7 @@ data class DeliveryConditionRequest(
 // ========================================
 
 @Serializable
-data class UserResponseDto(
+data class UserDto(
     @SerialName("name") val name: String,
     @SerialName("email") val email: String,
     @SerialName("phone") val phone: String? = null,
@@ -80,7 +80,7 @@ data class UserResponseDto(
 )
 
 @Serializable
-data class ReceiverListResponseDto(
+data class ReceiverListDto(
     @SerialName("receiverId") val receiverId: Long,
     @SerialName("name") val name: String,
     @SerialName("relation") val relation: String,
@@ -88,7 +88,7 @@ data class ReceiverListResponseDto(
 )
 
 @Serializable
-data class ReceiverDetailResponseDto(
+data class ReceiverDetailDto(
     @SerialName("receiverId") val receiverId: Long,
     @SerialName("name") val name: String,
     @SerialName("relation") val relation: String,
@@ -102,13 +102,13 @@ data class ReceiverDetailResponseDto(
 )
 
 @Serializable
-data class UserCreateReceiverResponseDto(
+data class UserCreateReceiverDto(
     @SerialName("receiverId") val receiverId: Long,
     @SerialName("authCode") val authCode: String,
 )
 
 @Serializable
-data class UserPatchReceiverResponseDto(
+data class UserPatchReceiverDto(
     @SerialName("receiverId") val receiverId: Long,
     @SerialName("name") val name: String,
     @SerialName("phone") val phone: String,
@@ -117,14 +117,14 @@ data class UserPatchReceiverResponseDto(
 )
 
 @Serializable
-data class UserPushSettingResponseDto(
+data class UserPushSettingDto(
     @SerialName("timeLetter") val timeLetter: Boolean,
     @SerialName("mindRecord") val mindRecord: Boolean,
     @SerialName("afterNote") val afterNote: Boolean,
 )
 
 @Serializable
-data class UserConnectedAccountResponseDto(
+data class UserConnectedAccountDto(
     @SerialName("local") val local: Boolean,
     @SerialName("google") val google: Boolean,
     @SerialName("naver") val naver: Boolean,
@@ -138,7 +138,7 @@ data class UserConnectedAccountResponseDto(
 )
 
 @Serializable
-data class DeliveryConditionResponseDto(
+data class DeliveryConditionDto(
     @SerialName("conditionType") val conditionType: DeliveryConditionTypeDto,
     @SerialName("inactivityPeriodDays") val inactivityPeriodDays: Int? = null,
     @SerialName("specificDate") val specificDate: String? = null,
@@ -152,7 +152,7 @@ data class DeliveryConditionResponseDto(
  * GET 응답은 provider 별 boolean + email, POST/DELETE 응답은 boolean 만 — email 은 null 로 내려올 수 있어 모두 optional.
  */
 @Serializable
-data class ConnectedAccountsResponseDto(
+data class ConnectedAccountsDto(
     val local: Boolean,
     val google: Boolean,
     val naver: Boolean,

--- a/core/network/src/main/kotlin/com/afternote/core/network/dto/delivery/DeliveryConditionDto.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/dto/delivery/DeliveryConditionDto.kt
@@ -69,15 +69,15 @@ enum class ConditionStateDto {
 // ========================================
 
 @Serializable
-data class DeliveryConditionItemRequest(
+data class DeliveryConditionItemRequestDto(
     @SerialName("contentType") val contentType: DeliveryContentTypeDto,
     @SerialName("conditionType") val conditionType: DeliveryConditionTypeDto,
     @SerialName("inactivityPeriod") val inactivityPeriod: InactivityPeriodDto? = null,
 )
 
 @Serializable
-data class ReceiverDeliveryConditionUpdateRequest(
-    @SerialName("conditions") val conditions: List<DeliveryConditionItemRequest>,
+data class ReceiverDeliveryConditionUpdateRequestDto(
+    @SerialName("conditions") val conditions: List<DeliveryConditionItemRequestDto>,
 )
 
 // ========================================
@@ -85,7 +85,7 @@ data class ReceiverDeliveryConditionUpdateRequest(
 // ========================================
 
 /**
- * 수신자별 전달조건 1건의 조회 응답. 요청([DeliveryConditionItemRequest])엔 없는 4개 필드
+ * 수신자별 전달조건 1건의 조회 응답. 요청([DeliveryConditionItemRequestDto])엔 없는 4개 필드
  * (state·fulfilled·gracePeriodStartedAt·fulfilledAt)는 **서버가 판정해 내려주는 값**이라 응답에만 있다.
  *
  * @property state 조건 진행 상태 — ACTIVE(대기) / PENDING_CONFIRMATION(미사용 감지 후 본인확인 유예 중) /
@@ -99,7 +99,7 @@ data class ReceiverDeliveryConditionUpdateRequest(
  * @property fulfilledAt 조건이 충족(전달 확정)된 시각(ISO-8601). 아직 미충족이면 null.
  */
 @Serializable
-data class DeliveryConditionItemResponse(
+data class DeliveryConditionItemDto(
     @SerialName("contentType") val contentType: DeliveryContentTypeDto,
     @SerialName("conditionType") val conditionType: DeliveryConditionTypeDto,
     @SerialName("inactivityPeriod") val inactivityPeriod: InactivityPeriodDto? = null,
@@ -110,7 +110,7 @@ data class DeliveryConditionItemResponse(
 )
 
 @Serializable
-data class ReceiverDeliveryConditionResponse(
+data class ReceiverDeliveryConditionDto(
     @SerialName("receiverId") val receiverId: Long,
-    @SerialName("conditions") val conditions: List<DeliveryConditionItemResponse>,
+    @SerialName("conditions") val conditions: List<DeliveryConditionItemDto>,
 )

--- a/core/network/src/main/kotlin/com/afternote/core/network/model/BaseResponse.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/model/BaseResponse.kt
@@ -7,8 +7,8 @@ import java.io.IOException
 /**
  * 서버 공통 응답 봉투. 제네릭 [T] 는 `data` 필드의 페이로드 타입 — `data` 없는 엔드포인트는 `BaseResponse<Unit>`.
  *
- * 액세스 토큰 잔여 수명(`expiresIn`)은 BE #410(2026-06-20)으로 발급 응답의 `data`(`LoginData`·
- * `ReissueData`) 안으로 옮겨졌다 — 더 이상 봉투 최상위 필드가 아니다. 그 외 서버 스키마
+ * 액세스 토큰 잔여 수명(`expiresIn`)은 BE #410(2026-06-20)으로 발급 응답의 `data`(`LoginDto`·
+ * `ReissueDto`) 안으로 옮겨졌다 — 더 이상 봉투 최상위 필드가 아니다. 그 외 서버 스키마
  * (`ApiResponse*`)의 클라 미소비 필드는 선언하지 않는다 (`NetworkModule.provideJson` 의
  * ignoreUnknownKeys 가 무시).
  */

--- a/core/network/src/main/kotlin/com/afternote/core/network/service/AccountApiService.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/service/AccountApiService.kt
@@ -1,10 +1,10 @@
 package com.afternote.core.network.service
 
-import com.afternote.core.network.dto.PasswordChangeRequest
-import com.afternote.core.network.dto.SendEmailCodeRequest
-import com.afternote.core.network.dto.SignUpData
-import com.afternote.core.network.dto.SignUpRequest
-import com.afternote.core.network.dto.VerifyEmailRequest
+import com.afternote.core.network.dto.PasswordChangeRequestDto
+import com.afternote.core.network.dto.SendEmailCodeRequestDto
+import com.afternote.core.network.dto.SignUpDto
+import com.afternote.core.network.dto.SignUpRequestDto
+import com.afternote.core.network.dto.VerifyEmailRequestDto
 import com.afternote.core.network.model.BaseResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -12,21 +12,21 @@ import retrofit2.http.POST
 interface AccountApiService {
     @POST("auth/email/send")
     suspend fun sendEmailCode(
-        @Body body: SendEmailCodeRequest,
+        @Body body: SendEmailCodeRequestDto,
     ): BaseResponse<Unit>
 
     @POST("auth/email/verify")
     suspend fun verifyEmail(
-        @Body body: VerifyEmailRequest,
+        @Body body: VerifyEmailRequestDto,
     ): BaseResponse<Unit>
 
     @POST("auth/sign-up")
     suspend fun signUp(
-        @Body body: SignUpRequest,
-    ): BaseResponse<SignUpData>
+        @Body body: SignUpRequestDto,
+    ): BaseResponse<SignUpDto>
 
     @POST("auth/password/change")
     suspend fun passwordChange(
-        @Body body: PasswordChangeRequest,
+        @Body body: PasswordChangeRequestDto,
     ): BaseResponse<Unit>
 }

--- a/core/network/src/main/kotlin/com/afternote/core/network/service/AuthApiService.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/service/AuthApiService.kt
@@ -1,9 +1,9 @@
 package com.afternote.core.network.service
 
-import com.afternote.core.network.dto.LoginData
-import com.afternote.core.network.dto.LoginRequest
-import com.afternote.core.network.dto.LogoutRequest
-import com.afternote.core.network.dto.SocialLoginRequest
+import com.afternote.core.network.dto.LoginDto
+import com.afternote.core.network.dto.LoginRequestDto
+import com.afternote.core.network.dto.LogoutRequestDto
+import com.afternote.core.network.dto.SocialLoginRequestDto
 import com.afternote.core.network.model.BaseResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -11,16 +11,16 @@ import retrofit2.http.POST
 interface AuthApiService {
     @POST("auth/login")
     suspend fun login(
-        @Body body: LoginRequest,
-    ): BaseResponse<LoginData.DefaultLoginData>
+        @Body body: LoginRequestDto,
+    ): BaseResponse<LoginDto.DefaultLoginDto>
 
     @POST("auth/social/login")
     suspend fun socialLogin(
-        @Body body: SocialLoginRequest,
-    ): BaseResponse<LoginData.SocialLoginData>
+        @Body body: SocialLoginRequestDto,
+    ): BaseResponse<LoginDto.SocialLoginDto>
 
     @POST("auth/logout")
     suspend fun logout(
-        @Body body: LogoutRequest,
+        @Body body: LogoutRequestDto,
     ): BaseResponse<Unit>
 }

--- a/core/network/src/main/kotlin/com/afternote/core/network/service/ImageApiService.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/service/ImageApiService.kt
@@ -1,7 +1,7 @@
 package com.afternote.core.network.service
 
+import com.afternote.core.network.dto.PresignedUrlDto
 import com.afternote.core.network.dto.PresignedUrlRequestDto
-import com.afternote.core.network.dto.PresignedUrlResponseDto
 import com.afternote.core.network.model.BaseResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -15,5 +15,5 @@ interface ImageApiService {
     @POST("files/presigned-url")
     suspend fun getPresignedUrl(
         @Body body: PresignedUrlRequestDto,
-    ): BaseResponse<PresignedUrlResponseDto>
+    ): BaseResponse<PresignedUrlDto>
 }

--- a/core/network/src/main/kotlin/com/afternote/core/network/service/TokenApiService.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/service/TokenApiService.kt
@@ -1,7 +1,7 @@
 package com.afternote.core.network.service
 
-import com.afternote.core.network.dto.ReissueData
-import com.afternote.core.network.dto.ReissueRequest
+import com.afternote.core.network.dto.ReissueDto
+import com.afternote.core.network.dto.ReissueRequestDto
 import com.afternote.core.network.model.BaseResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -9,6 +9,6 @@ import retrofit2.http.POST
 interface TokenApiService {
     @POST("auth/reissue")
     suspend fun reissue(
-        @Body body: ReissueRequest,
-    ): BaseResponse<ReissueData>
+        @Body body: ReissueRequestDto,
+    ): BaseResponse<ReissueDto>
 }

--- a/core/network/src/main/kotlin/com/afternote/core/network/service/UserApiService.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/service/UserApiService.kt
@@ -1,22 +1,22 @@
 package com.afternote.core.network.service
 
-import com.afternote.core.network.dto.DeliveryConditionRequest
-import com.afternote.core.network.dto.DeliveryConditionResponseDto
-import com.afternote.core.network.dto.ReceiverDetailResponseDto
-import com.afternote.core.network.dto.ReceiverListResponseDto
-import com.afternote.core.network.dto.SocialAccountLinkRequest
-import com.afternote.core.network.dto.UserConnectedAccountResponseDto
-import com.afternote.core.network.dto.UserCreateReceiverRequest
-import com.afternote.core.network.dto.UserCreateReceiverResponseDto
-import com.afternote.core.network.dto.UserPatchReceiverRequest
-import com.afternote.core.network.dto.UserPatchReceiverResponseDto
-import com.afternote.core.network.dto.UserPushSettingResponseDto
-import com.afternote.core.network.dto.UserResponseDto
-import com.afternote.core.network.dto.UserUpdateProfileRequest
-import com.afternote.core.network.dto.UserUpdatePushSettingRequest
-import com.afternote.core.network.dto.UserUpdateReceiverMessageRequest
-import com.afternote.core.network.dto.delivery.ReceiverDeliveryConditionResponse
-import com.afternote.core.network.dto.delivery.ReceiverDeliveryConditionUpdateRequest
+import com.afternote.core.network.dto.DeliveryConditionDto
+import com.afternote.core.network.dto.DeliveryConditionRequestDto
+import com.afternote.core.network.dto.ReceiverDetailDto
+import com.afternote.core.network.dto.ReceiverListDto
+import com.afternote.core.network.dto.SocialAccountLinkRequestDto
+import com.afternote.core.network.dto.UserConnectedAccountDto
+import com.afternote.core.network.dto.UserCreateReceiverDto
+import com.afternote.core.network.dto.UserCreateReceiverRequestDto
+import com.afternote.core.network.dto.UserDto
+import com.afternote.core.network.dto.UserPatchReceiverDto
+import com.afternote.core.network.dto.UserPatchReceiverRequestDto
+import com.afternote.core.network.dto.UserPushSettingDto
+import com.afternote.core.network.dto.UserUpdateProfileRequestDto
+import com.afternote.core.network.dto.UserUpdatePushSettingRequestDto
+import com.afternote.core.network.dto.UserUpdateReceiverMessageRequestDto
+import com.afternote.core.network.dto.delivery.ReceiverDeliveryConditionDto
+import com.afternote.core.network.dto.delivery.ReceiverDeliveryConditionUpdateRequestDto
 import com.afternote.core.network.model.BaseResponse
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -29,43 +29,43 @@ import retrofit2.http.Path
 interface UserApiService {
     // 수신자 목록 조회
     @GET("users/receivers")
-    suspend fun getReceivers(): BaseResponse<List<ReceiverListResponseDto>>
+    suspend fun getReceivers(): BaseResponse<List<ReceiverListDto>>
 
     // 수신자 등록
     @POST("users/receivers")
     suspend fun createReceiver(
-        @Body request: UserCreateReceiverRequest,
-    ): BaseResponse<UserCreateReceiverResponseDto>
+        @Body request: UserCreateReceiverRequestDto,
+    ): BaseResponse<UserCreateReceiverDto>
 
     // 수신자 상세 조회
     @GET("users/receivers/{receiverId}")
     suspend fun getReceiverDetail(
         @Path("receiverId") receiverId: Long,
-    ): BaseResponse<ReceiverDetailResponseDto>
+    ): BaseResponse<ReceiverDetailDto>
 
     // 수신자 정보 수정
     @PATCH("users/receivers/{receiverId}")
     suspend fun updateReceiver(
         @Path("receiverId") receiverId: Long,
-        @Body request: UserPatchReceiverRequest,
-    ): BaseResponse<UserPatchReceiverResponseDto>
+        @Body request: UserPatchReceiverRequestDto,
+    ): BaseResponse<UserPatchReceiverDto>
 
     // 수신자 메시지 수정
     @PATCH("users/receivers/{receiverId}/message")
     suspend fun updateReceiverMessage(
         @Path("receiverId") receiverId: Long,
-        @Body request: UserUpdateReceiverMessageRequest,
+        @Body request: UserUpdateReceiverMessageRequestDto,
     ): BaseResponse<Unit>
 
     // 내 프로필 조회
     @GET("users/me")
-    suspend fun getMyProfile(): BaseResponse<UserResponseDto>
+    suspend fun getMyProfile(): BaseResponse<UserDto>
 
     // 프로필 수정
     @PATCH("users/me")
     suspend fun updateMyProfile(
-        @Body request: UserUpdateProfileRequest,
-    ): BaseResponse<UserResponseDto>
+        @Body request: UserUpdateProfileRequestDto,
+    ): BaseResponse<UserDto>
 
     // 회원 탈퇴
     @DELETE("users/me")
@@ -84,40 +84,40 @@ interface UserApiService {
 
     // 푸시 알림 설정 조회
     @GET("users/push-settings")
-    suspend fun getMyPushSettings(): BaseResponse<UserPushSettingResponseDto>
+    suspend fun getMyPushSettings(): BaseResponse<UserPushSettingDto>
 
     // 푸시 알림 설정 수정
     @PATCH("users/push-settings")
     suspend fun updateMyPushSettings(
-        @Body request: UserUpdatePushSettingRequest,
-    ): BaseResponse<UserPushSettingResponseDto>
+        @Body request: UserUpdatePushSettingRequestDto,
+    ): BaseResponse<UserPushSettingDto>
 
     // 연결된 계정 조회
     @GET("users/connected-accounts")
-    suspend fun getConnectedAccounts(): BaseResponse<UserConnectedAccountResponseDto>
+    suspend fun getConnectedAccounts(): BaseResponse<UserConnectedAccountDto>
 
     // 소셜 계정 연결
     @POST("users/connected-accounts/{provider}")
     suspend fun linkConnectedAccount(
         @Path("provider") provider: String,
-        @Body request: SocialAccountLinkRequest,
-    ): BaseResponse<UserConnectedAccountResponseDto>
+        @Body request: SocialAccountLinkRequestDto,
+    ): BaseResponse<UserConnectedAccountDto>
 
     // 소셜 계정 연결 해제
     @DELETE("users/connected-accounts/{provider}")
     suspend fun unlinkConnectedAccount(
         @Path("provider") provider: String,
-    ): BaseResponse<UserConnectedAccountResponseDto>
+    ): BaseResponse<UserConnectedAccountDto>
 
     // 전달 조건 조회
     @GET("users/delivery-condition")
-    suspend fun getDeliveryCondition(): BaseResponse<DeliveryConditionResponseDto>
+    suspend fun getDeliveryCondition(): BaseResponse<DeliveryConditionDto>
 
     // 전달 조건 수정
     @PATCH("users/delivery-condition")
     suspend fun updateDeliveryCondition(
-        @Body request: DeliveryConditionRequest,
-    ): BaseResponse<DeliveryConditionResponseDto>
+        @Body request: DeliveryConditionRequestDto,
+    ): BaseResponse<DeliveryConditionDto>
 
     /**
      * 수신자별 전달조건 조회 — 특정 수신자(receiverId)에게 **콘텐츠 종류마다** 다르게 건 전달 조건 목록.
@@ -130,7 +130,7 @@ interface UserApiService {
     @GET("users/me/receivers/{receiverId}/delivery-conditions")
     suspend fun getReceiverDeliveryConditions(
         @Path("receiverId") receiverId: Long,
-    ): BaseResponse<ReceiverDeliveryConditionResponse>
+    ): BaseResponse<ReceiverDeliveryConditionDto>
 
     /**
      * 수신자별 전달조건 설정/변경 — 보낸 conditions[] 로 저장하고, **변경이 반영된 최신 전체 목록**을
@@ -147,6 +147,6 @@ interface UserApiService {
     @PUT("users/me/receivers/{receiverId}/delivery-conditions")
     suspend fun updateReceiverDeliveryConditions(
         @Path("receiverId") receiverId: Long,
-        @Body request: ReceiverDeliveryConditionUpdateRequest,
-    ): BaseResponse<ReceiverDeliveryConditionResponse>
+        @Body request: ReceiverDeliveryConditionUpdateRequestDto,
+    ): BaseResponse<ReceiverDeliveryConditionDto>
 }

--- a/core/network/src/test/kotlin/com/afternote/core/network/dto/AuthDtoExpiresInContractTest.kt
+++ b/core/network/src/test/kotlin/com/afternote/core/network/dto/AuthDtoExpiresInContractTest.kt
@@ -27,7 +27,7 @@ class AuthDtoExpiresInContractTest {
         val payload =
             """{"status":200,"code":200,"message":"성공","data":{"accessToken":"a","refreshToken":"r","expiresIn":3600}}"""
 
-        val data = json.decodeFromString<BaseResponse<LoginData.DefaultLoginData>>(payload).requireData()
+        val data = json.decodeFromString<BaseResponse<LoginDto.DefaultLoginDto>>(payload).requireData()
 
         assertEquals(3600L, data.expiresIn)
         assertEquals("a", data.accessToken)
@@ -38,7 +38,7 @@ class AuthDtoExpiresInContractTest {
         val payload =
             """{"status":200,"code":200,"message":"성공","data":{"accessToken":"a","refreshToken":"r","expiresIn":3600}}"""
 
-        val data = json.decodeFromString<BaseResponse<ReissueData>>(payload).requireData()
+        val data = json.decodeFromString<BaseResponse<ReissueDto>>(payload).requireData()
 
         assertEquals(3600L, data.expiresIn)
         assertEquals("r", data.refreshToken)
@@ -49,7 +49,7 @@ class AuthDtoExpiresInContractTest {
         val payload =
             """{"status":200,"code":200,"message":"성공","data":{"accessToken":"a","refreshToken":"r"}}"""
 
-        val data = json.decodeFromString<BaseResponse<LoginData.DefaultLoginData>>(payload).requireData()
+        val data = json.decodeFromString<BaseResponse<LoginDto.DefaultLoginDto>>(payload).requireData()
 
         assertNull(data.expiresIn)
         assertEquals("a", data.accessToken)

--- a/feature/afternote/data/src/debug/kotlin/com/afternote/feature/afternote/data/network/AfternoteMockFixtures.kt
+++ b/feature/afternote/data/src/debug/kotlin/com/afternote/feature/afternote/data/network/AfternoteMockFixtures.kt
@@ -1,7 +1,7 @@
 package com.afternote.feature.afternote.data.network
 
-import com.afternote.feature.afternote.data.dto.MusicSearchResponse
-import com.afternote.feature.afternote.data.dto.MusicTrack
+import com.afternote.feature.afternote.data.dto.MusicSearchResponseDto
+import com.afternote.feature.afternote.data.dto.MusicTrackDto
 import kotlinx.serialization.json.Json
 
 /**
@@ -20,18 +20,18 @@ internal object AfternoteMockFixtures {
     val musicSearchResponseJson: String
         get() =
             json.encodeToString(
-                MusicSearchResponse(
+                MusicSearchResponseDto(
                     tracks =
                         listOf(
-                            MusicTrack(artist = "김범수", title = "보고싶다", albumImageUrl = null),
-                            MusicTrack(artist = "윤도현", title = "사랑했나봐", albumImageUrl = null),
-                            MusicTrack(artist = "김광석", title = "나의 옛날이야기", albumImageUrl = null),
-                            MusicTrack(artist = "이문세", title = "그대와 영원히", albumImageUrl = null),
-                            MusicTrack(artist = "넬", title = "흩어진 꿈", albumImageUrl = null),
-                            MusicTrack(artist = "폴킴", title = "안녕", albumImageUrl = null),
-                            MusicTrack(artist = "에일리", title = "첫눈처럼 너에게 가겠다", albumImageUrl = null),
-                            MusicTrack(artist = "폴킴", title = "너를 만나", albumImageUrl = null),
-                            MusicTrack(artist = "박효신", title = "겨울비", albumImageUrl = null),
+                            MusicTrackDto(artist = "김범수", title = "보고싶다", albumImageUrl = null),
+                            MusicTrackDto(artist = "윤도현", title = "사랑했나봐", albumImageUrl = null),
+                            MusicTrackDto(artist = "김광석", title = "나의 옛날이야기", albumImageUrl = null),
+                            MusicTrackDto(artist = "이문세", title = "그대와 영원히", albumImageUrl = null),
+                            MusicTrackDto(artist = "넬", title = "흩어진 꿈", albumImageUrl = null),
+                            MusicTrackDto(artist = "폴킴", title = "안녕", albumImageUrl = null),
+                            MusicTrackDto(artist = "에일리", title = "첫눈처럼 너에게 가겠다", albumImageUrl = null),
+                            MusicTrackDto(artist = "폴킴", title = "너를 만나", albumImageUrl = null),
+                            MusicTrackDto(artist = "박효신", title = "겨울비", albumImageUrl = null),
                         ),
                 ),
             )

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/AfternoteDto.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/AfternoteDto.kt
@@ -7,79 +7,79 @@ import kotlinx.serialization.Serializable
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
-data class AfternoteCreateGalleryRequest(
+data class AfternoteCreateGalleryRequestDto(
     @EncodeDefault @SerialName("category") val category: String = "GALLERY",
     @SerialName("title") val title: String,
     @SerialName("actions") val actions: List<String>,
     @SerialName("leaveMessage") val leaveMessage: String? = null,
-    @SerialName("receivers") val receivers: List<AfternoteReceiverRef>,
+    @SerialName("receivers") val receivers: List<AfternoteReceiverRefDto>,
 )
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
-data class AfternoteCreatePlaylistRequest(
+data class AfternoteCreatePlaylistRequestDto(
     @EncodeDefault @SerialName("category") val category: String = "PLAYLIST",
     @SerialName("title") val title: String,
-    @SerialName("playlist") val playlist: AfternotePlaylist,
-    @SerialName("receivers") val receivers: List<AfternoteReceiverRef> = emptyList(),
+    @SerialName("playlist") val playlist: AfternotePlaylistDto,
+    @SerialName("receivers") val receivers: List<AfternoteReceiverRefDto> = emptyList(),
 )
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
-data class AfternoteCreateSocialRequest(
+data class AfternoteCreateSocialRequestDto(
     @EncodeDefault @SerialName("category") val category: String = "SOCIAL",
     @SerialName("title") val title: String,
     @SerialName("actions") val actions: List<String>,
     @SerialName("leaveMessage") val leaveMessage: String? = null,
-    @SerialName("credentials") val credentials: AfternoteCredentials? = null,
-    @SerialName("receivers") val receivers: List<AfternoteReceiverRef> = emptyList(),
+    @SerialName("credentials") val credentials: AfternoteCredentialsDto? = null,
+    @SerialName("receivers") val receivers: List<AfternoteReceiverRefDto> = emptyList(),
 )
 
 @Serializable
-data class AfternoteUpdateRequest(
+data class AfternoteUpdateRequestDto(
     @SerialName("category") val category: String,
     @SerialName("title") val title: String,
     @SerialName("actions") val actions: List<String>? = null,
     @SerialName("leaveMessage") val leaveMessage: String? = null,
-    @SerialName("credentials") val credentials: AfternoteCredentials? = null,
-    @SerialName("receivers") val receivers: List<AfternoteReceiverRef>? = null,
-    @SerialName("playlist") val playlist: AfternotePlaylist? = null,
+    @SerialName("credentials") val credentials: AfternoteCredentialsDto? = null,
+    @SerialName("receivers") val receivers: List<AfternoteReceiverRefDto>? = null,
+    @SerialName("playlist") val playlist: AfternotePlaylistDto? = null,
 )
 
 @Serializable
-data class AfternoteDetailResponse(
+data class AfternoteDetailDto(
     @SerialName("afternoteId") val afternoteId: Long,
     @SerialName("category") val category: String,
     @SerialName("title") val title: String,
     @SerialName("createdAt") val createdAt: String = "",
     @SerialName("updatedAt") val updatedAt: String = "",
-    @SerialName("credentials") val credentials: AfternoteCredentials? = null,
-    @SerialName("receivers") val receivers: List<AfternoteDetailReceiver>? = null,
+    @SerialName("credentials") val credentials: AfternoteCredentialsDto? = null,
+    @SerialName("receivers") val receivers: List<AfternoteDetailReceiverDto>? = null,
     @SerialName("actions") val actions: List<String>? = null,
     @SerialName("leaveMessage") val leaveMessage: String? = null,
-    @SerialName("playlist") val playlist: AfternotePlaylist? = null,
+    @SerialName("playlist") val playlist: AfternotePlaylistDto? = null,
 )
 
 @Serializable
-data class AfternoteIdResponse(
+data class AfternoteIdDto(
     @SerialName("afternoteId") val afternoteId: Long,
 )
 
 @Serializable
-data class AfternoteListResponse(
-    @SerialName("content") val content: List<AfternoteListItem> = emptyList(),
+data class AfternotePageDto(
+    @SerialName("content") val content: List<AfternoteListItemDto> = emptyList(),
     @SerialName("page") val page: Int = 0,
     @SerialName("size") val size: Int = 10,
     @SerialName("hasNext") val hasNext: Boolean = false,
 )
 
 @Serializable
-data class AfternoteCredentials(
+data class AfternoteCredentialsDto(
     @SerialName("id") val id: String? = null,
     @SerialName("password") val password: String? = null,
 )
 
 @Serializable
-data class AfternoteReceiverRef(
+data class AfternoteReceiverRefDto(
     @SerialName("receiverId") val receiverId: Long,
 )

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/MusicDto.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/MusicDto.kt
@@ -4,28 +4,28 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class MusicSearchResponse(
-    @SerialName("tracks") val tracks: List<MusicTrack> = emptyList(),
+data class MusicSearchResponseDto(
+    @SerialName("tracks") val tracks: List<MusicTrackDto> = emptyList(),
 )
 
 @Serializable
-data class MusicTrack(
+data class MusicTrackDto(
     @SerialName("artist") val artist: String,
     @SerialName("title") val title: String,
     @SerialName("albumImageUrl") val albumImageUrl: String? = null,
 )
 
 @Serializable
-data class AfternotePlaylist(
+data class AfternotePlaylistDto(
     @SerialName("profilePhoto") val profilePhoto: String? = null,
     @SerialName("atmosphere") val atmosphere: String? = null,
     @SerialName("memorialPhotoUrl") val memorialPhotoUrl: String? = null,
-    @SerialName("songs") val songs: List<AfternoteSong> = emptyList(),
-    @SerialName("memorialVideo") val memorialVideo: AfternoteMemorialVideo? = null,
+    @SerialName("songs") val songs: List<AfternoteSongDto> = emptyList(),
+    @SerialName("memorialVideo") val memorialVideo: AfternoteMemorialVideoDto? = null,
 )
 
 @Serializable
-data class AfternoteSong(
+data class AfternoteSongDto(
     @SerialName("id") val id: Long? = null,
     @SerialName("title") val title: String,
     @SerialName("artist") val artist: String,
@@ -33,7 +33,7 @@ data class AfternoteSong(
 )
 
 @Serializable
-data class AfternoteDetailReceiver(
+data class AfternoteDetailReceiverDto(
     @SerialName("receiverId") val receiverId: Long? = null,
     @SerialName("name") val name: String? = null,
     @SerialName("relation") val relation: String? = null,
@@ -41,7 +41,7 @@ data class AfternoteDetailReceiver(
 )
 
 @Serializable
-data class AfternoteListItem(
+data class AfternoteListItemDto(
     @SerialName("afternoteId") val afternoteId: Long,
     @SerialName("title") val title: String,
     @SerialName("category") val category: String,
@@ -49,7 +49,7 @@ data class AfternoteListItem(
 )
 
 @Serializable
-data class AfternoteMemorialVideo(
+data class AfternoteMemorialVideoDto(
     @SerialName("videoUrl") val videoUrl: String? = null,
     @SerialName("thumbnailUrl") val thumbnailUrl: String? = null,
 )

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/ReceiverAfternoteDto.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/ReceiverAfternoteDto.kt
@@ -4,13 +4,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ReceivedAfternoteListResponse(
-    @SerialName("afternotes") val afternotes: List<ReceivedAfternoteResponse> = emptyList(),
+data class ReceivedAfternoteListDto(
+    @SerialName("afternotes") val afternotes: List<ReceivedAfternoteDto> = emptyList(),
     @SerialName("totalCount") val totalCount: Int = 0,
 )
 
 @Serializable
-data class ReceivedAfternoteResponse(
+data class ReceivedAfternoteDto(
     @SerialName("id") val id: Long,
     @SerialName("title") val title: String? = null,
     @SerialName("category") val category: String? = null,
@@ -21,7 +21,7 @@ data class ReceivedAfternoteResponse(
 )
 
 @Serializable
-data class ReceivedAfternoteDetailResponse(
+data class ReceivedAfternoteDetailDto(
     @SerialName("id") val id: Long,
     @SerialName("category") val category: String? = null,
     @SerialName("title") val title: String? = null,
@@ -29,32 +29,32 @@ data class ReceivedAfternoteDetailResponse(
     @SerialName("leaveMessage") val leaveMessage: String? = null,
     @SerialName("senderName") val senderName: String? = null,
     @SerialName("createdAt") val createdAt: String? = null,
-    @SerialName("credentials") val credentials: ReceivedCredentialsInfo? = null,
-    @SerialName("playlist") val playlist: ReceivedPlaylistInfo? = null,
+    @SerialName("credentials") val credentials: ReceivedCredentialsDto? = null,
+    @SerialName("playlist") val playlist: ReceivedPlaylistDto? = null,
 )
 
 @Serializable
-data class ReceivedCredentialsInfo(
+data class ReceivedCredentialsDto(
     @SerialName("id") val id: String? = null,
     @SerialName("password") val password: String? = null,
 )
 
 @Serializable
-data class ReceivedPlaylistInfo(
+data class ReceivedPlaylistDto(
     @SerialName("atmosphere") val atmosphere: String? = null,
-    @SerialName("songs") val songs: List<ReceivedSongInfo> = emptyList(),
-    @SerialName("memorialVideo") val memorialVideo: ReceivedMemorialVideoInfo? = null,
+    @SerialName("songs") val songs: List<ReceivedSongDto> = emptyList(),
+    @SerialName("memorialVideo") val memorialVideo: ReceivedMemorialVideoDto? = null,
 )
 
 @Serializable
-data class ReceivedSongInfo(
+data class ReceivedSongDto(
     @SerialName("title") val title: String,
     @SerialName("artist") val artist: String,
     @SerialName("coverUrl") val coverUrl: String? = null,
 )
 
 @Serializable
-data class ReceivedMemorialVideoInfo(
+data class ReceivedMemorialVideoDto(
     @SerialName("videoUrl") val videoUrl: String? = null,
     @SerialName("thumbnailUrl") val thumbnailUrl: String? = null,
 )

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/ReceiverAuthDto.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/ReceiverAuthDto.kt
@@ -11,12 +11,12 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ReceiverAuthVerifyRequest(
+data class ReceiverAuthVerifyRequestDto(
     @SerialName("authCode") val authCode: String,
 )
 
 @Serializable
-data class ReceiverAuthVerifyResponse(
+data class ReceiverAuthVerifyDto(
     @SerialName("receiverId") val receiverId: Long,
     @SerialName("receiverName") val receiverName: String,
     @SerialName("senderName") val senderName: String,
@@ -24,18 +24,18 @@ data class ReceiverAuthVerifyResponse(
 )
 
 @Serializable
-data class ReceiverAuthCodeEmailSendRequest(
+data class ReceiverAuthCodeEmailSendRequestDto(
     @SerialName("email") val email: String,
 )
 
 @Serializable
-data class ReceiverEmailAuthVerifyRequest(
+data class ReceiverEmailAuthVerifyRequestDto(
     @SerialName("email") val email: String,
     @SerialName("authCode") val authCode: String,
 )
 
 @Serializable
-data class ReceiverEmailAuthVerifyResponse(
+data class ReceiverEmailAuthVerifyDto(
     @SerialName("receiverId") val receiverId: Long,
     @SerialName("receiverName") val receiverName: String,
     @SerialName("senderName") val senderName: String,
@@ -43,12 +43,12 @@ data class ReceiverEmailAuthVerifyResponse(
 )
 
 @Serializable
-data class ReceiverAuthPresignedUrlRequest(
+data class ReceiverAuthPresignedUrlRequestDto(
     @SerialName("extension") val extension: String,
 )
 
 @Serializable
-data class ReceiverAuthPresignedUrlResponse(
+data class ReceiverAuthPresignedUrlDto(
     @SerialName("presignedUrl") val presignedUrl: String,
     @SerialName("fileKey") val fileKey: String,
     @SerialName("fileUrl") val fileUrl: String,
@@ -64,13 +64,13 @@ data class ReceiverAuthPresignedUrlResponse(
  * 이 직렬화 형태(미제출 슬롯 키 생략)는 `DeliveryVerificationContractTest` 가 고정한다.
  */
 @Serializable
-data class DeliveryVerificationRequest(
+data class DeliveryVerificationRequestDto(
     @SerialName("deathCertificateUrl") val deathCertificateUrl: String? = null,
     @SerialName("familyRelationCertificateUrl") val familyRelationCertificateUrl: String? = null,
 )
 
 @Serializable
-data class DeliveryVerificationResponse(
+data class DeliveryVerificationDto(
     @SerialName("id") val id: Long,
     @SerialName("status") val status: String,
     @SerialName("deathCertificateUrl") val deathCertificateUrl: String? = null,
@@ -80,13 +80,13 @@ data class DeliveryVerificationResponse(
 )
 
 @Serializable
-data class ReceiverMessageResponse(
+data class ReceiverMessageDto(
     @SerialName("senderName") val senderName: String,
     @SerialName("message") val message: String? = null,
     @SerialName("createdAt") val createdAt: String? = null,
 )
 
-fun ReceiverAuthVerifyResponse.toDomain(): ReceiverIdentity =
+fun ReceiverAuthVerifyDto.toDomain(): ReceiverIdentity =
     ReceiverIdentity(
         receiverId = receiverId,
         receiverName = receiverName,
@@ -94,7 +94,7 @@ fun ReceiverAuthVerifyResponse.toDomain(): ReceiverIdentity =
         relation = relation,
     )
 
-fun ReceiverEmailAuthVerifyResponse.toDomain(): ReceiverEmailAuthResult =
+fun ReceiverEmailAuthVerifyDto.toDomain(): ReceiverEmailAuthResult =
     ReceiverEmailAuthResult(
         receiverId = receiverId,
         receiverName = receiverName,
@@ -102,7 +102,7 @@ fun ReceiverEmailAuthVerifyResponse.toDomain(): ReceiverEmailAuthResult =
         accessCode = accessCode,
     )
 
-fun ReceiverAuthPresignedUrlResponse.toDomain(): ReceiverAuthPresignedUrl =
+fun ReceiverAuthPresignedUrlDto.toDomain(): ReceiverAuthPresignedUrl =
     ReceiverAuthPresignedUrl(
         presignedUrl = presignedUrl,
         fileKey = fileKey,
@@ -110,7 +110,7 @@ fun ReceiverAuthPresignedUrlResponse.toDomain(): ReceiverAuthPresignedUrl =
         contentType = contentType,
     )
 
-fun DeliveryVerificationResponse.toDomain(): DeliveryVerification =
+fun DeliveryVerificationDto.toDomain(): DeliveryVerification =
     DeliveryVerification(
         id = id,
         status = DeliveryVerificationStatus.fromRaw(status),
@@ -120,7 +120,7 @@ fun DeliveryVerificationResponse.toDomain(): DeliveryVerification =
         createdAt = createdAt,
     )
 
-fun ReceiverMessageResponse.toDomain(): SenderMessageInfo =
+fun ReceiverMessageDto.toDomain(): SenderMessageInfo =
     SenderMessageInfo(
         senderName = senderName,
         message = message,

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/AfternoteListItemDtoToDomain.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/AfternoteListItemDtoToDomain.kt
@@ -1,13 +1,13 @@
 package com.afternote.feature.afternote.data.mapper
 
-import com.afternote.feature.afternote.data.dto.AfternoteListItem
+import com.afternote.feature.afternote.data.dto.AfternoteListItemDto
 import com.afternote.feature.afternote.domain.model.author.ListItem
 
 /**
  * Maps server DTOs to domain models at the boundary only.
  */
 
-fun AfternoteListItem.toDomain() =
+fun AfternoteListItemDto.toDomain() =
     ListItem(
         id = afternoteId.toString(),
         serviceName = title,
@@ -15,4 +15,4 @@ fun AfternoteListItem.toDomain() =
         type = categoryToServiceType(category),
     )
 
-fun List<AfternoteListItem>.toDomainList() = map { it.toDomain() }
+fun List<AfternoteListItemDto>.toDomainList() = map { it.toDomain() }

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/InputToDto.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/InputToDto.kt
@@ -1,26 +1,26 @@
 package com.afternote.feature.afternote.data.mapper
 
-import com.afternote.feature.afternote.data.dto.AfternoteCredentials
-import com.afternote.feature.afternote.data.dto.AfternoteMemorialVideo
-import com.afternote.feature.afternote.data.dto.AfternoteReceiverRef
+import com.afternote.feature.afternote.data.dto.AfternoteCredentialsDto
+import com.afternote.feature.afternote.data.dto.AfternoteMemorialVideoDto
+import com.afternote.feature.afternote.data.dto.AfternoteReceiverRefDto
 import com.afternote.feature.afternote.domain.model.author.AfternoteAccountCredentials
 import com.afternote.feature.afternote.domain.model.author.MemorialVideoPayload
 import com.afternote.feature.afternote.domain.model.author.ReceiverRefPayload
 
 fun MemorialVideoPayload.toDto() =
-    AfternoteMemorialVideo(
+    AfternoteMemorialVideoDto(
         videoUrl = videoUrl,
         thumbnailUrl = thumbnailUrl,
     )
 
 fun AfternoteAccountCredentials.toDto() =
-    AfternoteCredentials(
+    AfternoteCredentialsDto(
         id = id,
         password = password,
     )
 
 fun ReceiverRefPayload.toDto() =
-    AfternoteReceiverRef(
+    AfternoteReceiverRefDto(
         receiverId = receiverId,
     )
 

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/InputToRequest.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/InputToRequest.kt
@@ -1,17 +1,17 @@
 package com.afternote.feature.afternote.data.mapper
 
-import com.afternote.feature.afternote.data.dto.AfternoteCreateGalleryRequest
-import com.afternote.feature.afternote.data.dto.AfternoteCreatePlaylistRequest
-import com.afternote.feature.afternote.data.dto.AfternoteCreateSocialRequest
-import com.afternote.feature.afternote.data.dto.AfternoteReceiverRef
-import com.afternote.feature.afternote.data.dto.AfternoteUpdateRequest
+import com.afternote.feature.afternote.data.dto.AfternoteCreateGalleryRequestDto
+import com.afternote.feature.afternote.data.dto.AfternoteCreatePlaylistRequestDto
+import com.afternote.feature.afternote.data.dto.AfternoteCreateSocialRequestDto
+import com.afternote.feature.afternote.data.dto.AfternoteReceiverRefDto
+import com.afternote.feature.afternote.data.dto.AfternoteUpdateRequestDto
 import com.afternote.feature.afternote.domain.model.author.AfternoteUpdatePayload
 import com.afternote.feature.afternote.domain.model.author.CreateGalleryPayload
 import com.afternote.feature.afternote.domain.model.author.CreatePlaylistPayload
 import com.afternote.feature.afternote.domain.model.author.CreateSocialPayload
 
 fun AfternoteUpdatePayload.toRequest() =
-    AfternoteUpdateRequest(
+    AfternoteUpdateRequestDto(
         category = category,
         title = title,
         actions = actions,
@@ -22,28 +22,28 @@ fun AfternoteUpdatePayload.toRequest() =
     )
 
 fun CreateSocialPayload.toRequest() =
-    AfternoteCreateSocialRequest(
+    AfternoteCreateSocialRequestDto(
         category = "SOCIAL",
         title = title,
         actions = actions,
         leaveMessage = leaveMessage,
         credentials = credentials?.toDto(),
-        receivers = receiverIds.map { AfternoteReceiverRef(receiverId = it) },
+        receivers = receiverIds.map { AfternoteReceiverRefDto(receiverId = it) },
     )
 
 fun CreateGalleryPayload.toRequest() =
-    AfternoteCreateGalleryRequest(
+    AfternoteCreateGalleryRequestDto(
         category = "GALLERY",
         title = title,
         actions = actions,
         leaveMessage = leaveMessage,
-        receivers = receiverIds.map { AfternoteReceiverRef(receiverId = it) },
+        receivers = receiverIds.map { AfternoteReceiverRefDto(receiverId = it) },
     )
 
 fun CreatePlaylistPayload.toRequest() =
-    AfternoteCreatePlaylistRequest(
+    AfternoteCreatePlaylistRequestDto(
         category = "PLAYLIST",
         title = title,
         playlist = playlist.toDto(),
-        receivers = receiverIds.map { AfternoteReceiverRef(receiverId = it) },
+        receivers = receiverIds.map { AfternoteReceiverRefDto(receiverId = it) },
     )

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/PlaylistInputToDto.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/PlaylistInputToDto.kt
@@ -1,12 +1,12 @@
 package com.afternote.feature.afternote.data.mapper
 
-import com.afternote.feature.afternote.data.dto.AfternotePlaylist
-import com.afternote.feature.afternote.data.dto.AfternoteSong
+import com.afternote.feature.afternote.data.dto.AfternotePlaylistDto
+import com.afternote.feature.afternote.data.dto.AfternoteSongDto
 import com.afternote.feature.afternote.domain.model.author.PlaylistSongPayload
 import com.afternote.feature.afternote.domain.model.author.PlaylistWritePayload
 
 fun PlaylistWritePayload.toDto() =
-    AfternotePlaylist(
+    AfternotePlaylistDto(
         profilePhoto = profilePhoto,
         atmosphere = atmosphere,
         memorialPhotoUrl = memorialPhotoUrl,
@@ -15,7 +15,7 @@ fun PlaylistWritePayload.toDto() =
     )
 
 fun PlaylistSongPayload.toDto() =
-    AfternoteSong(
+    AfternoteSongDto(
         id = id,
         title = title,
         artist = artist,

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/ReceiverAfternoteListItemDtoToDomain.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/ReceiverAfternoteListItemDtoToDomain.kt
@@ -1,13 +1,13 @@
 package com.afternote.feature.afternote.data.mapper
 
-import com.afternote.feature.afternote.data.dto.ReceivedAfternoteResponse
+import com.afternote.feature.afternote.data.dto.ReceivedAfternoteDto
 import com.afternote.feature.afternote.domain.model.receiver.AfterNoteListItem
 
 /**
  * 서버 카테고리 enum(SOCIAL/GALLERY/PLAYLIST)을 프레젠테이션이 그대로 typeKey로 쓸 수 있는
  * 카테고리 키(SOCIAL_NETWORK/GALLERY_AND_FILES/MEMORIAL)로 정규화한다.
  */
-fun ReceivedAfternoteResponse.toDomain(): AfterNoteListItem =
+fun ReceivedAfternoteDto.toDomain(): AfterNoteListItem =
     AfterNoteListItem(
         id = id,
         title = title,
@@ -15,7 +15,7 @@ fun ReceivedAfternoteResponse.toDomain(): AfterNoteListItem =
         lastUpdatedAt = createdAt?.let { formatDateFromServer(it) },
     )
 
-fun List<ReceivedAfternoteResponse>.toReceiverDomainList(): List<AfterNoteListItem> = map { it.toDomain() }
+fun List<ReceivedAfternoteDto>.toReceiverDomainList(): List<AfterNoteListItem> = map { it.toDomain() }
 
 private fun serverCategoryToTypeKey(serverCategory: String): String =
     when (serverCategory.uppercase()) {

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/response/AfternoteDetailMapper.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/response/AfternoteDetailMapper.kt
@@ -1,10 +1,10 @@
 package com.afternote.feature.afternote.data.mapper.response
 
-import com.afternote.feature.afternote.data.dto.AfternoteCredentials
-import com.afternote.feature.afternote.data.dto.AfternoteDetailReceiver
-import com.afternote.feature.afternote.data.dto.AfternoteDetailResponse
-import com.afternote.feature.afternote.data.dto.AfternotePlaylist
-import com.afternote.feature.afternote.data.dto.AfternoteSong
+import com.afternote.feature.afternote.data.dto.AfternoteCredentialsDto
+import com.afternote.feature.afternote.data.dto.AfternoteDetailDto
+import com.afternote.feature.afternote.data.dto.AfternoteDetailReceiverDto
+import com.afternote.feature.afternote.data.dto.AfternotePlaylistDto
+import com.afternote.feature.afternote.data.dto.AfternoteSongDto
 import com.afternote.feature.afternote.data.mapper.categoryToServiceType
 import com.afternote.feature.afternote.data.mapper.formatDateFromServer
 import com.afternote.feature.afternote.domain.model.author.Detail
@@ -16,7 +16,7 @@ import com.afternote.feature.afternote.domain.model.author.playlist.DetailSong
 import com.afternote.feature.afternote.domain.model.author.playlist.PlaylistDetail
 import com.afternote.feature.afternote.domain.model.author.playlist.PlaylistDetailMemorialMedia
 
-fun AfternoteDetailResponse.toDetailDomain(): Detail =
+fun AfternoteDetailDto.toDetailDomain(): Detail =
     Detail(
         id = afternoteId,
         category = category,
@@ -29,30 +29,30 @@ fun AfternoteDetailResponse.toDetailDomain(): Detail =
         playlist = playlist?.toDomain(),
     )
 
-private fun List<AfternoteDetailReceiver>?.toDomain() =
+private fun List<AfternoteDetailReceiverDto>?.toDomain() =
     this?.map { a ->
         a.toDomain()
     } ?: emptyList()
 
-private fun AfternoteDetailResponse.toTimestamps(): DetailTimestamps =
+private fun AfternoteDetailDto.toTimestamps(): DetailTimestamps =
     DetailTimestamps(
         createdAt = formatDateFromServer(createdAt),
         updatedAt = formatDateFromServer(updatedAt),
     )
 
-private fun AfternoteDetailResponse.toProcessing() =
+private fun AfternoteDetailDto.toProcessing() =
     DetailProcessing(
         actions = actions ?: emptyList(),
         leaveMessage = leaveMessage,
     )
 
-private fun AfternoteCredentials.toDomain() =
+private fun AfternoteCredentialsDto.toDomain() =
     DetailCredentials(
         id = id,
         password = password,
     )
 
-private fun AfternotePlaylist.toDomain() =
+private fun AfternotePlaylistDto.toDomain() =
     PlaylistDetail(
         profilePhoto = profilePhoto,
         atmosphere = atmosphere,
@@ -60,14 +60,14 @@ private fun AfternotePlaylist.toDomain() =
         playlistDetailMemorialMedia = toMemorialMedia(),
     )
 
-private fun AfternotePlaylist.toMemorialMedia() =
+private fun AfternotePlaylistDto.toMemorialMedia() =
     PlaylistDetailMemorialMedia(
         photoUrl = memorialPhotoUrl ?: profilePhoto,
         videoUrl = memorialVideo?.videoUrl,
         thumbnailUrl = memorialVideo?.thumbnailUrl,
     )
 
-private fun AfternoteDetailReceiver.toDomain() =
+private fun AfternoteDetailReceiverDto.toDomain() =
     DetailReceiver(
         receiverId = receiverId,
         name = name ?: "",
@@ -75,7 +75,7 @@ private fun AfternoteDetailReceiver.toDomain() =
         phone = phone ?: "",
     )
 
-private fun AfternoteSong.toDomain() =
+private fun AfternoteSongDto.toDomain() =
     DetailSong(
         id = id,
         title = title,

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/response/ReceivedAfternoteDetailMapper.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/response/ReceivedAfternoteDetailMapper.kt
@@ -1,9 +1,9 @@
 package com.afternote.feature.afternote.data.mapper.response
 
-import com.afternote.feature.afternote.data.dto.ReceivedAfternoteDetailResponse
-import com.afternote.feature.afternote.data.dto.ReceivedCredentialsInfo
-import com.afternote.feature.afternote.data.dto.ReceivedPlaylistInfo
-import com.afternote.feature.afternote.data.dto.ReceivedSongInfo
+import com.afternote.feature.afternote.data.dto.ReceivedAfternoteDetailDto
+import com.afternote.feature.afternote.data.dto.ReceivedCredentialsDto
+import com.afternote.feature.afternote.data.dto.ReceivedPlaylistDto
+import com.afternote.feature.afternote.data.dto.ReceivedSongDto
 import com.afternote.feature.afternote.data.mapper.categoryToServiceType
 import com.afternote.feature.afternote.data.mapper.formatDateFromServer
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedAccountCredentials
@@ -11,7 +11,7 @@ import com.afternote.feature.afternote.domain.model.receiver.ReceivedAfternoteDe
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedPlaylistDetail
 import com.afternote.feature.afternote.domain.model.receiver.ReceivedPlaylistSong
 
-fun ReceivedAfternoteDetailResponse.toDomain(): ReceivedAfternoteDetail =
+fun ReceivedAfternoteDetailDto.toDomain(): ReceivedAfternoteDetail =
     ReceivedAfternoteDetail(
         title = title,
         senderName = senderName,
@@ -24,13 +24,13 @@ fun ReceivedAfternoteDetailResponse.toDomain(): ReceivedAfternoteDetail =
         credentials = credentials?.toDomain(),
     )
 
-private fun ReceivedCredentialsInfo.toDomain(): ReceivedAccountCredentials =
+private fun ReceivedCredentialsDto.toDomain(): ReceivedAccountCredentials =
     ReceivedAccountCredentials(
         id = id,
         password = password,
     )
 
-private fun ReceivedPlaylistInfo.toDomain(): ReceivedPlaylistDetail =
+private fun ReceivedPlaylistDto.toDomain(): ReceivedPlaylistDetail =
     ReceivedPlaylistDetail(
         songs = songs.map { it.toDomain() },
         atmosphere = atmosphere,
@@ -38,7 +38,7 @@ private fun ReceivedPlaylistInfo.toDomain(): ReceivedPlaylistDetail =
         memorialThumbnailUrl = memorialVideo?.thumbnailUrl,
     )
 
-private fun ReceivedSongInfo.toDomain(): ReceivedPlaylistSong =
+private fun ReceivedSongDto.toDomain(): ReceivedPlaylistSong =
     ReceivedPlaylistSong(
         title = title,
         artist = artist,

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/author/AfternoteAuthoringFailureMapper.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/author/AfternoteAuthoringFailureMapper.kt
@@ -13,7 +13,7 @@ private val apiErrorJson =
     }
 
 @Serializable
-private data class ApiErrorBody(
+private data class ApiErrorBodyDto(
     val code: Int? = null,
 )
 
@@ -31,7 +31,7 @@ internal fun mapAuthoringFailure(throwable: Throwable): Throwable {
         val body = throwable.response()?.errorBody()?.string() ?: return throwable
         val parsed =
             runCatching {
-                apiErrorJson.decodeFromString<ApiErrorBody>(body)
+                apiErrorJson.decodeFromString<ApiErrorBodyDto>(body)
             }.getOrNull()
         if (parsed?.code == RECEIVERS_REQUIRED_SERVER_CODE) {
             return AfternoteAuthoringValidationException(AfternoteAuthoringValidationKind.RECEIVERS_REQUIRED)

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/author/MusicSearchRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/author/MusicSearchRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.afternote.feature.afternote.data.repositoryimpl.author
 
-import com.afternote.feature.afternote.data.dto.MusicTrack
+import com.afternote.feature.afternote.data.dto.MusicTrackDto
 import com.afternote.feature.afternote.data.service.MusicApiService
 import com.afternote.feature.afternote.domain.model.author.playlist.SearchedSong
 import com.afternote.feature.afternote.domain.repository.author.MusicSearchRepository
@@ -25,7 +25,7 @@ class MusicSearchRepositoryImpl
             }
         }
 
-        private fun MusicTrack.toPlaylistSongDisplay(index: Int): SearchedSong {
+        private fun MusicTrackDto.toPlaylistSongDisplay(index: Int): SearchedSong {
             val id = "$artist|$title|$index"
             return SearchedSong(
                 id = id,

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImpl.kt
@@ -3,11 +3,11 @@ package com.afternote.feature.afternote.data.repositoryimpl.receiver
 import com.afternote.core.network.model.ApiException
 import com.afternote.core.network.model.requireData
 import com.afternote.core.network.model.requireStatus
-import com.afternote.feature.afternote.data.dto.DeliveryVerificationRequest
-import com.afternote.feature.afternote.data.dto.ReceiverAuthCodeEmailSendRequest
-import com.afternote.feature.afternote.data.dto.ReceiverAuthPresignedUrlRequest
-import com.afternote.feature.afternote.data.dto.ReceiverAuthVerifyRequest
-import com.afternote.feature.afternote.data.dto.ReceiverEmailAuthVerifyRequest
+import com.afternote.feature.afternote.data.dto.DeliveryVerificationRequestDto
+import com.afternote.feature.afternote.data.dto.ReceiverAuthCodeEmailSendRequestDto
+import com.afternote.feature.afternote.data.dto.ReceiverAuthPresignedUrlRequestDto
+import com.afternote.feature.afternote.data.dto.ReceiverAuthVerifyRequestDto
+import com.afternote.feature.afternote.data.dto.ReceiverEmailAuthVerifyRequestDto
 import com.afternote.feature.afternote.data.dto.toDomain
 import com.afternote.feature.afternote.data.service.ReceiverAuthApiService
 import com.afternote.feature.afternote.domain.error.ReceiverDeliverySubmitException
@@ -37,13 +37,13 @@ class ReceiverAuthRepositoryImpl
     ) : ReceiverAuthRepository {
         override suspend fun verify(authCode: String): Result<ReceiverIdentity> =
             runCatching {
-                api.verify(ReceiverAuthVerifyRequest(authCode)).requireData().toDomain()
+                api.verify(ReceiverAuthVerifyRequestDto(authCode)).requireData().toDomain()
             }
 
         override suspend fun sendEmailAuthCode(email: String): Result<Unit> =
             runCatching {
                 try {
-                    api.sendEmailAuthCode(ReceiverAuthCodeEmailSendRequest(email)).requireStatus()
+                    api.sendEmailAuthCode(ReceiverAuthCodeEmailSendRequestDto(email)).requireStatus()
                 } catch (e: ApiException) {
                     throw ReceiverEmailAuthException(serverMessage = e.serverMessage, serverCode = e.code)
                 }
@@ -57,7 +57,7 @@ class ReceiverAuthRepositoryImpl
                 try {
                     api
                         .verifyEmailAuthCode(
-                            ReceiverEmailAuthVerifyRequest(email = email, authCode = authCode),
+                            ReceiverEmailAuthVerifyRequestDto(email = email, authCode = authCode),
                         ).requireData()
                         .toDomain()
                 } catch (e: ApiException) {
@@ -67,7 +67,7 @@ class ReceiverAuthRepositoryImpl
 
         override suspend fun getPresignedUrl(extension: String): Result<ReceiverAuthPresignedUrl> =
             runCatching {
-                api.getPresignedUrl(ReceiverAuthPresignedUrlRequest(extension)).requireData().toDomain()
+                api.getPresignedUrl(ReceiverAuthPresignedUrlRequestDto(extension)).requireData().toDomain()
             }
 
         override suspend fun submitDeliveryVerification(
@@ -78,7 +78,7 @@ class ReceiverAuthRepositoryImpl
                 try {
                     api
                         .submitDeliveryVerification(
-                            DeliveryVerificationRequest(
+                            DeliveryVerificationRequestDto(
                                 deathCertificateUrl = deathCertificateUrl,
                                 familyRelationCertificateUrl = familyRelationCertificateUrl,
                             ),

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/service/AfternoteApiService.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/service/AfternoteApiService.kt
@@ -1,13 +1,13 @@
 package com.afternote.feature.afternote.data.service
 
 import com.afternote.core.network.model.BaseResponse
-import com.afternote.feature.afternote.data.dto.AfternoteCreateGalleryRequest
-import com.afternote.feature.afternote.data.dto.AfternoteCreatePlaylistRequest
-import com.afternote.feature.afternote.data.dto.AfternoteCreateSocialRequest
-import com.afternote.feature.afternote.data.dto.AfternoteDetailResponse
-import com.afternote.feature.afternote.data.dto.AfternoteIdResponse
-import com.afternote.feature.afternote.data.dto.AfternoteListResponse
-import com.afternote.feature.afternote.data.dto.AfternoteUpdateRequest
+import com.afternote.feature.afternote.data.dto.AfternoteCreateGalleryRequestDto
+import com.afternote.feature.afternote.data.dto.AfternoteCreatePlaylistRequestDto
+import com.afternote.feature.afternote.data.dto.AfternoteCreateSocialRequestDto
+import com.afternote.feature.afternote.data.dto.AfternoteDetailDto
+import com.afternote.feature.afternote.data.dto.AfternoteIdDto
+import com.afternote.feature.afternote.data.dto.AfternotePageDto
+import com.afternote.feature.afternote.data.dto.AfternoteUpdateRequestDto
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -22,33 +22,33 @@ interface AfternoteApiService {
         @Query("category") category: String?,
         @Query("page") pageNumber: Int?,
         @Query("size") size: Int?,
-    ): BaseResponse<AfternoteListResponse>
+    ): BaseResponse<AfternotePageDto>
 
     @GET("afternotes/{afternoteId}")
     suspend fun getAfternoteDetail(
         @Path("afternoteId") afternoteId: Long,
-    ): BaseResponse<AfternoteDetailResponse>
+    ): BaseResponse<AfternoteDetailDto>
 
     @POST("afternotes")
     suspend fun createAfternoteSocial(
-        @Body request: AfternoteCreateSocialRequest,
-    ): BaseResponse<AfternoteIdResponse>
+        @Body request: AfternoteCreateSocialRequestDto,
+    ): BaseResponse<AfternoteIdDto>
 
     @POST("afternotes")
     suspend fun createAfternoteGallery(
-        @Body request: AfternoteCreateGalleryRequest,
-    ): BaseResponse<AfternoteIdResponse>
+        @Body request: AfternoteCreateGalleryRequestDto,
+    ): BaseResponse<AfternoteIdDto>
 
     @POST("afternotes")
     suspend fun createAfternotePlaylist(
-        @Body request: AfternoteCreatePlaylistRequest,
-    ): BaseResponse<AfternoteIdResponse>
+        @Body request: AfternoteCreatePlaylistRequestDto,
+    ): BaseResponse<AfternoteIdDto>
 
     @PATCH("afternotes/{afternoteId}")
     suspend fun updateAfternote(
         @Path("afternoteId") afternoteId: Long,
-        @Body request: AfternoteUpdateRequest,
-    ): BaseResponse<AfternoteIdResponse>
+        @Body request: AfternoteUpdateRequestDto,
+    ): BaseResponse<AfternoteIdDto>
 
     @DELETE("afternotes/{afternoteId}")
     suspend fun deleteAfternote(

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/service/MusicApiService.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/service/MusicApiService.kt
@@ -1,6 +1,6 @@
 package com.afternote.feature.afternote.data.service
 
-import com.afternote.feature.afternote.data.dto.MusicSearchResponse
+import com.afternote.feature.afternote.data.dto.MusicSearchResponseDto
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -14,5 +14,5 @@ fun interface MusicApiService {
     @GET("music/search")
     suspend fun search(
         @Query("keyword") keyword: String,
-    ): MusicSearchResponse
+    ): MusicSearchResponseDto
 }

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/service/ReceiverAfternoteApiService.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/service/ReceiverAfternoteApiService.kt
@@ -1,8 +1,8 @@
 package com.afternote.feature.afternote.data.service
 
 import com.afternote.core.network.model.BaseResponse
-import com.afternote.feature.afternote.data.dto.ReceivedAfternoteDetailResponse
-import com.afternote.feature.afternote.data.dto.ReceivedAfternoteListResponse
+import com.afternote.feature.afternote.data.dto.ReceivedAfternoteDetailDto
+import com.afternote.feature.afternote.data.dto.ReceivedAfternoteListDto
 import retrofit2.http.GET
 import retrofit2.http.Path
 
@@ -12,11 +12,11 @@ interface ReceiverAfternoteApiService {
      * `X-Auth-Code` 헤더는 [com.afternote.feature.afternote.data.network.ReceiverAuthInterceptor]가 자동 부착한다.
      */
     @GET("receiver-auth/after-notes")
-    suspend fun getReceiverAfternotes(): BaseResponse<ReceivedAfternoteListResponse>
+    suspend fun getReceiverAfternotes(): BaseResponse<ReceivedAfternoteListDto>
 
     /** 인증번호로 수신한 특정 애프터노트의 상세 조회. */
     @GET("receiver-auth/after-notes/{afternoteId}")
     suspend fun getReceiverAfternoteDetail(
         @Path("afternoteId") afternoteId: Long,
-    ): BaseResponse<ReceivedAfternoteDetailResponse>
+    ): BaseResponse<ReceivedAfternoteDetailDto>
 }

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/service/ReceiverAuthApiService.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/service/ReceiverAuthApiService.kt
@@ -1,16 +1,16 @@
 package com.afternote.feature.afternote.data.service
 
 import com.afternote.core.network.model.BaseResponse
-import com.afternote.feature.afternote.data.dto.DeliveryVerificationRequest
-import com.afternote.feature.afternote.data.dto.DeliveryVerificationResponse
-import com.afternote.feature.afternote.data.dto.ReceiverAuthCodeEmailSendRequest
-import com.afternote.feature.afternote.data.dto.ReceiverAuthPresignedUrlRequest
-import com.afternote.feature.afternote.data.dto.ReceiverAuthPresignedUrlResponse
-import com.afternote.feature.afternote.data.dto.ReceiverAuthVerifyRequest
-import com.afternote.feature.afternote.data.dto.ReceiverAuthVerifyResponse
-import com.afternote.feature.afternote.data.dto.ReceiverEmailAuthVerifyRequest
-import com.afternote.feature.afternote.data.dto.ReceiverEmailAuthVerifyResponse
-import com.afternote.feature.afternote.data.dto.ReceiverMessageResponse
+import com.afternote.feature.afternote.data.dto.DeliveryVerificationDto
+import com.afternote.feature.afternote.data.dto.DeliveryVerificationRequestDto
+import com.afternote.feature.afternote.data.dto.ReceiverAuthCodeEmailSendRequestDto
+import com.afternote.feature.afternote.data.dto.ReceiverAuthPresignedUrlDto
+import com.afternote.feature.afternote.data.dto.ReceiverAuthPresignedUrlRequestDto
+import com.afternote.feature.afternote.data.dto.ReceiverAuthVerifyDto
+import com.afternote.feature.afternote.data.dto.ReceiverAuthVerifyRequestDto
+import com.afternote.feature.afternote.data.dto.ReceiverEmailAuthVerifyDto
+import com.afternote.feature.afternote.data.dto.ReceiverEmailAuthVerifyRequestDto
+import com.afternote.feature.afternote.data.dto.ReceiverMessageDto
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -26,34 +26,34 @@ import retrofit2.http.POST
 interface ReceiverAuthApiService {
     @POST("receiver-auth/verify")
     suspend fun verify(
-        @Body body: ReceiverAuthVerifyRequest,
-    ): BaseResponse<ReceiverAuthVerifyResponse>
+        @Body body: ReceiverAuthVerifyRequestDto,
+    ): BaseResponse<ReceiverAuthVerifyDto>
 
     /** 수신자 레코드에 등록된 email 로 6자리 인증번호 발송. 미등록 email 은 404 (code 1901). */
     @POST("receiver-auth/email/auth-code")
     suspend fun sendEmailAuthCode(
-        @Body body: ReceiverAuthCodeEmailSendRequest,
+        @Body body: ReceiverAuthCodeEmailSendRequestDto,
     ): BaseResponse<Unit>
 
     /** 발송된 6자리 인증번호 검증. 만료/불일치는 400 (code 1902). */
     @POST("receiver-auth/email/verify")
     suspend fun verifyEmailAuthCode(
-        @Body body: ReceiverEmailAuthVerifyRequest,
-    ): BaseResponse<ReceiverEmailAuthVerifyResponse>
+        @Body body: ReceiverEmailAuthVerifyRequestDto,
+    ): BaseResponse<ReceiverEmailAuthVerifyDto>
 
     @POST("receiver-auth/presigned-url")
     suspend fun getPresignedUrl(
-        @Body body: ReceiverAuthPresignedUrlRequest,
-    ): BaseResponse<ReceiverAuthPresignedUrlResponse>
+        @Body body: ReceiverAuthPresignedUrlRequestDto,
+    ): BaseResponse<ReceiverAuthPresignedUrlDto>
 
     @POST("receiver-auth/delivery-verification")
     suspend fun submitDeliveryVerification(
-        @Body body: DeliveryVerificationRequest,
-    ): BaseResponse<DeliveryVerificationResponse>
+        @Body body: DeliveryVerificationRequestDto,
+    ): BaseResponse<DeliveryVerificationDto>
 
     @GET("receiver-auth/delivery-verification/status")
-    suspend fun getDeliveryVerificationStatus(): BaseResponse<DeliveryVerificationResponse>
+    suspend fun getDeliveryVerificationStatus(): BaseResponse<DeliveryVerificationDto>
 
     @GET("receiver-auth/message")
-    suspend fun getSenderMessage(): BaseResponse<ReceiverMessageResponse>
+    suspend fun getSenderMessage(): BaseResponse<ReceiverMessageDto>
 }

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/DeliveryVerificationContractTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/DeliveryVerificationContractTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
  * `POST /receiver-auth/delivery-verification` 요청 계약 회귀 가드 (#380).
  *
  * 서버가 두 서류 URL 을 모두 요구하던 스펙을 "하나 이상" 으로 완화 — 2026-07-07 라이브 Swagger
- * (`afternote.kro.kr/v3/api-docs`) 실측: `DeliveryVerificationRequest` 스키마에서 required 제거,
+ * (`afternote.kro.kr/v3/api-docs`) 실측: `DeliveryVerificationRequestDto` 스키마에서 required 제거,
  * 두 필드 모두 nullable, description "두 서류 중 하나 이상 필수".
  *
  * Json 설정은 `NetworkModule.provideJson` 과 동일 (ignoreUnknownKeys + coerceInputValues).
@@ -25,18 +25,18 @@ class DeliveryVerificationContractTest {
 
     @Test
     fun `사망진단서만 제출 - 미제출 슬롯 키는 페이로드에서 생략`() {
-        val body = DeliveryVerificationRequest(deathCertificateUrl = "https://bucket/death.pdf")
+        val body = DeliveryVerificationRequestDto(deathCertificateUrl = "https://bucket/death.pdf")
 
-        val encoded = json.encodeToString(DeliveryVerificationRequest.serializer(), body)
+        val encoded = json.encodeToString(DeliveryVerificationRequestDto.serializer(), body)
 
         assertEquals("""{"deathCertificateUrl":"https://bucket/death.pdf"}""", encoded)
     }
 
     @Test
     fun `가족관계증명서만 제출 - 미제출 슬롯 키는 페이로드에서 생략`() {
-        val body = DeliveryVerificationRequest(familyRelationCertificateUrl = "https://bucket/family.pdf")
+        val body = DeliveryVerificationRequestDto(familyRelationCertificateUrl = "https://bucket/family.pdf")
 
-        val encoded = json.encodeToString(DeliveryVerificationRequest.serializer(), body)
+        val encoded = json.encodeToString(DeliveryVerificationRequestDto.serializer(), body)
 
         assertEquals("""{"familyRelationCertificateUrl":"https://bucket/family.pdf"}""", encoded)
     }
@@ -44,12 +44,12 @@ class DeliveryVerificationContractTest {
     @Test
     fun `두 서류 모두 제출 - 두 키 모두 포함`() {
         val body =
-            DeliveryVerificationRequest(
+            DeliveryVerificationRequestDto(
                 deathCertificateUrl = "https://bucket/death.pdf",
                 familyRelationCertificateUrl = "https://bucket/family.pdf",
             )
 
-        val encoded = json.encodeToString(DeliveryVerificationRequest.serializer(), body)
+        val encoded = json.encodeToString(DeliveryVerificationRequestDto.serializer(), body)
 
         assertEquals(
             """{"deathCertificateUrl":"https://bucket/death.pdf","familyRelationCertificateUrl":"https://bucket/family.pdf"}""",

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverAuthDtoMapperTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverAuthDtoMapperTest.kt
@@ -13,9 +13,9 @@ import org.junit.Test
  */
 class ReceiverAuthDtoMapperTest {
     @Test
-    fun `ReceiverMessageResponse toDomain - SenderMessageInfo 매핑`() {
+    fun `ReceiverMessageDto toDomain - SenderMessageInfo 매핑`() {
         val result =
-            ReceiverMessageResponse(
+            ReceiverMessageDto(
                 senderName = "홍길동",
                 message = "보고싶다",
                 createdAt = "2026-06-08T12:00:53",
@@ -26,16 +26,16 @@ class ReceiverAuthDtoMapperTest {
     }
 
     @Test
-    fun `ReceiverMessageResponse toDomain - message·createdAt 미제공 시 null 유지`() {
-        val result = ReceiverMessageResponse(senderName = "홍길동").toDomain()
+    fun `ReceiverMessageDto toDomain - message·createdAt 미제공 시 null 유지`() {
+        val result = ReceiverMessageDto(senderName = "홍길동").toDomain()
         assertNull(result.message)
         assertNull(result.createdAt)
     }
 
     @Test
-    fun `ReceiverAuthVerifyResponse toDomain - ReceiverIdentity 매핑`() {
+    fun `ReceiverAuthVerifyDto toDomain - ReceiverIdentity 매핑`() {
         val result =
-            ReceiverAuthVerifyResponse(
+            ReceiverAuthVerifyDto(
                 receiverId = 3L,
                 receiverName = "김수신",
                 senderName = "홍발신",
@@ -49,9 +49,9 @@ class ReceiverAuthDtoMapperTest {
     }
 
     @Test
-    fun `ReceiverEmailAuthVerifyResponse toDomain - ReceiverEmailAuthResult 매핑`() {
+    fun `ReceiverEmailAuthVerifyDto toDomain - ReceiverEmailAuthResult 매핑`() {
         val result =
-            ReceiverEmailAuthVerifyResponse(
+            ReceiverEmailAuthVerifyDto(
                 receiverId = 7L,
                 receiverName = "김수신",
                 senderName = "홍발신",
@@ -65,9 +65,9 @@ class ReceiverAuthDtoMapperTest {
     }
 
     @Test
-    fun `ReceiverAuthPresignedUrlResponse toDomain - 매핑`() {
+    fun `ReceiverAuthPresignedUrlDto toDomain - 매핑`() {
         val result =
-            ReceiverAuthPresignedUrlResponse(
+            ReceiverAuthPresignedUrlDto(
                 presignedUrl = "url",
                 fileKey = "key",
                 fileUrl = "file",
@@ -81,18 +81,18 @@ class ReceiverAuthDtoMapperTest {
     }
 
     @Test
-    fun `DeliveryVerificationResponse toDomain - status fromRaw 대소문자 무시`() {
+    fun `DeliveryVerificationDto toDomain - status fromRaw 대소문자 무시`() {
         assertEquals(DeliveryVerificationStatus.APPROVED, response(status = "approved").toDomain().status)
         assertEquals(DeliveryVerificationStatus.PENDING, response(status = "PENDING").toDomain().status)
     }
 
     @Test
-    fun `DeliveryVerificationResponse toDomain - 알 수 없는 status는 UNKNOWN`() {
+    fun `DeliveryVerificationDto toDomain - 알 수 없는 status는 UNKNOWN`() {
         assertEquals(DeliveryVerificationStatus.UNKNOWN, response(status = "WeIrD").toDomain().status)
     }
 
     @Test
-    fun `DeliveryVerificationResponse toDomain - 나머지 필드 전달`() {
+    fun `DeliveryVerificationDto toDomain - 나머지 필드 전달`() {
         val result = response(status = "REJECTED").toDomain()
         assertEquals(11L, result.id)
         assertEquals(DeliveryVerificationStatus.REJECTED, result.status)
@@ -103,7 +103,7 @@ class ReceiverAuthDtoMapperTest {
     }
 
     private fun response(status: String) =
-        DeliveryVerificationResponse(
+        DeliveryVerificationDto(
             id = 11L,
             status = status,
             deathCertificateUrl = "death",

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverEmailAuthContractTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverEmailAuthContractTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
  *
  * 페이로드는 2026-06-11 라이브 Swagger(`afternote.kro.kr/v3/api-docs`) 스키마 기반 합성 —
  * verify 성공 응답은 6자리 인증번호를 메일로 받아야 해서 자동 캡처 불가
- * (`ReceiverEmailAuthVerifyResponse` 4필드 구성·타입은 Swagger 와 BE 소스로 확정, 이슈 #407 본문).
+ * (`ReceiverEmailAuthVerifyDto` 4필드 구성·타입은 Swagger 와 BE 소스로 확정, 이슈 #407 본문).
  * 프로덕션 경로(`ReceiverAuthRepositoryImpl`)와 동일하게 Json 디코드 → `requireData()`/`requireStatus()`
  * → `toDomain()` 을 통과시킨다 — Json 설정은 `NetworkModule.provideJson` 과 동일
  * (ignoreUnknownKeys + coerceInputValues).
@@ -32,7 +32,7 @@ class ReceiverEmailAuthContractTest {
         val payload =
             """{"status":200,"code":200,"message":"성공","data":{"receiverId":3,"receiverName":"큐에이수신자","senderName":"큐에이발신자","accessCode":"123e4567-e89b-12d3-a456-426614174000"}}"""
 
-        val result = json.decodeFromString<BaseResponse<ReceiverEmailAuthVerifyResponse>>(payload).requireData().toDomain()
+        val result = json.decodeFromString<BaseResponse<ReceiverEmailAuthVerifyDto>>(payload).requireData().toDomain()
 
         assertEquals(3L, result.receiverId)
         assertEquals("큐에이수신자", result.receiverName)

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverMessageContractTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverMessageContractTest.kt
@@ -28,7 +28,7 @@ class ReceiverMessageContractTest {
         val payload =
             """{"status":200,"code":200,"message":"성공","data":{"senderName":"큐에이발신자","message":"실서버 통신 검증용 한 마디입니다. 잘 지내렴.","createdAt":"2026-06-10T15:27:14.141643"}}"""
 
-        val info = json.decodeFromString<BaseResponse<ReceiverMessageResponse>>(payload).requireData().toDomain()
+        val info = json.decodeFromString<BaseResponse<ReceiverMessageDto>>(payload).requireData().toDomain()
 
         assertEquals("큐에이발신자", info.senderName)
         assertEquals("실서버 통신 검증용 한 마디입니다. 잘 지내렴.", info.message)
@@ -40,7 +40,7 @@ class ReceiverMessageContractTest {
     fun `createdAt·message 없는 구버전 응답 - 디코드 깨지지 않고 null 유지`() {
         val payload = """{"status":200,"code":200,"data":{"senderName":"김철수"}}"""
 
-        val info = json.decodeFromString<BaseResponse<ReceiverMessageResponse>>(payload).requireData().toDomain()
+        val info = json.decodeFromString<BaseResponse<ReceiverMessageDto>>(payload).requireData().toDomain()
 
         assertNull(info.message)
         assertNull(info.createdAt)

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/AfternoteListItemDtoToDomainTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/AfternoteListItemDtoToDomainTest.kt
@@ -1,12 +1,12 @@
 package com.afternote.feature.afternote.data.mapper
 
-import com.afternote.feature.afternote.data.dto.AfternoteListItem
+import com.afternote.feature.afternote.data.dto.AfternoteListItemDto
 import com.afternote.feature.afternote.domain.AfternoteServiceType
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * [AfternoteListItem.toDomain] / [toDomainList] 회귀 가드.
+ * [AfternoteListItemDto.toDomain] / [toDomainList] 회귀 가드.
  * 작성자 목록 DTO→[com.afternote.feature.afternote.domain.model.author.ListItem] 매핑 +
  * 공유 헬퍼([formatDateFromServer]·[categoryToServiceType])의 경계 동작을 toDomain 경유로 검증.
  */
@@ -14,7 +14,7 @@ class AfternoteListItemDtoToDomainTest {
     @Test
     fun `toDomain - 필드 매핑 + id Long을 String으로`() {
         val result =
-            AfternoteListItem(
+            AfternoteListItemDto(
                 afternoteId = 7L,
                 title = "은행 계정",
                 category = "SOCIAL",
@@ -46,7 +46,7 @@ class AfternoteListItemDtoToDomainTest {
 
     @Test
     fun `toDomainList - 빈 리스트는 빈 리스트`() {
-        assertEquals(emptyList<Any>(), emptyList<AfternoteListItem>().toDomainList())
+        assertEquals(emptyList<Any>(), emptyList<AfternoteListItemDto>().toDomainList())
     }
 
     @Test
@@ -60,7 +60,7 @@ class AfternoteListItemDtoToDomainTest {
         title: String = "t",
         category: String = "SOCIAL",
         createdAt: String = "2025-01-01T00:00:00",
-    ) = AfternoteListItem(
+    ) = AfternoteListItemDto(
         afternoteId = afternoteId,
         title = title,
         category = category,

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/ReceiverAfternoteListItemDtoToDomainTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/ReceiverAfternoteListItemDtoToDomainTest.kt
@@ -1,12 +1,12 @@
 package com.afternote.feature.afternote.data.mapper
 
-import com.afternote.feature.afternote.data.dto.ReceivedAfternoteResponse
+import com.afternote.feature.afternote.data.dto.ReceivedAfternoteDto
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
- * [ReceivedAfternoteResponse.toDomain] / [toReceiverDomainList] 회귀 가드.
+ * [ReceivedAfternoteDto.toDomain] / [toReceiverDomainList] 회귀 가드.
  * 수신자 목록 DTO→[com.afternote.feature.afternote.domain.model.receiver.AfterNoteListItem] 매핑.
  * 서버 카테고리(SOCIAL/GALLERY/PLAYLIST/MUSIC)를 presentation typeKey로 정규화하는 규칙과
  * null 가드(category·createdAt)를 검증한다.
@@ -15,7 +15,7 @@ class ReceiverAfternoteListItemDtoToDomainTest {
     @Test
     fun `toDomain - 필드 매핑 + category 정규화 + 날짜 포맷`() {
         val result =
-            ReceivedAfternoteResponse(
+            ReceivedAfternoteDto(
                 id = 9L,
                 title = "사진첩",
                 category = "GALLERY",
@@ -61,7 +61,7 @@ class ReceiverAfternoteListItemDtoToDomainTest {
         title: String? = "t",
         category: String? = "SOCIAL",
         createdAt: String? = "2025-01-01T00:00:00",
-    ) = ReceivedAfternoteResponse(
+    ) = ReceivedAfternoteDto(
         id = id,
         title = title,
         category = category,

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/response/AfternoteDetailMapperTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/response/AfternoteDetailMapperTest.kt
@@ -1,11 +1,11 @@
 package com.afternote.feature.afternote.data.mapper.response
 
-import com.afternote.feature.afternote.data.dto.AfternoteCredentials
-import com.afternote.feature.afternote.data.dto.AfternoteDetailReceiver
-import com.afternote.feature.afternote.data.dto.AfternoteDetailResponse
-import com.afternote.feature.afternote.data.dto.AfternoteMemorialVideo
-import com.afternote.feature.afternote.data.dto.AfternotePlaylist
-import com.afternote.feature.afternote.data.dto.AfternoteSong
+import com.afternote.feature.afternote.data.dto.AfternoteCredentialsDto
+import com.afternote.feature.afternote.data.dto.AfternoteDetailDto
+import com.afternote.feature.afternote.data.dto.AfternoteDetailReceiverDto
+import com.afternote.feature.afternote.data.dto.AfternoteMemorialVideoDto
+import com.afternote.feature.afternote.data.dto.AfternotePlaylistDto
+import com.afternote.feature.afternote.data.dto.AfternoteSongDto
 import com.afternote.feature.afternote.domain.AfternoteServiceType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -13,16 +13,16 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * [AfternoteDetailResponse.toDetailDomain] 회귀 가드 (작성자 상세).
+ * [AfternoteDetailDto.toDetailDomain] 회귀 가드 (작성자 상세).
  * 핵심 경계: receivers null→emptyList, receiver 필드 null→"", actions null→emptyList,
  * memorialPhotoUrl 없으면 profilePhoto로 대체, memorialVideo null→video/thumbnail null,
  * credentials·playlist nullable 매핑.
  */
-class AfternoteDetailResponseMapperTest {
+class AfternoteDetailMapperTest {
     @Test
     fun `toDetailDomain - 최소 응답은 nullable이 비거나 null`() {
         val result =
-            AfternoteDetailResponse(
+            AfternoteDetailDto(
                 afternoteId = 1L,
                 category = "SOCIAL",
                 title = "t",
@@ -39,7 +39,7 @@ class AfternoteDetailResponseMapperTest {
     @Test
     fun `toDetailDomain - timestamps 포맷`() {
         val result =
-            AfternoteDetailResponse(
+            AfternoteDetailDto(
                 afternoteId = 1L,
                 category = "SOCIAL",
                 title = "t",
@@ -54,11 +54,11 @@ class AfternoteDetailResponseMapperTest {
     @Test
     fun `toDetailDomain - receiver의 null 필드는 빈 문자열`() {
         val result =
-            AfternoteDetailResponse(
+            AfternoteDetailDto(
                 afternoteId = 1L,
                 category = "GALLERY",
                 title = "t",
-                receivers = listOf(AfternoteDetailReceiver(receiverId = 5L)),
+                receivers = listOf(AfternoteDetailReceiverDto(receiverId = 5L)),
             ).toDetailDomain()
 
         val receiver = result.receivers.single()
@@ -71,11 +71,11 @@ class AfternoteDetailResponseMapperTest {
     @Test
     fun `toDetailDomain - credentials 매핑`() {
         val result =
-            AfternoteDetailResponse(
+            AfternoteDetailDto(
                 afternoteId = 1L,
                 category = "SOCIAL",
                 title = "t",
-                credentials = AfternoteCredentials(id = "user", password = "pw"),
+                credentials = AfternoteCredentialsDto(id = "user", password = "pw"),
             ).toDetailDomain()
 
         assertEquals("user", result.credentials!!.id)
@@ -85,16 +85,16 @@ class AfternoteDetailResponseMapperTest {
     @Test
     fun `toDetailDomain - memorialPhotoUrl 없으면 profilePhoto로 대체`() {
         val result =
-            AfternoteDetailResponse(
+            AfternoteDetailDto(
                 afternoteId = 1L,
                 category = "PLAYLIST",
                 title = "t",
                 playlist =
-                    AfternotePlaylist(
+                    AfternotePlaylistDto(
                         profilePhoto = "profile.jpg",
                         memorialPhotoUrl = null,
-                        songs = listOf(AfternoteSong(id = 3L, title = "s", artist = "a")),
-                        memorialVideo = AfternoteMemorialVideo(videoUrl = "v.mp4", thumbnailUrl = "t.jpg"),
+                        songs = listOf(AfternoteSongDto(id = 3L, title = "s", artist = "a")),
+                        memorialVideo = AfternoteMemorialVideoDto(videoUrl = "v.mp4", thumbnailUrl = "t.jpg"),
                     ),
             ).toDetailDomain()
 
@@ -115,11 +115,11 @@ class AfternoteDetailResponseMapperTest {
     @Test
     fun `toDetailDomain - memorialPhotoUrl 있으면 그대로`() {
         val result =
-            AfternoteDetailResponse(
+            AfternoteDetailDto(
                 afternoteId = 1L,
                 category = "PLAYLIST",
                 title = "t",
-                playlist = AfternotePlaylist(profilePhoto = "profile.jpg", memorialPhotoUrl = "memorial.jpg"),
+                playlist = AfternotePlaylistDto(profilePhoto = "profile.jpg", memorialPhotoUrl = "memorial.jpg"),
             ).toDetailDomain()
 
         assertEquals("memorial.jpg", result.playlist!!.playlistDetailMemorialMedia.photoUrl)
@@ -128,11 +128,11 @@ class AfternoteDetailResponseMapperTest {
     @Test
     fun `toDetailDomain - memorialVideo null이면 video thumbnail null`() {
         val result =
-            AfternoteDetailResponse(
+            AfternoteDetailDto(
                 afternoteId = 1L,
                 category = "PLAYLIST",
                 title = "t",
-                playlist = AfternotePlaylist(profilePhoto = "p", memorialVideo = null),
+                playlist = AfternotePlaylistDto(profilePhoto = "p", memorialVideo = null),
             ).toDetailDomain()
 
         val media = result.playlist!!.playlistDetailMemorialMedia

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/response/ReceivedAfternoteDetailMapperTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/response/ReceivedAfternoteDetailMapperTest.kt
@@ -1,25 +1,25 @@
 package com.afternote.feature.afternote.data.mapper.response
 
-import com.afternote.feature.afternote.data.dto.ReceivedAfternoteDetailResponse
-import com.afternote.feature.afternote.data.dto.ReceivedCredentialsInfo
-import com.afternote.feature.afternote.data.dto.ReceivedMemorialVideoInfo
-import com.afternote.feature.afternote.data.dto.ReceivedPlaylistInfo
-import com.afternote.feature.afternote.data.dto.ReceivedSongInfo
+import com.afternote.feature.afternote.data.dto.ReceivedAfternoteDetailDto
+import com.afternote.feature.afternote.data.dto.ReceivedCredentialsDto
+import com.afternote.feature.afternote.data.dto.ReceivedMemorialVideoDto
+import com.afternote.feature.afternote.data.dto.ReceivedPlaylistDto
+import com.afternote.feature.afternote.data.dto.ReceivedSongDto
 import com.afternote.feature.afternote.domain.AfternoteServiceType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
- * [ReceivedAfternoteDetailResponse.toDomain] 회귀 가드 (수신자 상세).
+ * [ReceivedAfternoteDetailDto.toDomain] 회귀 가드 (수신자 상세).
  * 경계: createdAt null→null·있으면 포맷, category null→type null, playlist·credentials nullable 매핑,
  * memorialVideo의 video/thumbnail 추출.
  */
-class ReceivedAfternoteDetailResponseMapperTest {
+class ReceivedAfternoteDetailMapperTest {
     @Test
     fun `toDomain - 필드 매핑 + createdAt 포맷 + type 매핑`() {
         val result =
-            ReceivedAfternoteDetailResponse(
+            ReceivedAfternoteDetailDto(
                 id = 1L,
                 category = "MUSIC",
                 title = "추모",
@@ -36,29 +36,29 @@ class ReceivedAfternoteDetailResponseMapperTest {
 
     @Test
     fun `toDomain - category null이면 type null`() {
-        assertNull(ReceivedAfternoteDetailResponse(id = 1L, category = null).toDomain().type)
+        assertNull(ReceivedAfternoteDetailDto(id = 1L, category = null).toDomain().type)
     }
 
     @Test
     fun `toDomain - createdAt null이면 createdAt null`() {
-        assertNull(ReceivedAfternoteDetailResponse(id = 1L, createdAt = null).toDomain().createdAt)
+        assertNull(ReceivedAfternoteDetailDto(id = 1L, createdAt = null).toDomain().createdAt)
     }
 
     @Test
     fun `toDomain - playlist null이면 null`() {
-        assertNull(ReceivedAfternoteDetailResponse(id = 1L, playlist = null).toDomain().playlist)
+        assertNull(ReceivedAfternoteDetailDto(id = 1L, playlist = null).toDomain().playlist)
     }
 
     @Test
     fun `toDomain - playlist 있으면 songs·atmosphere·memorialVideo 매핑`() {
         val result =
-            ReceivedAfternoteDetailResponse(
+            ReceivedAfternoteDetailDto(
                 id = 1L,
                 playlist =
-                    ReceivedPlaylistInfo(
+                    ReceivedPlaylistDto(
                         atmosphere = "차분",
-                        songs = listOf(ReceivedSongInfo(title = "s", artist = "a", coverUrl = "c")),
-                        memorialVideo = ReceivedMemorialVideoInfo(videoUrl = "v", thumbnailUrl = "t"),
+                        songs = listOf(ReceivedSongDto(title = "s", artist = "a", coverUrl = "c")),
+                        memorialVideo = ReceivedMemorialVideoDto(videoUrl = "v", thumbnailUrl = "t"),
                     ),
             ).toDomain()
 
@@ -72,9 +72,9 @@ class ReceivedAfternoteDetailResponseMapperTest {
     @Test
     fun `toDomain - credentials 매핑`() {
         val result =
-            ReceivedAfternoteDetailResponse(
+            ReceivedAfternoteDetailDto(
                 id = 1L,
-                credentials = ReceivedCredentialsInfo(id = "u", password = "p"),
+                credentials = ReceivedCredentialsDto(id = "u", password = "p"),
             ).toDomain()
 
         assertEquals("u", result.credentials!!.id)

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImplEmailAuthTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImplEmailAuthTest.kt
@@ -2,16 +2,16 @@ package com.afternote.feature.afternote.data.repositoryimpl.receiver
 
 import com.afternote.core.network.model.ApiException
 import com.afternote.core.network.model.BaseResponse
-import com.afternote.feature.afternote.data.dto.DeliveryVerificationRequest
-import com.afternote.feature.afternote.data.dto.DeliveryVerificationResponse
-import com.afternote.feature.afternote.data.dto.ReceiverAuthCodeEmailSendRequest
-import com.afternote.feature.afternote.data.dto.ReceiverAuthPresignedUrlRequest
-import com.afternote.feature.afternote.data.dto.ReceiverAuthPresignedUrlResponse
-import com.afternote.feature.afternote.data.dto.ReceiverAuthVerifyRequest
-import com.afternote.feature.afternote.data.dto.ReceiverAuthVerifyResponse
-import com.afternote.feature.afternote.data.dto.ReceiverEmailAuthVerifyRequest
-import com.afternote.feature.afternote.data.dto.ReceiverEmailAuthVerifyResponse
-import com.afternote.feature.afternote.data.dto.ReceiverMessageResponse
+import com.afternote.feature.afternote.data.dto.DeliveryVerificationDto
+import com.afternote.feature.afternote.data.dto.DeliveryVerificationRequestDto
+import com.afternote.feature.afternote.data.dto.ReceiverAuthCodeEmailSendRequestDto
+import com.afternote.feature.afternote.data.dto.ReceiverAuthPresignedUrlDto
+import com.afternote.feature.afternote.data.dto.ReceiverAuthPresignedUrlRequestDto
+import com.afternote.feature.afternote.data.dto.ReceiverAuthVerifyDto
+import com.afternote.feature.afternote.data.dto.ReceiverAuthVerifyRequestDto
+import com.afternote.feature.afternote.data.dto.ReceiverEmailAuthVerifyDto
+import com.afternote.feature.afternote.data.dto.ReceiverEmailAuthVerifyRequestDto
+import com.afternote.feature.afternote.data.dto.ReceiverMessageDto
 import com.afternote.feature.afternote.data.service.ReceiverAuthApiService
 import com.afternote.feature.afternote.domain.error.ReceiverEmailAuthException
 import kotlinx.coroutines.runBlocking
@@ -103,7 +103,7 @@ class ReceiverAuthRepositoryImplEmailAuthTest {
                             code = 200,
                             message = "성공",
                             data =
-                                ReceiverEmailAuthVerifyResponse(
+                                ReceiverEmailAuthVerifyDto(
                                     receiverId = 3L,
                                     receiverName = "큐에이수신자",
                                     senderName = "큐에이발신자",
@@ -123,25 +123,25 @@ class ReceiverAuthRepositoryImplEmailAuthTest {
 
 /** 이메일 인증 두 메서드만 주입 가능한 fake — 나머지 endpoint 는 본 테스트 대상 아님. */
 private class FakeReceiverAuthApiService(
-    private val onSendEmailAuthCode: (ReceiverAuthCodeEmailSendRequest) -> BaseResponse<Unit> = { error("unused") },
+    private val onSendEmailAuthCode: (ReceiverAuthCodeEmailSendRequestDto) -> BaseResponse<Unit> = { error("unused") },
     private val onVerifyEmailAuthCode: (
-        ReceiverEmailAuthVerifyRequest,
-    ) -> BaseResponse<ReceiverEmailAuthVerifyResponse> = { error("unused") },
+        ReceiverEmailAuthVerifyRequestDto,
+    ) -> BaseResponse<ReceiverEmailAuthVerifyDto> = { error("unused") },
 ) : ReceiverAuthApiService {
-    override suspend fun verify(body: ReceiverAuthVerifyRequest): BaseResponse<ReceiverAuthVerifyResponse> = error("unused")
+    override suspend fun verify(body: ReceiverAuthVerifyRequestDto): BaseResponse<ReceiverAuthVerifyDto> = error("unused")
 
-    override suspend fun sendEmailAuthCode(body: ReceiverAuthCodeEmailSendRequest): BaseResponse<Unit> = onSendEmailAuthCode(body)
+    override suspend fun sendEmailAuthCode(body: ReceiverAuthCodeEmailSendRequestDto): BaseResponse<Unit> = onSendEmailAuthCode(body)
 
-    override suspend fun verifyEmailAuthCode(body: ReceiverEmailAuthVerifyRequest): BaseResponse<ReceiverEmailAuthVerifyResponse> =
+    override suspend fun verifyEmailAuthCode(body: ReceiverEmailAuthVerifyRequestDto): BaseResponse<ReceiverEmailAuthVerifyDto> =
         onVerifyEmailAuthCode(body)
 
-    override suspend fun getPresignedUrl(body: ReceiverAuthPresignedUrlRequest): BaseResponse<ReceiverAuthPresignedUrlResponse> =
+    override suspend fun getPresignedUrl(body: ReceiverAuthPresignedUrlRequestDto): BaseResponse<ReceiverAuthPresignedUrlDto> =
         error("unused")
 
-    override suspend fun submitDeliveryVerification(body: DeliveryVerificationRequest): BaseResponse<DeliveryVerificationResponse> =
+    override suspend fun submitDeliveryVerification(body: DeliveryVerificationRequestDto): BaseResponse<DeliveryVerificationDto> =
         error("unused")
 
-    override suspend fun getDeliveryVerificationStatus(): BaseResponse<DeliveryVerificationResponse> = error("unused")
+    override suspend fun getDeliveryVerificationStatus(): BaseResponse<DeliveryVerificationDto> = error("unused")
 
-    override suspend fun getSenderMessage(): BaseResponse<ReceiverMessageResponse> = error("unused")
+    override suspend fun getSenderMessage(): BaseResponse<ReceiverMessageDto> = error("unused")
 }

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/api/DailyQuestionApiService.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/api/DailyQuestionApiService.kt
@@ -1,10 +1,10 @@
 package com.afternote.feature.mindrecord.data.api
 
 import com.afternote.core.network.model.BaseResponse
-import com.afternote.feature.mindrecord.data.dto.DailyQuestionCreateRequest
-import com.afternote.feature.mindrecord.data.dto.DailyQuestionListItem
-import com.afternote.feature.mindrecord.data.dto.DailyQuestionUpdateRequest
-import com.afternote.feature.mindrecord.data.dto.TodayDailyQuestionResponse
+import com.afternote.feature.mindrecord.data.dto.DailyQuestionCreateRequestDto
+import com.afternote.feature.mindrecord.data.dto.DailyQuestionListItemDto
+import com.afternote.feature.mindrecord.data.dto.DailyQuestionUpdateRequestDto
+import com.afternote.feature.mindrecord.data.dto.TodayDailyQuestionDto
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -17,20 +17,20 @@ interface DailyQuestionApiService {
     @GET("daily-questions")
     suspend fun getDailyQuestions(
         @Query("date") date: String? = null,
-    ): BaseResponse<List<DailyQuestionListItem>>
+    ): BaseResponse<List<DailyQuestionListItemDto>>
 
     @GET("daily-questions/today")
-    suspend fun getTodayDailyQuestion(): BaseResponse<TodayDailyQuestionResponse>
+    suspend fun getTodayDailyQuestion(): BaseResponse<TodayDailyQuestionDto>
 
     @POST("daily-questions")
     suspend fun createDailyQuestion(
-        @Body request: DailyQuestionCreateRequest,
+        @Body request: DailyQuestionCreateRequestDto,
     ): BaseResponse<Unit>
 
     @PATCH("daily-questions/{userDailyQuestionId}")
     suspend fun updateDailyQuestion(
         @Path("userDailyQuestionId") userDailyQuestionId: Long,
-        @Body request: DailyQuestionUpdateRequest,
+        @Body request: DailyQuestionUpdateRequestDto,
     ): BaseResponse<Unit>
 
     @DELETE("daily-questions/{userDailyQuestionId}")

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/api/DiaryApiService.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/api/DiaryApiService.kt
@@ -1,9 +1,9 @@
 package com.afternote.feature.mindrecord.data.api
 
 import com.afternote.core.network.model.BaseResponse
-import com.afternote.feature.mindrecord.data.dto.DiaryCreateRequest
-import com.afternote.feature.mindrecord.data.dto.DiaryListResponse
-import com.afternote.feature.mindrecord.data.dto.DiaryUpdateRequest
+import com.afternote.feature.mindrecord.data.dto.DiaryCreateRequestDto
+import com.afternote.feature.mindrecord.data.dto.DiaryListDto
+import com.afternote.feature.mindrecord.data.dto.DiaryUpdateRequestDto
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -17,17 +17,17 @@ interface DiaryApiService {
     suspend fun getDiaries(
         @Query("yearMonth") yearMonth: String,
         @Query("draftOnly") draftOnly: Boolean? = null,
-    ): BaseResponse<DiaryListResponse>
+    ): BaseResponse<DiaryListDto>
 
     @POST("diary")
     suspend fun createDiary(
-        @Body request: DiaryCreateRequest,
+        @Body request: DiaryCreateRequestDto,
     ): BaseResponse<Unit>
 
     @PATCH("diary/{diaryId}")
     suspend fun updateDiary(
         @Path("diaryId") diaryId: Long,
-        @Body request: DiaryUpdateRequest,
+        @Body request: DiaryUpdateRequestDto,
     ): BaseResponse<Unit>
 
     @DELETE("diary/{diaryId}")

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/api/MindRecordReceiverApiService.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/api/MindRecordReceiverApiService.kt
@@ -1,8 +1,8 @@
 package com.afternote.feature.mindrecord.data.api
 
 import com.afternote.core.network.model.BaseResponse
-import com.afternote.feature.mindrecord.data.dto.ReceiverDailyQuestionListResponse
-import com.afternote.feature.mindrecord.data.dto.ReceiverDiaryListResponse
+import com.afternote.feature.mindrecord.data.dto.ReceiverDailyQuestionListDto
+import com.afternote.feature.mindrecord.data.dto.ReceiverDiaryListDto
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -18,12 +18,12 @@ interface MindRecordReceiverApiService {
         @Query("sort") sort: String? = null,
         @Query("startDate") startDate: String? = null,
         @Query("endDate") endDate: String? = null,
-    ): BaseResponse<ReceiverDailyQuestionListResponse>
+    ): BaseResponse<ReceiverDailyQuestionListDto>
 
     @GET("receiver-auth/diary")
     suspend fun getReceiverDiaries(
         @Query("sort") sort: String? = null,
         @Query("startDate") startDate: String? = null,
         @Query("endDate") endDate: String? = null,
-    ): BaseResponse<ReceiverDiaryListResponse>
+    ): BaseResponse<ReceiverDiaryListDto>
 }

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/api/WeeklyReportApiService.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/api/WeeklyReportApiService.kt
@@ -1,7 +1,7 @@
 package com.afternote.feature.mindrecord.data.api
 
 import com.afternote.core.network.model.BaseResponse
-import com.afternote.feature.mindrecord.data.dto.WeeklyReportResponse
+import com.afternote.feature.mindrecord.data.dto.WeeklyReportDto
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -9,5 +9,5 @@ interface WeeklyReportApiService {
     @GET("mind-record")
     suspend fun getWeeklyReport(
         @Query("date") date: String,
-    ): BaseResponse<WeeklyReportResponse>
+    ): BaseResponse<WeeklyReportDto>
 }

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DailyQuestionDto.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DailyQuestionDto.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonNames
 
 @Serializable
-data class DailyQuestionCreateRequest(
+data class DailyQuestionCreateRequestDto(
     @SerialName("content") val content: String,
     @SerialName("isDraft") val isDraft: Boolean,
     @SerialName("questionId") val questionId: Long,
@@ -16,7 +16,7 @@ data class DailyQuestionCreateRequest(
 )
 
 @Serializable
-data class DailyQuestionUpdateRequest(
+data class DailyQuestionUpdateRequestDto(
     @SerialName("content") val content: String? = null,
     @SerialName("isDraft") val isDraft: Boolean? = null,
     @SerialName("date") val date: String? = null,
@@ -25,7 +25,7 @@ data class DailyQuestionUpdateRequest(
 )
 
 @Serializable
-data class DailyQuestionListItem(
+data class DailyQuestionListItemDto(
     // 서버는 사용자별 답변 레코드 ID 를 `userDailyQuestionId` 로 내려준다.
     // 도메인에서는 그대로 `dailyQuestionId` 로 받지만 와이어 키는 다름에 주의.
     // 노션 명세 예시는 `dailyQuestionId` 키를 사용 — 어느 쪽이 오더라도 파싱되도록 대체 키 허용.
@@ -39,7 +39,7 @@ data class DailyQuestionListItem(
 )
 
 @Serializable
-data class TodayDailyQuestionResponse(
+data class TodayDailyQuestionDto(
     @SerialName("questionId") val questionId: Long,
     @SerialName("day") val day: Int,
     @SerialName("content") val content: String,

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DiaryDto.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/DiaryDto.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class TodayMood {
+enum class TodayMoodDto {
     @SerialName("HAPPY")
     HAPPY,
 
@@ -16,40 +16,40 @@ enum class TodayMood {
 }
 
 @Serializable
-data class DiaryCreateRequest(
+data class DiaryCreateRequestDto(
     @SerialName("title") val title: String,
     @SerialName("content") val content: String,
     @SerialName("isDraft") val isDraft: Boolean,
-    @SerialName("todayMood") val todayMood: TodayMood,
+    @SerialName("todayMood") val todayMood: TodayMoodDto,
     @SerialName("imageUrl") val imageUrl: String? = null,
     @SerialName("receiverIds") val receiverIds: List<Long>? = null,
 )
 
 @Serializable
-data class DiaryUpdateRequest(
+data class DiaryUpdateRequestDto(
     @SerialName("title") val title: String,
     @SerialName("content") val content: String,
     @SerialName("isDraft") val isDraft: Boolean,
-    @SerialName("todayMood") val todayMood: TodayMood,
+    @SerialName("todayMood") val todayMood: TodayMoodDto,
     @SerialName("date") val date: String,
     @SerialName("imageUrl") val imageUrl: String? = null,
 )
 
 @Serializable
-data class DiaryListItem(
+data class DiaryListItemDto(
     @SerialName("diaryId") val diaryId: Long,
     @SerialName("title") val title: String,
     @SerialName("content") val content: String,
     @SerialName("createdAt") val createdAt: String,
     @SerialName("imageUrl") val imageUrl: String? = null,
-    @SerialName("todayMood") val todayMood: TodayMood,
+    @SerialName("todayMood") val todayMood: TodayMoodDto,
 )
 
 // `/diary` 응답의 `data` 는 객체 — `diaries` 외에 조회 대상 달의 비-임시 다이어리 수
 // (`monthDiaryCount`)와 최근 7일 최빈 기분(`weeklyDominantMood`)이 함께 내려옴.
 @Serializable
-data class DiaryListResponse(
-    @SerialName("diaries") val diaries: List<DiaryListItem> = emptyList(),
+data class DiaryListDto(
+    @SerialName("diaries") val diaries: List<DiaryListItemDto> = emptyList(),
     @SerialName("monthDiaryCount") val monthDiaryCount: Int = 0,
-    @SerialName("weeklyDominantMood") val weeklyDominantMood: TodayMood? = null,
+    @SerialName("weeklyDominantMood") val weeklyDominantMood: TodayMoodDto? = null,
 )

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/MindRecordDto.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/MindRecordDto.kt
@@ -5,12 +5,12 @@ import kotlinx.serialization.Serializable
 
 /** `GET /receiver-auth/daily-question` 응답 (`data`). */
 @Serializable
-data class ReceiverDailyQuestionListResponse(
-    @SerialName("dailyQuestions") val dailyQuestions: List<ReceiverDailyQuestionItem> = emptyList(),
+data class ReceiverDailyQuestionListDto(
+    @SerialName("dailyQuestions") val dailyQuestions: List<ReceiverDailyQuestionItemDto> = emptyList(),
 )
 
 @Serializable
-data class ReceiverDailyQuestionItem(
+data class ReceiverDailyQuestionItemDto(
     @SerialName("userDailyQuestionId") val userDailyQuestionId: Long,
     // 원본 질문 내용이 title, 사용자가 작성한 답변이 content.
     @SerialName("title") val title: String,
@@ -22,18 +22,18 @@ data class ReceiverDailyQuestionItem(
 
 /** `GET /receiver-auth/diary` 응답 (`data`). */
 @Serializable
-data class ReceiverDiaryListResponse(
-    @SerialName("diaries") val diaries: List<ReceiverDiaryItem> = emptyList(),
+data class ReceiverDiaryListDto(
+    @SerialName("diaries") val diaries: List<ReceiverDiaryItemDto> = emptyList(),
 )
 
 @Serializable
-data class ReceiverDiaryItem(
+data class ReceiverDiaryItemDto(
     @SerialName("diaryId") val diaryId: Long,
     @SerialName("title") val title: String,
     @SerialName("content") val content: String,
     @SerialName("isDraft") val isDraft: Boolean = false,
     @SerialName("imageUrl") val imageUrl: String? = null,
-    @SerialName("todayMood") val todayMood: TodayMood? = null,
+    @SerialName("todayMood") val todayMood: TodayMoodDto? = null,
     // 작성일 (yyyy-MM-dd).
     @SerialName("date") val date: String = "",
     // "yyyy.MM.dd 요일" 형식.

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/WeeklyReportDto.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/dto/WeeklyReportDto.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class WeeklyReportResponse(
+data class WeeklyReportDto(
     @SerialName("dailyQuestionAmount") val dailyQuestionAmount: Int = 0,
     @SerialName("diaryAmount") val diaryAmount: Int = 0,
     @SerialName("summaryText") val summaryText: String = "",
@@ -19,7 +19,7 @@ data class WeeklyReportDayDto(
     @SerialName("diaryId") val diaryId: Long = 0L,
     @SerialName("day") val day: Int = 0,
     @SerialName("isDiary") val isDiary: Boolean = false,
-    @SerialName("emotion") val emotion: TodayMood? = null,
+    @SerialName("emotion") val emotion: TodayMoodDto? = null,
 )
 
 @Serializable

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DailyQuestionMapper.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DailyQuestionMapper.kt
@@ -1,15 +1,15 @@
 package com.afternote.feature.mindrecord.data.mapper
 
-import com.afternote.feature.mindrecord.data.dto.DailyQuestionCreateRequest
-import com.afternote.feature.mindrecord.data.dto.DailyQuestionListItem
-import com.afternote.feature.mindrecord.data.dto.DailyQuestionUpdateRequest
-import com.afternote.feature.mindrecord.data.dto.TodayDailyQuestionResponse
+import com.afternote.feature.mindrecord.data.dto.DailyQuestionCreateRequestDto
+import com.afternote.feature.mindrecord.data.dto.DailyQuestionListItemDto
+import com.afternote.feature.mindrecord.data.dto.DailyQuestionUpdateRequestDto
+import com.afternote.feature.mindrecord.data.dto.TodayDailyQuestionDto
 import com.afternote.feature.mindrecord.domain.model.DailyQuestion
 import com.afternote.feature.mindrecord.domain.model.DailyQuestionCreatePayload
 import com.afternote.feature.mindrecord.domain.model.DailyQuestionUpdatePayload
 import com.afternote.feature.mindrecord.domain.model.TodayDailyQuestion
 
-fun DailyQuestionListItem.toDomain(): DailyQuestion =
+fun DailyQuestionListItemDto.toDomain(): DailyQuestion =
     DailyQuestion(
         dailyQuestionId = dailyQuestionId,
         title = title,
@@ -18,7 +18,7 @@ fun DailyQuestionListItem.toDomain(): DailyQuestion =
         imageUrl = imageUrl,
     )
 
-fun TodayDailyQuestionResponse.toDomain(): TodayDailyQuestion =
+fun TodayDailyQuestionDto.toDomain(): TodayDailyQuestion =
     TodayDailyQuestion(
         questionId = questionId,
         day = day,
@@ -26,16 +26,16 @@ fun TodayDailyQuestionResponse.toDomain(): TodayDailyQuestion =
         isAnswered = isAnswered,
     )
 
-fun DailyQuestionCreatePayload.toRequest(): DailyQuestionCreateRequest =
-    DailyQuestionCreateRequest(
+fun DailyQuestionCreatePayload.toRequest(): DailyQuestionCreateRequestDto =
+    DailyQuestionCreateRequestDto(
         content = content,
         isDraft = isDraft,
         questionId = questionId,
         imageUrl = imageUrl,
     )
 
-fun DailyQuestionUpdatePayload.toRequest(): DailyQuestionUpdateRequest =
-    DailyQuestionUpdateRequest(
+fun DailyQuestionUpdatePayload.toRequest(): DailyQuestionUpdateRequestDto =
+    DailyQuestionUpdateRequestDto(
         content = content,
         isDraft = isDraft,
         date = date,

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DiaryMapper.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/DiaryMapper.kt
@@ -1,17 +1,17 @@
 package com.afternote.feature.mindrecord.data.mapper
 
-import com.afternote.feature.mindrecord.data.dto.DiaryCreateRequest
-import com.afternote.feature.mindrecord.data.dto.DiaryListItem
-import com.afternote.feature.mindrecord.data.dto.DiaryListResponse
-import com.afternote.feature.mindrecord.data.dto.DiaryUpdateRequest
+import com.afternote.feature.mindrecord.data.dto.DiaryCreateRequestDto
+import com.afternote.feature.mindrecord.data.dto.DiaryListDto
+import com.afternote.feature.mindrecord.data.dto.DiaryListItemDto
+import com.afternote.feature.mindrecord.data.dto.DiaryUpdateRequestDto
+import com.afternote.feature.mindrecord.data.dto.TodayMoodDto
 import com.afternote.feature.mindrecord.domain.model.Diary
 import com.afternote.feature.mindrecord.domain.model.DiaryCreatePayload
 import com.afternote.feature.mindrecord.domain.model.DiaryList
 import com.afternote.feature.mindrecord.domain.model.DiaryUpdatePayload
 import com.afternote.feature.mindrecord.domain.model.TodayMood
-import com.afternote.feature.mindrecord.data.dto.TodayMood as TodayMoodDto
 
-fun DiaryListItem.toDomain(): Diary =
+fun DiaryListItemDto.toDomain(): Diary =
     Diary(
         diaryId = diaryId,
         title = title,
@@ -21,7 +21,7 @@ fun DiaryListItem.toDomain(): Diary =
         imageUrl = imageUrl,
     )
 
-fun DiaryListResponse.toDomain(): DiaryList =
+fun DiaryListDto.toDomain(): DiaryList =
     DiaryList(
         diaries = diaries.map { it.toDomain() },
         monthDiaryCount = monthDiaryCount,
@@ -42,8 +42,8 @@ fun TodayMood.toDto(): TodayMoodDto =
         TodayMood.SAD -> TodayMoodDto.SAD
     }
 
-fun DiaryCreatePayload.toRequest(): DiaryCreateRequest =
-    DiaryCreateRequest(
+fun DiaryCreatePayload.toRequest(): DiaryCreateRequestDto =
+    DiaryCreateRequestDto(
         title = title,
         content = content,
         isDraft = isDraft,
@@ -52,8 +52,8 @@ fun DiaryCreatePayload.toRequest(): DiaryCreateRequest =
         receiverIds = receiverIds,
     )
 
-fun DiaryUpdatePayload.toRequest(): DiaryUpdateRequest =
-    DiaryUpdateRequest(
+fun DiaryUpdatePayload.toRequest(): DiaryUpdateRequestDto =
+    DiaryUpdateRequestDto(
         title = title,
         content = content,
         isDraft = isDraft,

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/MindRecordMapper.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/MindRecordMapper.kt
@@ -1,14 +1,14 @@
 package com.afternote.feature.mindrecord.data.mapper
 
-import com.afternote.feature.mindrecord.data.dto.ReceiverDailyQuestionItem
-import com.afternote.feature.mindrecord.data.dto.ReceiverDiaryItem
+import com.afternote.feature.mindrecord.data.dto.ReceiverDailyQuestionItemDto
+import com.afternote.feature.mindrecord.data.dto.ReceiverDiaryItemDto
 import com.afternote.feature.mindrecord.domain.model.MindRecordSummary
 import com.afternote.feature.mindrecord.domain.model.MindRecordType
 
 // 서버 createdAt 은 "yyyy.MM.dd 요일" — 기간 필터/정렬용 recordDate 는 ISO(yyyy-MM-dd)로 정규화.
 private fun String.toIsoDate(): String = take(10).replace('.', '-')
 
-fun ReceiverDailyQuestionItem.toDomain(): MindRecordSummary =
+fun ReceiverDailyQuestionItemDto.toDomain(): MindRecordSummary =
     MindRecordSummary(
         id = userDailyQuestionId,
         type = MindRecordType.DAILY_QUESTION,
@@ -21,7 +21,7 @@ fun ReceiverDailyQuestionItem.toDomain(): MindRecordSummary =
         imageUrl = imageUrl,
     )
 
-fun ReceiverDiaryItem.toDomain(): MindRecordSummary =
+fun ReceiverDiaryItemDto.toDomain(): MindRecordSummary =
     MindRecordSummary(
         id = diaryId,
         type = MindRecordType.DIARY,

--- a/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/WeeklyReportMapper.kt
+++ b/feature/mindrecord/data/src/main/kotlin/com/afternote/feature/mindrecord/data/mapper/WeeklyReportMapper.kt
@@ -2,14 +2,14 @@ package com.afternote.feature.mindrecord.data.mapper
 
 import com.afternote.feature.mindrecord.data.dto.WeeklyReportDailyQuestionDto
 import com.afternote.feature.mindrecord.data.dto.WeeklyReportDayDto
+import com.afternote.feature.mindrecord.data.dto.WeeklyReportDto
 import com.afternote.feature.mindrecord.data.dto.WeeklyReportEmotionDto
-import com.afternote.feature.mindrecord.data.dto.WeeklyReportResponse
 import com.afternote.feature.mindrecord.domain.model.WeeklyReport
 import com.afternote.feature.mindrecord.domain.model.WeeklyReportDailyQuestion
 import com.afternote.feature.mindrecord.domain.model.WeeklyReportDay
 import com.afternote.feature.mindrecord.domain.model.WeeklyReportEmotion
 
-fun WeeklyReportResponse.toDomain(): WeeklyReport =
+fun WeeklyReportDto.toDomain(): WeeklyReport =
     WeeklyReport(
         dailyQuestionAmount = dailyQuestionAmount,
         diaryAmount = diaryAmount,

--- a/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/api/ReceiverTimeLetterApiService.kt
+++ b/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/api/ReceiverTimeLetterApiService.kt
@@ -1,17 +1,17 @@
 package com.afternote.feature.timeletter.data.api
 
 import com.afternote.core.network.model.BaseResponse
-import com.afternote.feature.timeletter.data.dto.ReceivedTimeLetterListResponseDto
-import com.afternote.feature.timeletter.data.dto.ReceivedTimeLetterResponseDto
+import com.afternote.feature.timeletter.data.dto.ReceivedTimeLetterDto
+import com.afternote.feature.timeletter.data.dto.ReceivedTimeLetterListDto
 import retrofit2.http.GET
 import retrofit2.http.Path
 
 interface ReceiverTimeLetterApiService {
     @GET("receiver-auth/time-letters")
-    suspend fun getReceivedTimeLetters(): BaseResponse<ReceivedTimeLetterListResponseDto>
+    suspend fun getReceivedTimeLetters(): BaseResponse<ReceivedTimeLetterListDto>
 
     @GET("receiver-auth/time-letters/{timeLetterReceiverId}")
     suspend fun getReceivedTimeLetterDetail(
         @Path("timeLetterReceiverId") timeLetterReceiverId: Long,
-    ): BaseResponse<ReceivedTimeLetterResponseDto>
+    ): BaseResponse<ReceivedTimeLetterDto>
 }

--- a/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/api/TimeLetterApiService.kt
+++ b/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/api/TimeLetterApiService.kt
@@ -1,11 +1,11 @@
 package com.afternote.feature.timeletter.data.api
 
 import com.afternote.core.network.model.BaseResponse
-import com.afternote.feature.timeletter.data.dto.TimeLetterCreateRequest
-import com.afternote.feature.timeletter.data.dto.TimeLetterDeleteRequest
-import com.afternote.feature.timeletter.data.dto.TimeLetterListResponseDto
-import com.afternote.feature.timeletter.data.dto.TimeLetterResponseDto
-import com.afternote.feature.timeletter.data.dto.TimeLetterUpdateRequest
+import com.afternote.feature.timeletter.data.dto.TimeLetterCreateRequestDto
+import com.afternote.feature.timeletter.data.dto.TimeLetterDeleteRequestDto
+import com.afternote.feature.timeletter.data.dto.TimeLetterDto
+import com.afternote.feature.timeletter.data.dto.TimeLetterListDto
+import com.afternote.feature.timeletter.data.dto.TimeLetterUpdateRequestDto
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -16,35 +16,35 @@ import retrofit2.http.Path
 interface TimeLetterApiService {
     // 타임레터 전체 조회 (SCHEDULED)
     @GET("time-letters")
-    suspend fun getTimeLetters(): BaseResponse<TimeLetterListResponseDto>
+    suspend fun getTimeLetters(): BaseResponse<TimeLetterListDto>
 
     // 임시저장 전체 조회 (DRAFT)
     @GET("time-letters/temporary")
-    suspend fun getTemporaryTimeLetters(): BaseResponse<TimeLetterListResponseDto>
+    suspend fun getTemporaryTimeLetters(): BaseResponse<TimeLetterListDto>
 
     // 타임레터 단일 조회
     @GET("time-letters/{timeLetterId}")
     suspend fun getTimeLetter(
         @Path("timeLetterId") timeLetterId: Long,
-    ): BaseResponse<TimeLetterResponseDto>
+    ): BaseResponse<TimeLetterDto>
 
     // 타임레터 등록 (DRAFT or SCHEDULED)
     @POST("time-letters")
     suspend fun createTimeLetter(
-        @Body request: TimeLetterCreateRequest,
-    ): BaseResponse<TimeLetterResponseDto>
+        @Body request: TimeLetterCreateRequestDto,
+    ): BaseResponse<TimeLetterDto>
 
     // 타임레터 수정
     @PATCH("time-letters/{timeLetterId}")
     suspend fun updateTimeLetter(
         @Path("timeLetterId") timeLetterId: Long,
-        @Body request: TimeLetterUpdateRequest,
-    ): BaseResponse<TimeLetterResponseDto>
+        @Body request: TimeLetterUpdateRequestDto,
+    ): BaseResponse<TimeLetterDto>
 
     // 타임레터 단일/다건 삭제
     @POST("time-letters/delete")
     suspend fun deleteTimeLetters(
-        @Body request: TimeLetterDeleteRequest,
+        @Body request: TimeLetterDeleteRequestDto,
     ): BaseResponse<Unit>
 
     // 임시저장 전체 삭제

--- a/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/dto/ReceivedTimeLetterDto.kt
+++ b/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/dto/ReceivedTimeLetterDto.kt
@@ -4,11 +4,11 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ReceivedTimeLetterResponseDto(
+data class ReceivedTimeLetterDto(
     @SerialName("id") val id: Long,
     @SerialName("timeLetterReceiverId") val timeLetterReceiverId: Long,
     @SerialName("title") val title: String? = null,
-    @SerialName("blocks") val blocks: List<TimeLetterBlockResponseDto> = emptyList(),
+    @SerialName("blocks") val blocks: List<TimeLetterBlockDto> = emptyList(),
     @SerialName("sendAt") val sendAt: String? = null,
     @SerialName("status") val status: TimeLetterStatusDto,
     @SerialName("senderName") val senderName: String? = null,
@@ -18,7 +18,7 @@ data class ReceivedTimeLetterResponseDto(
 )
 
 @Serializable
-data class ReceivedTimeLetterListResponseDto(
-    @SerialName("timeLetters") val timeLetters: List<ReceivedTimeLetterResponseDto>,
+data class ReceivedTimeLetterListDto(
+    @SerialName("timeLetters") val timeLetters: List<ReceivedTimeLetterDto>,
     @SerialName("totalCount") val totalCount: Int,
 )

--- a/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/dto/TimeLetterDto.kt
+++ b/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/dto/TimeLetterDto.kt
@@ -34,7 +34,7 @@ enum class TimeLetterBlockTypeDto {
 }
 
 @Serializable
-data class TimeLetterBlockRequest(
+data class TimeLetterBlockRequestDto(
     @SerialName("blockType") val blockType: TimeLetterBlockTypeDto,
     @SerialName("blockOrder") val blockOrder: Int,
     @SerialName("textContent") val textContent: String? = null,
@@ -43,7 +43,7 @@ data class TimeLetterBlockRequest(
 )
 
 @Serializable
-data class TimeLetterBlockResponseDto(
+data class TimeLetterBlockDto(
     @SerialName("id") val id: Long,
     @SerialName("blockType") val blockType: TimeLetterBlockTypeDto,
     @SerialName("blockOrder") val blockOrder: Int,
@@ -53,40 +53,40 @@ data class TimeLetterBlockResponseDto(
 )
 
 @Serializable
-data class TimeLetterCreateRequest(
+data class TimeLetterCreateRequestDto(
     @SerialName("title") val title: String? = null,
     @SerialName("sendAt") val sendAt: String? = null,
     @SerialName("status") val status: TimeLetterStatusDto,
-    @SerialName("blocks") val blocks: List<TimeLetterBlockRequest> = emptyList(),
+    @SerialName("blocks") val blocks: List<TimeLetterBlockRequestDto> = emptyList(),
     @SerialName("receiverIds") val receiverIds: List<Long> = emptyList(),
 )
 
 @Serializable
-data class TimeLetterUpdateRequest(
+data class TimeLetterUpdateRequestDto(
     @SerialName("title") val title: String? = null,
     @SerialName("sendAt") val sendAt: String? = null,
     @SerialName("status") val status: TimeLetterStatusDto? = null,
-    @SerialName("blocks") val blocks: List<TimeLetterBlockRequest> = emptyList(),
+    @SerialName("blocks") val blocks: List<TimeLetterBlockRequestDto> = emptyList(),
 )
 
 @Serializable
-data class TimeLetterDeleteRequest(
+data class TimeLetterDeleteRequestDto(
     @SerialName("timeLetterIds") val timeLetterIds: List<Long>,
 )
 
 @Serializable
-data class TimeLetterResponseDto(
+data class TimeLetterDto(
     @SerialName("id") val id: Long,
     @SerialName("title") val title: String? = null,
     @SerialName("sendAt") val sendAt: String? = null,
     @SerialName("deliveredAt") val deliveredAt: String? = null,
     @SerialName("status") val status: TimeLetterStatusDto,
-    @SerialName("blocks") val blocks: List<TimeLetterBlockResponseDto> = emptyList(),
+    @SerialName("blocks") val blocks: List<TimeLetterBlockDto> = emptyList(),
     @SerialName("receiverIds") val receiverIds: List<Long> = emptyList(),
 )
 
 @Serializable
-data class TimeLetterListResponseDto(
-    @SerialName("timeLetters") val timeLetters: List<TimeLetterResponseDto>,
+data class TimeLetterListDto(
+    @SerialName("timeLetters") val timeLetters: List<TimeLetterDto>,
     @SerialName("totalCount") val totalCount: Int,
 )

--- a/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/mapper/ReceivedTimeLetterMapper.kt
+++ b/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/mapper/ReceivedTimeLetterMapper.kt
@@ -1,11 +1,11 @@
 package com.afternote.feature.timeletter.data.mapper
 
-import com.afternote.feature.timeletter.data.dto.ReceivedTimeLetterListResponseDto
-import com.afternote.feature.timeletter.data.dto.ReceivedTimeLetterResponseDto
+import com.afternote.feature.timeletter.data.dto.ReceivedTimeLetterDto
+import com.afternote.feature.timeletter.data.dto.ReceivedTimeLetterListDto
 import com.afternote.feature.timeletter.domain.model.ReceivedTimeLetter
 import com.afternote.feature.timeletter.domain.model.ReceivedTimeLetterList
 
-fun ReceivedTimeLetterResponseDto.toDomain(): ReceivedTimeLetter =
+fun ReceivedTimeLetterDto.toDomain(): ReceivedTimeLetter =
     ReceivedTimeLetter(
         id = id,
         timeLetterReceiverId = timeLetterReceiverId,
@@ -19,7 +19,7 @@ fun ReceivedTimeLetterResponseDto.toDomain(): ReceivedTimeLetter =
         isRead = isRead,
     )
 
-fun ReceivedTimeLetterListResponseDto.toDomain(): ReceivedTimeLetterList =
+fun ReceivedTimeLetterListDto.toDomain(): ReceivedTimeLetterList =
     ReceivedTimeLetterList(
         timeLetters = timeLetters.map { it.toDomain() },
         totalCount = totalCount,

--- a/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/mapper/TimeLetterMapper.kt
+++ b/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/mapper/TimeLetterMapper.kt
@@ -1,10 +1,10 @@
 package com.afternote.feature.timeletter.data.mapper
 
-import com.afternote.feature.timeletter.data.dto.TimeLetterBlockRequest
-import com.afternote.feature.timeletter.data.dto.TimeLetterBlockResponseDto
+import com.afternote.feature.timeletter.data.dto.TimeLetterBlockDto
+import com.afternote.feature.timeletter.data.dto.TimeLetterBlockRequestDto
 import com.afternote.feature.timeletter.data.dto.TimeLetterBlockTypeDto
-import com.afternote.feature.timeletter.data.dto.TimeLetterListResponseDto
-import com.afternote.feature.timeletter.data.dto.TimeLetterResponseDto
+import com.afternote.feature.timeletter.data.dto.TimeLetterDto
+import com.afternote.feature.timeletter.data.dto.TimeLetterListDto
 import com.afternote.feature.timeletter.data.dto.TimeLetterStatusDto
 import com.afternote.feature.timeletter.domain.model.NewTimeLetterBlock
 import com.afternote.feature.timeletter.domain.model.TimeLetter
@@ -36,7 +36,7 @@ fun TimeLetterBlockTypeDto.toDomain(): TimeLetterBlockType =
         TimeLetterBlockTypeDto.LINK -> TimeLetterBlockType.LINK
     }
 
-fun TimeLetterBlockResponseDto.toDomain(): TimeLetterBlock =
+fun TimeLetterBlockDto.toDomain(): TimeLetterBlock =
     TimeLetterBlock(
         id = id,
         blockType = blockType.toDomain(),
@@ -46,7 +46,7 @@ fun TimeLetterBlockResponseDto.toDomain(): TimeLetterBlock =
         mimeType = mimeType,
     )
 
-fun TimeLetterResponseDto.toDomain(): TimeLetter =
+fun TimeLetterDto.toDomain(): TimeLetter =
     TimeLetter(
         id = id,
         title = title,
@@ -57,14 +57,14 @@ fun TimeLetterResponseDto.toDomain(): TimeLetter =
         receiverIds = receiverIds,
     )
 
-fun TimeLetterListResponseDto.toDomain(): TimeLetterList =
+fun TimeLetterListDto.toDomain(): TimeLetterList =
     TimeLetterList(
         timeLetters = timeLetters.map { it.toDomain() },
         totalCount = totalCount,
     )
 
-fun NewTimeLetterBlock.toDto(): TimeLetterBlockRequest =
-    TimeLetterBlockRequest(
+fun NewTimeLetterBlock.toDto(): TimeLetterBlockRequestDto =
+    TimeLetterBlockRequestDto(
         blockType =
             when (blockType) {
                 TimeLetterBlockType.TEXT -> TimeLetterBlockTypeDto.TEXT

--- a/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/repositoryImpl/TimeLetterRepositoryImpl.kt
+++ b/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/repositoryImpl/TimeLetterRepositoryImpl.kt
@@ -3,9 +3,9 @@ package com.afternote.feature.timeletter.data.repositoryImpl
 import com.afternote.core.network.model.requireData
 import com.afternote.core.network.model.requireStatus
 import com.afternote.feature.timeletter.data.api.TimeLetterApiService
-import com.afternote.feature.timeletter.data.dto.TimeLetterCreateRequest
-import com.afternote.feature.timeletter.data.dto.TimeLetterDeleteRequest
-import com.afternote.feature.timeletter.data.dto.TimeLetterUpdateRequest
+import com.afternote.feature.timeletter.data.dto.TimeLetterCreateRequestDto
+import com.afternote.feature.timeletter.data.dto.TimeLetterDeleteRequestDto
+import com.afternote.feature.timeletter.data.dto.TimeLetterUpdateRequestDto
 import com.afternote.feature.timeletter.data.mapper.toDomain
 import com.afternote.feature.timeletter.data.mapper.toDto
 import com.afternote.feature.timeletter.domain.model.NewTimeLetterBlock
@@ -47,7 +47,7 @@ class TimeLetterRepositoryImpl
         ): TimeLetter =
             timeLetterApiService
                 .createTimeLetter(
-                    TimeLetterCreateRequest(
+                    TimeLetterCreateRequestDto(
                         title = title,
                         sendAt = sendAt,
                         status = status.toDto(),
@@ -68,7 +68,7 @@ class TimeLetterRepositoryImpl
                 .updateTimeLetter(
                     timeLetterId = timeLetterId,
                     request =
-                        TimeLetterUpdateRequest(
+                        TimeLetterUpdateRequestDto(
                             title = title,
                             sendAt = sendAt,
                             status = status?.toDto(),
@@ -79,7 +79,7 @@ class TimeLetterRepositoryImpl
 
         override suspend fun deleteTimeLetters(timeLetterIds: List<Long>) {
             timeLetterApiService
-                .deleteTimeLetters(TimeLetterDeleteRequest(timeLetterIds = timeLetterIds))
+                .deleteTimeLetters(TimeLetterDeleteRequestDto(timeLetterIds = timeLetterIds))
                 .requireStatus()
         }
 


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #444 — refactor(data): wire 모델 명명 -Dto 통일 (Response·ResponseDto·Data 표기 혼재 해소)

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- Response·ResponseDto·Data·Info 로 혼재하던 wire 모델(직렬화 대상) 클래스명을 -Dto 접미로 통일 — 심볼 rename 91건, 68파일 +594/-594 순수 개명으로 로직 변경 없음
- bare `XxxRequest` 요청 모델도 wire 모델이므로 `XxxRequestDto` 로 같은 규칙에 수렴
- `MusicSearchResponse`→`MusicSearchResponseDto` — 유일한 BaseResponse 미래핑 직접 응답이라 Response 어휘를 유지한 채 Dto 만 부여
- 매퍼 파일명 4건(rename) 및 테스트 클래스명 2건 동반 개명 — top-level 함수 홀더라 참조 파급 없음
- DiaryMapper 의 `TodayMood as TodayMoodDto` import alias 제거 (본명이 Dto 가 되어 불필요)
- ktlintFormat 에 따른 import 재정렬 포함
- 유지 대상: `BaseResponse`(공통 봉투) · enum `*Dto` · `PresignedUrlRequestDto` · `mapper/response` 패키지명 · `InputToRequest.kt`

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — data 계층 명명 통일만 수행

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- `Received*Info` 4종도 wire 모델이라 -Dto 로 통일. #428 제거 예정인 구 유저단위 DeliveryCondition 계열에도 일괄 적용(곧 삭제될 이름이지만 규칙 일관성 우선)
- dead 후보 2건 발견: `ConnectedAccountsDto`·`ConnectAccountRequestDto` (참조 0) — 삭제는 별도 작업으로 분리
- `ReceiverListDto` 는 리스트 "요소"인데 List 어휘를 가짐 — 의미 개선은 별도 작업
- 같은 작업이 AS 커밋 과정에서 2커밋(본체 66파일 + 테스트 rename 2파일)으로 나뉨 — 내용상 한 덩어리
- 검증: 전 모듈 컴파일(main/debug/test) + 유닛테스트 98건(core:network 27·core:data 20·afternote:data 51) + ktlintCheck green, `@SerialName` 리터럴 멀티셋 diff identical 로 wire 무변 기계 확증, pre-push `./gradlew :app:compileDebugKotlin` BUILD SUCCESSFUL
