### PR TITLE
refactor(core): 에러 빨강 이원화 정리 — error 토큰 정본화·requiredMark 신설·야생 Red 제거 (closes 445)

### DIFF
--- a/core/ui/src/main/kotlin/com/afternote/core/ui/theme/Color.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/theme/Color.kt
@@ -45,8 +45,14 @@ private val Accent8 = Color(0xFF6E5A7F)
 private val Accent9 = Color(0xFF24324A)
 private val Accent10 = Color(0xFF3A4A8A)
 
-/** 시맨틱 에러/필수표시 색. 필수 입력 마커·검증 실패 등에 사용. */
-private val Error = Color(0xFFFF3647)
+/** 에러 문구 색. 검증 실패 등 인라인 에러 텍스트에 사용 (시안 에러 문구 6곳 정본). */
+private val Error = Color(0xFFFF0C0C)
+
+/**
+ * 필수 입력 표시 점 색 (시안 필수 마커 32곳 정본).
+ * 에러 문구([Error])와 값이 다른 것은 시안의 용도별 구분 의도 — 통일 금지.
+ */
+private val RequiredMark = Color(0xFFFF3647)
 
 internal fun lightColors() =
     AfternoteColors(
@@ -74,6 +80,7 @@ internal fun lightColors() =
         accent9 = Accent9,
         accent10 = Accent10,
         error = Error,
+        requiredMark = RequiredMark,
         isLightMode = true,
     )
 
@@ -103,6 +110,7 @@ internal fun darkColors() =
         accent9 = Accent9,
         accent10 = Accent10,
         error = Error,
+        requiredMark = RequiredMark,
         isLightMode = false,
     )
 
