### PR TITLE
refactor(data): 수신자 email/verify 응답의 accessCode 수신 제거 (closes 454)

### DIFF
--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/ReceiverAuthDto.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/ReceiverAuthDto.kt
@@ -34,12 +34,19 @@ data class ReceiverEmailAuthVerifyRequestDto(
     @SerialName("authCode") val authCode: String,
 )
 
+/**
+ * `receiver-auth/email/verify` 성공 응답.
+ *
+ * 서버가 함께 내려주는 `accessCode`(마스터 키와 동일한 UUID)는 **의도적으로 매핑하지 않는다** —
+ * 수신하면 다음 단계인 마스터 키 입력에서 받을 값을 미리 아는 셈이라 그 단계가 무력화된다.
+ * 서버 측에서도 제거 예정이므로, 필드를 두지 않아야 제거 시점과 무관하게 파싱이 안전하다
+ * (`NetworkModule.provideJson` 의 `ignoreUnknownKeys` 가 잔여 키를 무시). 이슈 #454
+ */
 @Serializable
 data class ReceiverEmailAuthVerifyDto(
     @SerialName("receiverId") val receiverId: Long,
     @SerialName("receiverName") val receiverName: String,
     @SerialName("senderName") val senderName: String,
-    @SerialName("accessCode") val accessCode: String,
 )
 
 @Serializable
@@ -99,7 +106,6 @@ fun ReceiverEmailAuthVerifyDto.toDomain(): ReceiverEmailAuthResult =
         receiverId = receiverId,
         receiverName = receiverName,
         senderName = senderName,
-        accessCode = accessCode,
     )
 
 fun ReceiverAuthPresignedUrlDto.toDomain(): ReceiverAuthPresignedUrl =

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverAuthDtoMapperTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverAuthDtoMapperTest.kt
@@ -55,13 +55,11 @@ class ReceiverAuthDtoMapperTest {
                 receiverId = 7L,
                 receiverName = "김수신",
                 senderName = "홍발신",
-                accessCode = "b7a3c9d1-1234-5678-9abc-def012345678",
             ).toDomain()
 
         assertEquals(7L, result.receiverId)
         assertEquals("김수신", result.receiverName)
         assertEquals("홍발신", result.senderName)
