### PR TITLE
fix(afternote): mock 목록 픽스처 페이지 키 pageNumber→page 정합 (closes 451)

### DIFF
--- a/feature/afternote/data/src/debug/kotlin/com/afternote/feature/afternote/data/network/AfternoteMockFixtures.kt
+++ b/feature/afternote/data/src/debug/kotlin/com/afternote/feature/afternote/data/network/AfternoteMockFixtures.kt
@@ -109,7 +109,7 @@ internal object AfternoteMockFixtures {
           {"afternoteId":1,"title":"인스타그램","category":"SOCIAL","createdAt":"2024-06-01"},
           {"afternoteId":2,"title":"갤러리","category":"GALLERY","createdAt":"2024-06-02"},
           {"afternoteId":3,"title":"네이버 메일","category":"SOCIAL","createdAt":"2024-06-03"}
-        ],"pageNumber":0,"size":10,"hasNext":false}}
+        ],"page":0,"size":10,"hasNext":false}}
         """.trimIndent()
 
     val MOCK_CREATE_JSON =


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #451 — fix(afternote): mock 목록 픽스처 페이지 키 pageNumber→page 정합

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- Mock 목록 응답 픽스처(`AfternoteMockFixtures.kt`, debug 소스셋)의 페이지 필드 키 `"pageNumber"` → `"page"` 1줄 정합 (931fc634)
- Swagger 명세·파싱 DTO(`AfternoteDto.kt` `@SerialName("page") val page`)의 확정 키는 `page` — 현재는 `ignoreUnknownKeys = true` 로 무시되고 기본값 0 이 픽스처 값과 우연히 일치해 증상이 가려져 있었으나, 0 이외 페이지로 픽스처를 확장하는 순간 mock 동작이 어긋나는 상태였음

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — debug 소스셋 mock 픽스처 JSON 문자열 1줄 수정

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- **stack PR (base=feat/444)**: PR #448 이 같은 파일의 DTO rename 을 포함해 머지 순서 의존 — #448 머지 후 자동 retarget 되면 그때 머지해 주세요 (이슈 #451 에 blocked_by #444 Relationships 설정됨)
- 빌드 검증: `:feature:afternote:data:compileDebugKotlin` + `:feature:afternote:data:testDebugUnitTest` BUILD SUCCESSFUL, ktlint 1.8.0 통과