@@ -136,6 +144,7 @@ class AfternoteColors(
     accent9: Color,
     accent10: Color,
     error: Color,
+    requiredMark: Color,
     isLightMode: Boolean,
 ) {
     var white by mutableStateOf(white)
@@ -186,6 +195,8 @@ class AfternoteColors(
         private set
     var error by mutableStateOf(error)
         private set
+    var requiredMark by mutableStateOf(requiredMark)
+        private set
     var isLightMode by mutableStateOf(isLightMode)
         private set
 
@@ -214,6 +225,7 @@ class AfternoteColors(
         accent9: Color = this.accent9,
         accent10: Color = this.accent10,
         error: Color = this.error,
+        requiredMark: Color = this.requiredMark,
         isLightMode: Boolean = this.isLightMode,
     ) = AfternoteColors(
         white = white,
@@ -240,6 +252,7 @@ class AfternoteColors(
         accent9 = accent9,
         accent10 = accent10,
         error = error,
+        requiredMark = requiredMark,
         isLightMode = isLightMode,
     )
 
@@ -268,8 +281,7 @@ class AfternoteColors(
         this.accent9 = other.accent9
         this.accent10 = other.accent10
         this.error = other.error
+        this.requiredMark = other.requiredMark
         this.isLightMode = other.isLightMode
     }
 }
-
-val Red = Color(0xFFFF0C0C) // 에러 메시지용 빨간색

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/EditorSectionLabel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/EditorSectionLabel.kt
@@ -72,7 +72,7 @@ fun EditorSectionLabel(
                     Modifier
                         .size(4.dp)
                         .background(
-                            color = AfternoteDesign.colors.error,
+                            color = AfternoteDesign.colors.requiredMark,
                             shape = CircleShape,
                         ).align(Alignment.Top),
             )

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionWriteScreen.kt
@@ -25,7 +25,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.asString
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
-import com.afternote.core.ui.theme.Red
 import com.afternote.core.ui.topbar.DetailTopBar
 import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.component.DailyQuestionBanner
@@ -112,7 +111,7 @@ fun DailyQuestionWriteScreen(
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
                     text = errorMessage,
-                    color = Red,
+                    color = AfternoteDesign.colors.error,
                     style = AfternoteDesign.typography.captionLargeR,
                 )
             }

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryWriteScreen.kt
@@ -44,7 +44,6 @@ import com.afternote.core.ui.R
 import com.afternote.core.ui.asString
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
-import com.afternote.core.ui.theme.Red
 import com.afternote.core.ui.topbar.DetailTopBar
 import com.afternote.feature.mindrecord.domain.model.TodayMood
 import com.afternote.feature.mindrecord.presentation.component.BottomSheetCalendar
@@ -253,7 +252,7 @@ fun DiaryWriteScreen(
             if (errorMessage != null) {
                 Text(
                     text = errorMessage,
-                    color = Red,
+                    color = AfternoteDesign.colors.error,
                     style = AfternoteDesign.typography.captionLargeR,
                 )
             }

--- a/feature/setting/presentation/src/main/kotlin/com/afternote/feature/setting/presentation/screen/WithdrawConfirmScreen.kt
+++ b/feature/setting/presentation/src/main/kotlin/com/afternote/feature/setting/presentation/screen/WithdrawConfirmScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.AfternoteTextField
@@ -33,7 +32,6 @@ import com.afternote.core.ui.button.AfternoteButtonType
 import com.afternote.core.ui.popup.Popup
 import com.afternote.core.ui.popup.PopupType
 import com.afternote.core.ui.theme.AfternoteDesign
-import com.afternote.core.ui.theme.Red
 import com.afternote.core.ui.topbar.DetailTopBar
 import com.afternote.feature.setting.presentation.R
 import com.afternote.feature.setting.presentation.viewmodel.SettingUiState
@@ -107,7 +105,7 @@ fun WithdrawConfirmScreen(
                 Text(
                     text = stringResource(R.string.withdraw_confirm_error),
                     style = AfternoteDesign.typography.captionLargeR,
-                    color = Red,
+                    color = AfternoteDesign.colors.error,
                 )
             }
             Spacer(Modifier.weight(1f))


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #445 — refactor(core): 에러 문구 빨간색 이원화 정리 — 야생 Red 상수와 테마 error 토큰 통일

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- 이슈의 블로커였던 "어느 값이 정본인지"를 Figma 시안 전수 실측으로 해소 — 결과는 [이슈 실측 코멘트](https://github.com/Afternote/Afternote-FE/issues/445#issuecomment-4978410675) 참조 (c463471c)
- **실측 결론: 두 값 공존은 화면별 불일치가 아니라 용도별 구분** — 에러 문구 `#FF0C0C`(6곳 일관) vs 필수 표시 점 `#FF3647`(32곳 일관). "한 값 통일" 대신 용도별 토큰으로 정리
- `AfternoteColors.error` 값을 에러 문구 정본 `#FF0C0C` 로 조정 (기존 `#FF3647` 은 문구 용도로는 미사용이었음)
- 필수 표시 점 전용 `AfternoteColors.requiredMark`(`#FF3647`) 신설 — `EditorSectionLabel` 의 4dp 필수 점에 적용 (시안의 4×4 Ellipse 와 대응)
- 테마 밖 야생 상수 `Red` 제거, 사용처 3곳(`DiaryWriteScreen`·`DailyQuestionWriteScreen`·`WithdrawConfirmScreen`)을 `AfternoteDesign.colors.error` 로 교체

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 모든 사용처의 렌더 색이 기존과 동일(문구 FF0C0C 유지, 점 FF3647 유지)한 토큰 재배선이라 시각 변화가 없고, 스크린샷 baseline 영향 없음

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- **mindrecord(일기·데일리질문 쓰기)·setting(탈퇴 확인) 오너 참고**: 해당 화면의 `Red` → `colors.error` 교체가 포함됩니다. 그려지는 색은 동일합니다
- 시안 이상치 1건: 온보딩 아이디/비밀번호 찾기의 에러 문구(노드 2431:14215)만 `#FF0000` — 디자인쪽 정리 대상으로 보이며, 코드는 정본 `#FF0C0C` 기준
- 빌드 검증: `:core:ui`·`:feature:afternote:presentation`·`:feature:mindrecord:presentation`·`:feature:setting:presentation` `compileDebugKotlin` + `:core:ui`·`:feature:afternote:presentation` `compileDebugScreenshotTestKotlin` BUILD SUCCESSFUL, 변경 파일 ktlint 1.8.0 통과, `Red` 잔존 참조 0건