### PR TITLE
fix(core): 눌림 피드백이 Material ripple 이 아닌 디버그 사각형으로 표시되는 문제 수정 (closes 436)

### DIFF
--- a/core/ui/src/main/kotlin/com/afternote/core/ui/theme/Theme.kt
+++ b/core/ui/src/main/kotlin/com/afternote/core/ui/theme/Theme.kt
@@ -1,7 +1,9 @@
 package com.afternote.core.ui.theme
 
+import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
@@ -21,6 +23,9 @@ private val LocalTypography =
     staticCompositionLocalOf {
         AfternoteTypography()
     }
+
+// ripple()은 컴포저블이 아니라서 remember가 필요 없고, 여러 컴포넌트가 함께 써도 되므로 할당을 아끼려 top-level로 추출
+private val AfternoteRipple = ripple()
 
 @Composable
 fun AfternoteTheme(
@@ -47,6 +52,9 @@ fun AfternoteTheme(
         // provides 앞의 객체의 current 프로퍼티를 호출하면 provides 뒤의 객체를 제공하도록 current를 호출한 컴포저블부터 모든 하위 트리에 세팅
         LocalColors provides rememberedColors,
         LocalTypography provides typography,
+        // 제공하지 않으면 clickable의 눌림 피드백이 foundation 기본값(DefaultDebugIndication)으로 떨어져
+        // 노드 전체를 덮는 검정 사각형이 그려짐 — MaterialTheme도 같은 방식으로 ripple을 제공함
+        LocalIndication provides AfternoteRipple,
     ) {
         // 별도의 style 지정이 없다면 value를 content 내부의 모든 Text 컴포저블의 style의 기본값으로 지정
         ProvideTextStyle(typography.bodyLargeR, content = content)


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #436 — fix(core): 눌림 피드백이 Material ripple 이 아닌 디버그 사각형으로 표시됨 (LocalIndication 미제공)

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `7420440d` — `AfternoteTheme` 의 `CompositionLocalProvider` 에 `LocalIndication provides ripple()` 추가 (`core/ui/theme/Theme.kt`, 8줄)
- `ripple()` 은 composable 이 아니라 remember 가 필요 없고 여러 컴포넌트가 공유 가능해 top-level `val AfternoteRipple` 로 추출
- 영향 범위는 이슈 본문보다 넓었다. `AfternoteTheme` 이 `MaterialTheme` 래핑 없이 `LocalColors`·`LocalTypography` 만 provide 해서, **프로덕션의 모든 `clickable` 이** foundation 기본값 `DefaultDebugIndication` 을 쓰고 있었다. 레포의 `MaterialTheme { }` 2곳은 둘 다 `@Preview` 전용이라(`ReceiverPlayListScreen.kt:66`, `ReceiverAfternoteScreen.kt:213`) 실사용 경로에는 래핑이 0건이었다.
- 예외는 `indication = ripple()` 을 인자로 직접 넘긴 5곳뿐이라, 앱 안에서 눌림 표현이 두 갈래로 갈려 있었다(라디오·체크박스만 ripple, 나머지 전부 검정 사각형).

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

눌림 상태는 정지 스크린샷으로 구분이 안 된다 — bounded ripple 도 다 퍼지면 노드 경계를 채워 사각형으로 보이므로, 모양이 아니라 **색 농도**가 유일한 판별자다. 에뮬레이터에서 로그인 화면 "아이디/비밀번호 찾기" 를 누른 순간을 캡처해 픽셀을 측정했다.

| | 배경 | 눌린 영역 | 알파 |
| --- | --- | --- | --- |
| 수정 전 | `(250,250,250)` | `(175,175,175)` | **0.300** |
| 수정 후 | `(250,250,250)` | `(229,229,229)` | **0.084** |

수정 전 알파가 정확히 `0.300` 으로, foundation 소스의 `DefaultDebugIndication` 이 그리는 `Color.Black.copy(alpha = 0.3f)` 와 일치한다. 수정 후는 ripple 알파.

스크린샷 baseline 은 영향 없다 — indication 은 press/hover/focus 에만 그려지고 baseline 은 정적 렌더다.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 빌드 검증: `./gradlew :core:ui:compileDebugKotlin` BUILD SUCCESSFUL, `./gradlew build` BUILD SUCCESSFUL
- 새 의존은 없다. `material3` 는 `build-logic/src/main/kotlin/AndroidCommonConfig.kt:68` 에서 전 모듈 공통 `implementation` 이고, `core:ui` 는 이미 `androidx.compose.material3.ripple` 을 쓰고 있다(`AfternoteCircularCheckbox`, `CustomRadioButton`). 이슈 Note 의 "의존 방향 검토 필요" 는 해당 없음.
- `indication = ripple()` 을 직접 넘기던 5곳은 그대로 뒀다. `AfternoteCircularCheckbox.kt:94` 는 `bounded = false` + 커스텀 radius 라 유지가 맞고, 나머지 4곳(`CustomRadioButton.kt:85`, `LastWishesRadioGroup.kt:171`, `SelectableRadioCard.kt:50`, `feature/setting` 의 `RadioGroupCard.kt:54`)은 이제 중복이지만 타 오너 파일까지 건드리게 돼 이 PR 범위 밖으로 뒀다. 별도 정리 대상.
- ripple 색·투명도 토큰은 디자인 확정 전이라 material3 기본값(`LocalContentColor` 기반)을 쓴다. 토큰이 정해지면 `androidx.compose.material:material-ripple` 의 `createRippleModifierNode()` 로 `AfternoteDesign` 토큰을 직접 조회하는 커스텀 ripple 을 만드는 것이 공식 안내 경로다 — https://developer.android.com/develop/ui/compose/touch-input/user-interactions/migrate-indication-ripple
