### PR TITLE
fix(build): git hooks .git 경로 하드코딩으로 인한 worktree 커밋 차단 수정 (closes 419)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,17 +13,21 @@ plugins {
 
 tasks.register<Exec>("installGitHooks") {
     group = "verification"
-    description = "Installs git-hooks/{pre-commit,pre-push} into .git/hooks (run once per clone)."
+    description = "Installs git-hooks/{pre-commit,pre-push} into the shared git hooks dir (run once per clone)."
     workingDir(layout.projectDirectory)
     commandLine(
         "sh",
         "-c",
-        "if test -d .git/hooks; then " +
-            "cp git-hooks/pre-commit .git/hooks/pre-commit && " +
-            "chmod +x .git/hooks/pre-commit && " +
-            "cp git-hooks/pre-push .git/hooks/pre-push && " +
-            "chmod +x .git/hooks/pre-push && " +
-            "echo \"Installed .git/hooks/{pre-commit,pre-push}\"; " +
-            "else echo \"installGitHooks: .git/hooks not found, skipping\"; fi",
+        // worktree 에서는 .git 이 디렉터리가 아니라 gitdir 포인터 파일이라 ".git/hooks" 가
+        // 성립하지 않는다. hooks 는 메인 저장소와 공용이므로 항상
+        // `git rev-parse --git-common-dir` 기준으로 설치한다.
+        "HOOKS_DIR=\"\$(git rev-parse --git-common-dir 2>/dev/null)/hooks\"; " +
+            "if test -d \"\$HOOKS_DIR\"; then " +
+            "cp git-hooks/pre-commit \"\$HOOKS_DIR/pre-commit\" && " +
+            "chmod +x \"\$HOOKS_DIR/pre-commit\" && " +
+            "cp git-hooks/pre-push \"\$HOOKS_DIR/pre-push\" && " +
+            "chmod +x \"\$HOOKS_DIR/pre-push\" && " +
+            "echo \"Installed \$HOOKS_DIR/{pre-commit,pre-push}\"; " +
+            "else echo \"installGitHooks: git hooks dir not found, skipping\"; fi",
     )
 }

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -20,7 +20,11 @@ STAGED_KT=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(kt|kts
 
 # CI(ScaCap/action-ktlint)에 핀된 버전과 일치. libs.versions.toml 의 `ktlint = "1.8.0"`.
 KTLINT_VERSION="1.8.0"
-KTLINT="$ROOT/.git/hooks/.ktlint-${KTLINT_VERSION}"
+# worktree 에서는 $ROOT/.git 이 디렉터리가 아니라 gitdir 포인터 파일이라
+# "$ROOT/.git/hooks/..." 경로가 성립하지 않는다. 캐시는 항상 공용 hooks
+# 디렉터리(메인 저장소의 .git/hooks) 기준으로 잡는다.
+HOOKS_DIR="$(cd "$(git rev-parse --git-common-dir)/hooks" && pwd)"
+KTLINT="$HOOKS_DIR/.ktlint-${KTLINT_VERSION}"
 
 if [ ! -x "$KTLINT" ]; then
     echo "Downloading ktlint ${KTLINT_VERSION}..."


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #419 — fix(build): git hooks 의 .git 경로 하드코딩으로 인한 worktree 커밋 차단 수정

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `git-hooks/pre-commit`: ktlint 바이너리 캐시 경로를 `$ROOT/.git/hooks/...` 하드코딩에서 `git rev-parse --git-common-dir` 기반 공용 hooks 디렉터리로 교체 (47820cd8)
- 루트 `build.gradle.kts` `installGitHooks` task: `test -d .git/hooks` 전제를 제거하고 동일하게 공용 hooks 디렉터리 기준으로 설치
- worktree 에서는 `.git` 이 디렉터리가 아니라 gitdir 포인터 **파일**이라 두 곳 모두 경로가 불성립하던 문제 — hooks 는 메인 저장소와 공용이므로 의미상으로도 공용 디렉터리 기준이 정확

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 빌드 스크립트·git hook 셸 스크립트만 변경

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 설치본 `.git/hooks/pre-commit` 에는 동일 수정이 핫픽스로 이미 적용·검증돼 있었고, 이 PR 은 정본(`git-hooks/` + `installGitHooks`)을 일치시키는 작업 — 커밋 전 정본·설치본 diff IDENTICAL 확인
- 실측 검증: 메인 체크아웃·worktree 양쪽에서 `git rev-parse --git-common-dir` 경로 해석 정상, worktree 에서 구 로직(`test -d .git/hooks`) 불성립 재현 확인
- 빌드 검증: `./gradlew installGitHooks` BUILD SUCCESSFUL (`Installed .git/hooks/{pre-commit,pre-push}`)