-        assertEquals("b7a3c9d1-1234-5678-9abc-def012345678", result.accessCode)
     }
 
     @Test

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverEmailAuthContractTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverEmailAuthContractTest.kt
@@ -8,14 +8,18 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * `POST /receiver-auth/email/auth-code`·`POST /receiver-auth/email/verify` 응답 계약 회귀 가드 (#407).
+ * `POST /receiver-auth/email/auth-code`·`POST /receiver-auth/email/verify` 응답 계약 회귀 가드 (#407, #454).
  *
  * 페이로드는 2026-06-11 라이브 Swagger(`afternote.kro.kr/v3/api-docs`) 스키마 기반 합성 —
  * verify 성공 응답은 6자리 인증번호를 메일로 받아야 해서 자동 캡처 불가
- * (`ReceiverEmailAuthVerifyDto` 4필드 구성·타입은 Swagger 와 BE 소스로 확정, 이슈 #407 본문).
+ * (필드 구성·타입은 Swagger 와 BE 소스로 확정, 이슈 #407 본문).
  * 프로덕션 경로(`ReceiverAuthRepositoryImpl`)와 동일하게 Json 디코드 → `requireData()`/`requireStatus()`
  * → `toDomain()` 을 통과시킨다 — Json 설정은 `NetworkModule.provideJson` 과 동일
  * (ignoreUnknownKeys + coerceInputValues).
+ *
+ * verify 성공 응답을 **accessCode 동봉·제거 두 형태 모두** 가드하는 이유: 서버가 마스터 키와 동일한
+ * `accessCode` 를 응답에서 제거할 예정이라([ReceiverEmailAuthVerifyDto] 참고), 제거 배포가 언제 나가든
+ * 파싱이 깨지지 않아야 한다 (#454).
  *
  * 에러 응답(404 code 1901 / 400 code 1902)은 HTTP 4xx 라 `ApiErrorInterceptor` 가 가로채는 경로 —
  * 그 이후의 도메인 예외 변환은 `ReceiverAuthRepositoryImplEmailAuthTest` 가 가드한다.
@@ -28,7 +32,7 @@ class ReceiverEmailAuthContractTest {
         }
 
     @Test
-    fun `email-verify 성공 응답 - 디코드부터 accessCode 포함 도메인 모델까지 도달`() {
+    fun `email-verify 성공 응답(accessCode 동봉) - 잔여 키를 무시하고 도메인 모델까지 도달`() {
         val payload =
             """{"status":200,"code":200,"message":"성공","data":{"receiverId":3,"receiverName":"큐에이수신자","senderName":"큐에이발신자","accessCode":"123e4567-e89b-12d3-a456-426614174000"}}"""
 
@@ -37,8 +41,18 @@ class ReceiverEmailAuthContractTest {
         assertEquals(3L, result.receiverId)
         assertEquals("큐에이수신자", result.receiverName)
         assertEquals("큐에이발신자", result.senderName)
-        // 백엔드가 receiver.getAuthCode() 를 그대로 반환 — 마스터 키와 동일한 UUID.
-        assertEquals("123e4567-e89b-12d3-a456-426614174000", result.accessCode)
+    }
+
+    @Test
+    fun `email-verify 성공 응답(accessCode 제거 후) - 디코드 성공`() {
+        val payload =
+            """{"status":200,"code":200,"message":"성공","data":{"receiverId":3,"receiverName":"큐에이수신자","senderName":"큐에이발신자"}}"""
+
+        val result = json.decodeFromString<BaseResponse<ReceiverEmailAuthVerifyDto>>(payload).requireData().toDomain()
+
+        assertEquals(3L, result.receiverId)
+        assertEquals("큐에이수신자", result.receiverName)
+        assertEquals("큐에이발신자", result.senderName)
     }
 
     @Test

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImplEmailAuthTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImplEmailAuthTest.kt
@@ -107,7 +107,6 @@ class ReceiverAuthRepositoryImplEmailAuthTest {
                                     receiverId = 3L,
                                     receiverName = "큐에이수신자",
                                     senderName = "큐에이발신자",
-                                    accessCode = "123e4567-e89b-12d3-a456-426614174000",
                                 ),
                         )
                     },
@@ -117,7 +116,8 @@ class ReceiverAuthRepositoryImplEmailAuthTest {
         val result = runBlocking { repository.verifyEmailAuthCode("a@b.com", "123456") }.getOrThrow()
 
         assertEquals(3L, result.receiverId)
-        assertEquals("123e4567-e89b-12d3-a456-426614174000", result.accessCode)
+        assertEquals("큐에이수신자", result.receiverName)
+        assertEquals("큐에이발신자", result.senderName)
     }
 }
 

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/IdentityVerificationViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/IdentityVerificationViewModel.kt
@@ -23,8 +23,8 @@ import javax.inject.Inject
  * 안내 문구는 [ReceiverEmailAuthException.serverMessage] 를 그대로 노출하고, 인프라 실패는 정적 리소스로 폴백.
  *
  * 검증 성공 시 [IdentityVerificationRepository.markVerified] 로 캐시를 켜고 isVerified 신호 발행 →
- * UI 가 마스터 키(5) 단계로 이동. 응답의 `accessCode`(마스터 키 동일 값) 활용 — 자동 채움/단계 스킵 —
- * 은 디자인 결정 대기라 현재는 수신만 하고 사용하지 않는다 (#407).
+ * UI 가 마스터 키(5) 단계로 이동. 이메일 인증은 신원 확인까지만 담당하며 마스터 키를 대신 획득하지
+ * 않는다 — 그랬다면 마스터 키 단계가 무력화된다 (#454).
  *
  * 메모리 정책상 ViewModel 은 [androidx.compose.foundation.text.input.TextFieldState] 를 보유하지 않는다.
  * UI 가 입력값을 [onEmailChange]·[onCodeChange] 로 흘려주고 본 VM 은 String 만 관리.

--- a/feature/receiver/domain/src/main/java/com/afternote/feature/receiver/domain/model/ReceiverAuthModels.kt
+++ b/feature/receiver/domain/src/main/java/com/afternote/feature/receiver/domain/model/ReceiverAuthModels.kt
@@ -10,17 +10,15 @@ data class ReceiverIdentity(
 /**
  * 수신자 본인 확인 이메일 인증 검증(`receiver-auth/email/verify`) 성공 결과.
  *
- * [ReceiverIdentity] 와 비슷하지만 다른 계약 — `relation` 이 없고 [accessCode] 가 있다 (별개 endpoint).
+ * [ReceiverIdentity] 와 비슷하지만 다른 계약 — `relation` 이 없다 (별개 endpoint).
  *
- * @property accessCode 이후 `X-Auth-Code` 헤더에 쓰는 UUID 접근 코드. 백엔드가 "이메일 인증 성공
- *   = 마스터 키 획득" 으로 설계해 마스터 키와 동일한 값을 돌려준다. 마스터 키 입력 단계의
- *   스킵/자동 채움 여부는 디자인 결정 대기 — 결정 전까지 presentation 은 수신만 하고 사용하지 않는다 (#407).
+ * 이메일 인증은 신원 확인까지만 담당한다. `X-Auth-Code` 에 쓰는 마스터 키는 이 결과가 아니라
+ * 마스터 키 입력 화면의 사용자 입력에서 온다.
  */
 data class ReceiverEmailAuthResult(
     val receiverId: Long,
     val receiverName: String,
     val senderName: String,
-    val accessCode: String,
 )
 
 data class ReceiverAuthPresignedUrl(


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #454 — refactor(data): 수신자 email/verify 응답의 accessCode 수신 제거 (BE 필드 제거 선행 가드)

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `ReceiverEmailAuthVerifyDto`·`ReceiverEmailAuthResult` 에서 `accessCode` 필드 제거 + `toDomain()` 갱신 (4477ef45).
- 서버가 내려주는 `accessCode` 는 마스터 키(`Receiver.authCode`)와 **동일한 값**이라, 수신하면 다음 단계인 마스터 키 입력 화면에서 받을 값을 미리 아는 셈이 되어 그 단계가 무력화된다. BE 측 확인 결과 설계 의도가 아니라 테스트 편의로 넣어둔 값이며 응답에서 제거 예정 (2026-07-16 확인).
- 읽는 프로덕션 코드는 원래 0건이라 회귀 표면 없음 — 유일 호출부 `IdentityVerificationViewModel` 이 `.onSuccess { }` 에서 결과 객체를 참조하지 않고 버리며, `X-Auth-Code` 헤더는 `MasterKeyViewModel` 의 수동 입력분(`ReceiverAuthCodeDataSource`)으로만 채워진다.
- `ReceiverEmailAuthContractTest` 에 `accessCode` **동봉·제거 두 형태** 디코드 회귀 가드 추가 — BE 제거 배포가 언제 나가든 파싱이 깨지지 않는다.
- `ReceiverEmailAuthResult`·`IdentityVerificationViewModel` 의 KDoc 현행화 — "#407 디자인 결정 대기라 수신만 하고 사용하지 않는다" 전제 폐기. `ReceiverAuthDto` 에는 "서버가 주는데 왜 매핑하지 않는지" 를 남겨 필드 재유입을 막는다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — presentation 은 KDoc 주석 2줄만 수정이라 스크린샷 baseline 영향 없음.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- **FE 선행이 필수인 이유**: DTO 가 `val accessCode: String`(non-null·기본값 없음)이라 BE 가 먼저 제거하면 `MissingFieldException` 이 나고 `ReceiverAuthRepositoryImpl` 의 `runCatching` 이 이를 삼켜 `Result.failure` 로 흘린다. 사용자에겐 "인증번호 불일치"라는 엉뚱한 메시지가 뜨고, 이메일 인증이 마스터 키 화면 도달의 유일 게이트(`ReceiverNavGraph.kt:109-113`)라 수신자 흐름 전체가 막힌다. `ignoreUnknownKeys = true` 는 여분 키만 무시할 뿐 누락된 필수 필드는 못 봐준다 (유닛테스트로 실측 확인). 본 PR 이 머지되면 배포 순서와 무관하게 안전해진다.
- **base 가 develop 이 아니라 `feat/444`(#448)**: #448 이 `ReceiverAuthDto.kt` 및 테스트 3건을 -Dto 리네임으로 이미 수정 중이라 develop 기준이면 충돌 확정. #448 머지 후 develop 으로 갱신 예정.
- 빌드 검증: `./gradlew :feature:afternote:data:testDebugUnitTest` 15건 green (failures 0 / errors 0), `:feature:receiver:domain:compileDebugKotlin`·`:feature:afternote:presentation:compileDebugKotlin` BUILD SUCCESSFUL.
- refs #407 — accessCode 처리를 "디자인 결정 대기"로 남기고 종결했던 이슈. 본 PR 이 그 잔여분을 정리한다.
