### PR TITLE
fix(core): 비밀번호 마스킹 OutputTransformation 문자 단위 치환으로 캐럿 이동 수정 (closes 458)

### DIFF
--- a/core/ui/src/main/kotlin/com/afternote/core/ui/TextFieldShort.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/TextFieldShort.kt
@@ -54,6 +54,22 @@ import android.view.KeyEvent as NativeKeyEvent
 // 1. 공통 내부 구현체 (건드릴 필요 없음)
 // ============================================================================
 
+private const val PASSWORD_MASK_CHAR = "•"
+
+/**
+ * 비밀번호 마스킹 [OutputTransformation].
+ *
+ * 전체 범위를 `replace(0, length, ...)` 로 한 번에 치환하면 그 구간이 통째로 wedge 가 되어
+ * 캐럿이 텍스트 중간에 들어가지 못하고 맨 앞/맨 뒤로만 스냅된다. 문자 단위 1:1 치환은
+ * `OffsetMappingCalculator` 가 편집 연산으로 기록조차 하지 않아 오프셋 매핑이 identity 로 남는다.
+ */
+private val PasswordMaskOutputTransformation =
+    OutputTransformation {
+        for (i in 0 until length) {
+            replace(i, i + 1, PASSWORD_MASK_CHAR)
+        }
+    }
+
 @Composable
 private fun TextFieldShort(
     state: TextFieldState,
@@ -87,9 +103,7 @@ private fun TextFieldShort(
         outputTransformation =
             outputTransformation
                 ?: if (keyboardType == KeyboardType.Password) {
-                    OutputTransformation {
-                        replace(0, length, '\u2022'.toString().repeat(length))
-                    }
+                    PasswordMaskOutputTransformation
                 } else {
                     null
                 },


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #458 — fix(core): 비밀번호 마스킹 OutputTransformation 의 전체 replace 로 캐럿이 텍스트 중간에 서지 못함

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `TextFieldShort` 의 password 마스킹 `OutputTransformation` 을 `replace(0, length, ...)` 전체 치환에서 문자 단위 1:1 치환으로 변경 (e73872b1).
- 전체를 통째로 바꾸면 그 구간이 하나의 wedge(캐럿이 안으로 들어갈 수 없는 구간)로 기록되어, 구간 내부 오프셋이 전부 모호해지고 캐럿이 맨 앞(0)/맨 뒤(N)로만 스냅됐다. 2자 이상 입력 시 발생. 캐럿이 맨 앞으로 간 상태에서는 백스페이스도 먹지 않는다.
- 1→1 치환은 `OffsetMappingCalculator` 의 `if (sourceLength < 2 && sourceLength == newLength) return` 가드에 걸려 편집 연산으로 **기록조차 되지 않아** 오프셋 매핑이 identity 로 남는다. 같은 파일 KDoc 이 `•` 마스킹을 identity 예시로 든다.
- `OutputTransformation` 인스턴스를 top-level `val` 로 추출 — 매 recomposition 마다 새 람다가 생기지 않는다.
- 마스킹 렌더 결과는 종전과 동일(`•` 그대로). 캐럿 거동만 바뀐다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 마스킹 출력이 동일해 렌더 픽셀에 차이가 없다. 스크린샷 baseline 영향 없음: password 관련 테스트(`SignUpPasswordScreenScreenshotTest`, `LoginScreenScreenshotTest`)가 모두 빈 입력 상태라 `OutputTransformation` 출력이 어느 쪽이든 같다. core/ui 의 `AfternoteTextField` Preview 는 Password 타입을 쓰지 않는다.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 에뮬레이터 실측 검증(Pixel 7, API 36). 수정 전: 비밀번호 필드에 `abcdefgh` 입력 후 4번째 점 뒤를 탭 → 캐럿이 맨 앞으로 튕기고, 이어 백스페이스를 눌러도 점 8개 그대로(커서가 offset 0 이라 지울 게 없음). 수정 후: 같은 절차에서 캐럿이 탭한 자리에 서고, 백스페이스로 4번째 문자가 지워져 점 7개. 같은 화면 이메일 필드(일반 텍스트, `OutputTransformation` 미적용)는 수정 전에도 `abcd`+`Z`+`efgh` 로 정상 삽입돼 password 분기만의 문제임이 대조로 확인된다.
- 회원가입 비밀번호 단계는 1단계 이메일 인증이 실서버 의존이라 직접 진입이 막혀, 동일 컴포넌트(`AfternoteTextField` + `KeyboardType.Password`)를 쓰는 로그인 화면에서 검증했다. 분기가 `TextFieldShort.kt:89` 한 곳이라 코드 경로가 완전히 같다.
- 영향 범위는 리포트된 회원가입 외 3곳 더 — `SignUpPasswordScreen.kt:90`(비밀번호)·`:100`(확인), `LoginScreen.kt:151`(로그인), `SocialNetworkEditorContent.kt:55`(소셜 계정). core/ui 한 곳 수정으로 전부 해소된다.
- 프레임워크 한계나 버전 문제가 아니라 우리 코드 문제다. foundation 릴리스 노트에 wedge/캐럿 스냅 관련 수정 이력이 없어 BOM 업그레이드로는 해결되지 않는다. 근거는 로컬 `foundation-android-1.10.6-sources.jar` 원문 대조 — `TransformedTextFieldState` KDoc 의 wedge 정의, `OffsetMappingCalculator` KDoc 의 "map ambiguously to the entire replaced range".
- 한계: UTF-16 code unit 단위라 surrogate pair(이모지)는 점 2개로 렌더된다. 비밀번호 필드 특성상 실무 영향은 낮다고 판단해 이번 범위에서 제외했다. 구조적 정공법은 `BasicSecureTextField`(마스킹을 코드포인트 1:1 `CodepointTransformation` 으로 처리) 이전이나, `decorator` + `AfternoteFieldContainer` 구조와 `keyboardType == Password` 암묵 트리거 API 설계를 함께 바꿔야 해 이번 버그픽스와 분리하는 게 맞다고 봤다.
- 빌드 검증: `./gradlew :core:ui:compileDebugKotlin` BUILD SUCCESSFUL, `./gradlew :app:assembleDebug` BUILD SUCCESSFUL (에뮬 설치·검증에 사용한 빌드).
