### PR TITLE
fix(onboarding): 예외 message null 시 실패 스낵바 무음 케이스 수정 (closes 475)

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigationActions.kt
@@ -66,6 +66,10 @@ fun rememberOnboardingNavActions(navController: NavController): OnboardingNavAct
                 navController.popBackStack()
             }
 
+            override fun navigateToFindId() {
+                navController.navigate(OnboardingRoute.FindIdRoute)
+            }
+
             override fun proceedToSignUpResidentNumber() {
                 navController.navigate(OnboardingRoute.SignUpResidentNumberRoute)
             }

--- a/core/data/src/main/java/com/afternote/core/data/mapper/auth/AuthMapper.kt
+++ b/core/data/src/main/java/com/afternote/core/data/mapper/auth/AuthMapper.kt
@@ -1,8 +1,10 @@
 package com.afternote.core.data.mapper.auth
 
 import com.afternote.core.model.AccountRegistration
+import com.afternote.core.model.FoundAccount
 import com.afternote.core.model.Session
 import com.afternote.core.model.TokenBundle
+import com.afternote.core.network.dto.EmailFindDto
 import com.afternote.core.network.dto.LoginDto
 import com.afternote.core.network.dto.ReissueDto
 import com.afternote.core.network.dto.SignUpDto
@@ -12,6 +14,8 @@ import com.afternote.core.network.dto.SignUpDto
  */
 object AuthMapper {
     fun toSignUpResult(dto: SignUpDto): AccountRegistration = AccountRegistration(userId = dto.userId, email = dto.email)
+
+    fun toFoundAccount(dto: EmailFindDto): FoundAccount = FoundAccount(name = dto.name, email = dto.email)
 
     fun toDefaultLoginResult(dto: LoginDto.DefaultLoginDto): Session.DefaultSession =
         Session.DefaultSession(

--- a/core/data/src/main/java/com/afternote/core/data/repoimpl/account/AccountRepositoryImpl.kt
+++ b/core/data/src/main/java/com/afternote/core/data/repoimpl/account/AccountRepositoryImpl.kt
@@ -3,6 +3,9 @@ package com.afternote.core.data.repoimpl.account
 import com.afternote.core.data.mapper.auth.AuthMapper
 import com.afternote.core.domain.repository.account.AccountRepository
 import com.afternote.core.model.AccountRegistration
+import com.afternote.core.model.FoundAccount
+import com.afternote.core.network.dto.EmailFindRequestDto
+import com.afternote.core.network.dto.FindSendCodeRequestDto
 import com.afternote.core.network.dto.PasswordChangeRequestDto
 import com.afternote.core.network.dto.SendEmailCodeRequestDto
 import com.afternote.core.network.dto.SignUpRequestDto
@@ -35,6 +38,28 @@ class AccountRepositoryImpl
                             certificateCode,
                         ),
                     ).requireStatus()
+            }
+
+        override suspend fun sendFindCode(email: String): Result<Unit> =
+            runCatching {
+                accountApiService
+                    .sendFindCode(FindSendCodeRequestDto(email))
+                    .requireStatus()
+            }
+
+        override suspend fun findAccount(
+            email: String,
+            certificateCode: String,
+        ): Result<FoundAccount> =
+            runCatching {
+                val response =
+                    accountApiService.findEmail(
+                        EmailFindRequestDto(
+                            email,
+                            certificateCode,
+                        ),
+                    )
+                AuthMapper.toFoundAccount(response.requireData())
             }
 
         override suspend fun signUp(

--- a/core/data/src/test/java/com/afternote/core/data/mapper/auth/AuthMapperTest.kt
+++ b/core/data/src/test/java/com/afternote/core/data/mapper/auth/AuthMapperTest.kt
@@ -1,8 +1,10 @@
 package com.afternote.core.data.mapper.auth
 
 import com.afternote.core.model.AccountRegistration
+import com.afternote.core.model.FoundAccount
 import com.afternote.core.model.Session
 import com.afternote.core.model.TokenBundle
+import com.afternote.core.network.dto.EmailFindDto
 import com.afternote.core.network.dto.LoginDto
 import com.afternote.core.network.dto.ReissueDto
 import com.afternote.core.network.dto.SignUpDto
@@ -22,6 +24,14 @@ class AuthMapperTest {
         val result = AuthMapper.toSignUpResult(SignUpDto(userId = 42L, email = "user@example.com"))
 
         assertEquals(AccountRegistration(userId = 42L, email = "user@example.com"), result)
+    }
+
+    @Test
+    fun `toFoundAccount - name·email 매핑 (자리 바뀜 가드)`() {
+        // 둘 다 String 이라 자리가 바뀌어도 컴파일은 통과한다 — 서로 구분되는 값으로 가드.
+        val result = AuthMapper.toFoundAccount(EmailFindDto(name = "박채연", email = "parkchae01@gmail.com"))
+
+        assertEquals(FoundAccount(name = "박채연", email = "parkchae01@gmail.com"), result)
     }
 
     @Test

--- a/core/domain/src/main/java/com/afternote/core/domain/repository/account/AccountRepository.kt
+++ b/core/domain/src/main/java/com/afternote/core/domain/repository/account/AccountRepository.kt
@@ -1,6 +1,7 @@
 package com.afternote.core.domain.repository.account
 
 import com.afternote.core.model.AccountRegistration
+import com.afternote.core.model.FoundAccount
 
 interface AccountRepository {
     suspend fun sendEmailCode(email: String): Result<Unit>
@@ -9,6 +10,18 @@ interface AccountRepository {
         email: String,
         certificateCode: String,
     ): Result<Unit>
+
+    /** 아이디/비밀번호 찾기용 인증번호 발송. 회원가입용 [sendEmailCode] 와 엔드포인트가 다르다. */
+    suspend fun sendFindCode(email: String): Result<Unit>
+
+    /**
+     * 아이디 찾기 — 인증번호 검증 후 가입 계정을 돌려받는다 (서버 계약명은 `auth/email/find`,
+     * 이 앱의 로그인 아이디가 곧 이메일이라 서버가 "아이디 찾기" 를 이렇게 부른다).
+     */
+    suspend fun findAccount(
+        email: String,
+        certificateCode: String,
+    ): Result<FoundAccount>
 
     suspend fun signUp(
         email: String,

--- a/core/model/src/main/kotlin/com/afternote/core/model/AuthResult.kt
+++ b/core/model/src/main/kotlin/com/afternote/core/model/AuthResult.kt
@@ -9,6 +9,17 @@ data class AccountRegistration(
 )
 
 /**
+ * 아이디 찾기 성공 결과.
+ *
+ * @property email 가입 이메일. 이 앱은 이메일과 별개인 아이디를 두지 않아(로그인 = 이메일 + 비밀번호)
+ *   찾은 "아이디" 가 곧 이 값이다.
+ */
+data class FoundAccount(
+    val name: String,
+    val email: String,
+)
+
+/**
  * 로그인 성공 결과.
  */
 sealed class Session {

--- a/core/network/src/main/kotlin/com/afternote/core/network/dto/AuthDto.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/dto/AuthDto.kt
@@ -14,6 +14,25 @@ data class VerifyEmailRequestDto(
     @SerialName("certificateCode") val certificateCode: String,
 )
 
+/** 아이디/비밀번호 찾기 전용 인증번호 발송 요청 (POST /auth/find/send/code). 회원가입용 [SendEmailCodeRequestDto] 와 엔드포인트가 다르다. */
+@Serializable
+data class FindSendCodeRequestDto(
+    val email: String,
+)
+
+@Serializable
+data class EmailFindRequestDto(
+    val email: String,
+    @SerialName("certificateCode") val certificateCode: String,
+)
+
+/** 아이디 찾기 결과. 이 앱의 로그인 아이디가 곧 [email] 이라 서버는 가입 이메일을 그대로 돌려준다. */
+@Serializable
+data class EmailFindDto(
+    val name: String,
+    val email: String,
+)
+
 @Serializable
 data class SignUpRequestDto(
     val email: String,

--- a/core/network/src/main/kotlin/com/afternote/core/network/service/AccountApiService.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/service/AccountApiService.kt
@@ -1,5 +1,8 @@
 package com.afternote.core.network.service
 
+import com.afternote.core.network.dto.EmailFindDto
+import com.afternote.core.network.dto.EmailFindRequestDto
+import com.afternote.core.network.dto.FindSendCodeRequestDto
 import com.afternote.core.network.dto.PasswordChangeRequestDto
 import com.afternote.core.network.dto.SendEmailCodeRequestDto
 import com.afternote.core.network.dto.SignUpDto
@@ -14,6 +17,16 @@ interface AccountApiService {
     suspend fun sendEmailCode(
         @Body body: SendEmailCodeRequestDto,
     ): BaseResponse<Unit>
+
+    @POST("auth/find/send/code")
+    suspend fun sendFindCode(
+        @Body body: FindSendCodeRequestDto,
+    ): BaseResponse<Unit>
+
+    @POST("auth/email/find")
+    suspend fun findEmail(
+        @Body body: EmailFindRequestDto,
+    ): BaseResponse<EmailFindDto>
 
     @POST("auth/email/verify")
     suspend fun verifyEmail(

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/findaccount/FindIdScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/findaccount/FindIdScreen.kt
@@ -1,0 +1,246 @@
+package com.afternote.feature.onboarding.presentation.findaccount
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.afternote.core.ui.AfternoteTextField
+import com.afternote.core.ui.TextFieldType
+import com.afternote.core.ui.scaffold.FlowStepScaffold
+import com.afternote.core.ui.theme.AfternoteDesign
+import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.onboarding.presentation.R
+
+private val HeaderSpacing = 8.dp
+
+/**
+ * 아이디 찾기 1단계 — 이메일 인증.
+ *
+ * 인증번호 "확인" 이 곧 조회라(`auth/email/find` 가 인증번호를 함께 받는다) 확인에 성공해야
+ * "다음" 이 열리고, 결과 화면은 VM 에 담긴 계정을 읽는다.
+ */
+@Composable
+fun FindIdScreen(
+    initialEmail: String,
+    initialCertificateCode: String,
+    isSendingCode: Boolean,
+    isVerificationSent: Boolean,
+    isSendCodeEnabled: Boolean,
+    isVerifyEnabled: Boolean,
+    isNextEnabled: Boolean,
+    resendCooldownSeconds: Int,
+    hasVerificationError: Boolean,
+    snackbarHostState: SnackbarHostState,
+    onEmailChange: (String) -> Unit,
+    onCertificateCodeChange: (String) -> Unit,
+    onRequestCode: () -> Unit,
+    onVerifyCode: () -> Unit,
+    onNextClick: () -> Unit,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val emailState = rememberTextFieldState(initialEmail)
+    val certificateCodeState = rememberTextFieldState(initialCertificateCode)
+
+    // "바뀔 때마다 onEmailChange 호출"을 수행하는 장치가 이 블록이다. TextFieldState 에는 콜백이 없고,
+    // LaunchedEffect 의 key(emailState) 는 객체 동일성 비교라 내용(.text) 변이에는 반응하지 않는다
+    // (rememberTextFieldState 인스턴스는 화면 수명 내내 동일 → key 만으론 최초 1회 실행 후 침묵).
+    // snapshotFlow 가 스냅샷 읽기 추적으로 내용 변이를 리컴포지션 없이 구독해 값이 달라질 때만 흘리고,
+    // LaunchedEffect 는 그 수집 코루틴의 수명(화면 이탈 시 자동 해제)만 맡는다. (SignUpScreen 선례)
+    // key=emailState 는 재시작 트리거가 아니라 의존성 선언 — remember 덕에 지금은 인스턴스가 안 갈리지만,
+    // 갈리는 리팩터링이 오면 옛 구독을 취소하고 새 인스턴스로 갈아타게 하는 보험이다 (Unit 이면 유령 구독).
+    LaunchedEffect(emailState) {
+        snapshotFlow { emailState.text.toString() }.collect(onEmailChange)
+    }
+    LaunchedEffect(certificateCodeState) {
+        snapshotFlow { certificateCodeState.text.toString() }.collect(onCertificateCodeChange)
+    }
+
+    val requestCodeText =
+        when {
+            isSendingCode -> {
+                stringResource(R.string.find_account_code_requesting)
+            }
+
+            resendCooldownSeconds > 0 -> {
+                stringResource(
+                    R.string.find_account_code_resend_cooldown,
+                    resendCooldownSeconds,
+                )
+            }
+
+            isVerificationSent -> {
+                stringResource(R.string.find_account_code_resend)
+            }
+
+            else -> {
+                stringResource(R.string.find_account_code_request)
+            }
+        }
+
+    FlowStepScaffold(
+        topBarTitle = stringResource(R.string.find_id_title),
+        actionButtonText = stringResource(R.string.find_account_next),
+        onBackClick = onBackClick,
+        onActionClick = onNextClick,
+        modifier = modifier,
+        isActionEnabled = isNextEnabled,
+        snackbarHostState = snackbarHostState,
+    ) {
+        Spacer(modifier = Modifier.height(HeaderSpacing))
+        Column(
+            modifier = Modifier.imePadding(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.find_account_verify_email_title),
+                style = AfternoteDesign.typography.h1,
+                color = AfternoteDesign.colors.gray9,
+            )
+            Text(
+                text = stringResource(R.string.find_account_verify_email_description),
+                // 시안 텍스트 스펙 = NanumBarunGothic Regular 12 / 행간 18 → captionLargeR (bodySmallB 는 Bold 14/20 로 불일치)
+                style = AfternoteDesign.typography.captionLargeR,
+                color = AfternoteDesign.colors.gray5,
+            )
+
+            AfternoteTextField(
+                state = emailState,
+                type =
+                    TextFieldType.Variant7(
+                        text = requestCodeText,
+                        onClick = onRequestCode,
+                        enabled = isSendCodeEnabled,
+                    ),
+                placeholder = stringResource(R.string.find_account_email_placeholder),
+                keyboardType = KeyboardType.Email,
+                imeAction = ImeAction.Next,
+            )
+
+            // 인증번호 필드의 "확인" 은 발송 이력이 있을 때만 노출 (시안 초기 상태엔 없음).
+            AfternoteTextField(
+                state = certificateCodeState,
+                type =
+                    if (isVerificationSent) {
+                        TextFieldType.Variant7(
+                            text = stringResource(R.string.find_account_code_confirm),
+                            onClick = onVerifyCode,
+                            enabled = isVerifyEnabled,
+                        )
+                    } else {
+                        TextFieldType.Basic
+                    },
+                placeholder = stringResource(R.string.find_account_code_placeholder),
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Done,
+                onImeAction = {
+                    if (isVerifyEnabled) onVerifyCode()
+                },
+            )
+
+            // 인증번호 불일치는 인라인 에러로, 그 외 실패는 스낵바로 나뉜다 (시안 2431-14204).
+            if (hasVerificationError) {
+                Text(
+                    text = stringResource(R.string.find_account_code_mismatch),
+                    style = AfternoteDesign.typography.captionLargeB,
+                    color = AfternoteDesign.colors.error,
+                )
+            } else if (isVerificationSent) {
+                Text(
+                    text = stringResource(R.string.find_account_code_sent),
+                    style = AfternoteDesign.typography.captionLargeB,
+                    color = AfternoteDesign.colors.b1,
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FindIdScreenPreview() {
+    AfternoteTheme {
+        FindIdScreen(
+            initialEmail = "",
+            initialCertificateCode = "",
+            isSendingCode = false,
+            isVerificationSent = false,
+            isSendCodeEnabled = false,
+            isVerifyEnabled = false,
+            isNextEnabled = false,
+            resendCooldownSeconds = 0,
+            hasVerificationError = false,
+            snackbarHostState = remember { SnackbarHostState() },
+            onEmailChange = {},
+            onCertificateCodeChange = {},
+            onRequestCode = {},
+            onVerifyCode = {},
+            onNextClick = {},
+            onBackClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "인증번호 전송됨")
+@Composable
+private fun FindIdScreenCodeSentPreview() {
+    AfternoteTheme {
+        FindIdScreen(
+            initialEmail = "parkchae01@gmail.com",
+            initialCertificateCode = "",
+            isSendingCode = false,
+            isVerificationSent = true,
+            isSendCodeEnabled = true,
+            isVerifyEnabled = false,
+            isNextEnabled = false,
+            resendCooldownSeconds = 0,
+            hasVerificationError = false,
+            snackbarHostState = remember { SnackbarHostState() },
+            onEmailChange = {},
+            onCertificateCodeChange = {},
+            onRequestCode = {},
+            onVerifyCode = {},
+            onNextClick = {},
+            onBackClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "인증번호 불일치")
+@Composable
+private fun FindIdScreenErrorPreview() {
+    AfternoteTheme {
+        FindIdScreen(
+            initialEmail = "parkchae01@gmail.com",
+            initialCertificateCode = "123456",
+            isSendingCode = false,
+            isVerificationSent = true,
+            isSendCodeEnabled = true,
+            isVerifyEnabled = true,
+            isNextEnabled = false,
+            resendCooldownSeconds = 0,
+            hasVerificationError = true,
+            snackbarHostState = remember { SnackbarHostState() },
+            onEmailChange = {},
+            onCertificateCodeChange = {},
+            onRequestCode = {},
+            onVerifyCode = {},
+            onNextClick = {},
+            onBackClick = {},
+        )
+    }
+}

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/findaccount/FindIdUiState.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/findaccount/FindIdUiState.kt
@@ -1,0 +1,53 @@
+package com.afternote.feature.onboarding.presentation.findaccount
+
+import android.util.Patterns
+import com.afternote.core.model.FoundAccount
+
+/**
+ * 아이디 찾기 화면 상태.
+ *
+ * 시안에 인증번호 만료 타이머가 없어 회원가입(`SignUpUiState.verificationRemainingSeconds`)과 달리
+ * 만료 카운트다운을 두지 않는다. 만료 판정은 서버가 하고, 만료된 코드는 [verificationError] 로 표시된다.
+ *
+ * @property resendCooldownSeconds "재전송" 버튼 잠금의 남은 초 — 0 보다 크면 "재전송 (Ns)" 표시·비활성.
+ *   발송 성공마다 30초로 재잠금되는 클라이언트 측 연타 방지이며, **인증번호 유효시간과 무관**하다
+ *   (만료 판정은 서버 몫, 쿨다운 종료 ≠ 코드 만료).
+ * @property foundAccount "확인" 성공 시 서버가 돌려준 계정. non-null 이면 "다음" 이 열린다.
+ * @property verificationError 인증번호 불일치 — 시안상 인증번호 필드 아래 인라인 문구로 표시(스낵바 아님).
+ * @property errorMessage 인증번호 불일치 외의 실패(네트워크 등) — 스낵바로 표시.
+ */
+data class FindIdUiState(
+    val email: String = "",
+    val certificateCode: String = "",
+    val isSendingCode: Boolean = false,
+    val isVerificationSent: Boolean = false,
+    val isVerifying: Boolean = false,
+    val resendCooldownSeconds: Int = 0,
+    val foundAccount: FoundAccount? = null,
+    val verificationError: String? = null,
+    val errorMessage: String? = null,
+) {
+    /**
+     * 이메일 형식 검사. [Patterns.EMAIL_ADDRESS] 는 컴파일된 정규식(`Pattern`) 상수라
+     * `matcher(입력)` 으로 그 문자열 전용 실행기를 만든 뒤 `matches()`(**전체 일치** — 부분 검색
+     * `find()` 와 다름) 로 판정하는 Java regex 2단계 API 를 쓴다. 회원가입과 동일 방식.
+     */
+    val isEmailFormatValid: Boolean
+        get() = email.isNotBlank() && Patterns.EMAIL_ADDRESS.matcher(email).matches()
+
+    /** 인증번호 발송/재발송 가능 여부. 쿨다운 중이거나 이메일 형식이 틀리면 막는다. */
+    val isSendCodeEnabled: Boolean
+        get() = !isSendingCode && resendCooldownSeconds == 0 && isEmailFormatValid
+
+    /** 인증번호 필드의 "확인" 활성 여부. 발송 이력이 있고 자릿수를 채워야 열린다. */
+    val isVerifyEnabled: Boolean
+        get() = !isVerifying && isVerificationSent && certificateCode.length >= MIN_VERIFICATION_CODE_LENGTH
+
+    /** 하단 "다음" 활성 여부. "확인" 으로 계정을 받아야만 결과 화면으로 넘어갈 수 있다. */
+    val isNextEnabled: Boolean
+        get() = foundAccount != null
+
+    companion object {
+        const val MIN_VERIFICATION_CODE_LENGTH = 6
+    }
+}

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/findaccount/FindIdViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/findaccount/FindIdViewModel.kt
@@ -51,7 +51,7 @@ class FindIdViewModel
                         _uiState.update { it.copy(isVerificationSent = true, verificationError = null) }
                         startResendCooldown()
                     }.onFailure { error ->
-                        _uiState.update { it.copy(errorMessage = error.message) }
+                        _uiState.update { it.copy(errorMessage = error.message ?: "") }
                     }
                 _uiState.update { it.copy(isSendingCode = false) }
             }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/findaccount/FindIdViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/findaccount/FindIdViewModel.kt
@@ -1,0 +1,103 @@
+package com.afternote.feature.onboarding.presentation.findaccount
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.afternote.core.domain.repository.account.AccountRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * 아이디 찾기 플로우 ViewModel. 인증 화면과 결과 화면이 `Route.Onboarding` 그래프 스코프로 공유한다
+ * (결과 화면이 [FindIdUiState.foundAccount] 를 읽어야 해서 Route 인자 대신 VM 공유를 택했다 —
+ * 회원가입 플로우가 이미 같은 방식이다).
+ *
+ * `TextFieldState` 는 Screen 이 소유하고 VM 은 String 만 들고 있는다.
+ */
+@HiltViewModel
+class FindIdViewModel
+    @Inject
+    constructor(
+        private val accountRepository: AccountRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow(FindIdUiState())
+        val uiState: StateFlow<FindIdUiState> = _uiState.asStateFlow()
+
+        private var cooldownJob: Job? = null
+
+        fun updateEmail(value: String) =
+            _uiState.update {
+                // 이메일이 바뀌면 앞서 받은 계정·에러는 더 이상 그 이메일의 것이 아니다.
+                it.copy(email = value, foundAccount = null, verificationError = null)
+            }
+
+        fun updateCertificateCode(value: String) = _uiState.update { it.copy(certificateCode = value, verificationError = null) }
+
+        fun requestVerificationCode() {
+            val state = _uiState.value
+            if (!state.isSendCodeEnabled) return
+            viewModelScope.launch {
+                _uiState.update { it.copy(isSendingCode = true) }
+                accountRepository
+                    .sendFindCode(state.email)
+                    .onSuccess {
+                        _uiState.update { it.copy(isVerificationSent = true, verificationError = null) }
+                        startResendCooldown()
+                    }.onFailure { error ->
+                        _uiState.update { it.copy(errorMessage = error.message) }
+                    }
+                _uiState.update { it.copy(isSendingCode = false) }
+            }
+        }
+
+        /**
+         * 인증번호 "확인". 찾기 흐름에는 검증 전용 엔드포인트가 없고 `auth/email/find` 가
+         * 인증번호까지 함께 받아 계정을 돌려주므로, 확인 = 검증 + 조회를 한 번에 한다.
+         * 결과는 [FindIdUiState.foundAccount] 에 담아두고 "다음" 에서 결과 화면이 소비한다.
+         */
+        fun verifyCode() {
+            val state = _uiState.value
+            if (!state.isVerifyEnabled) return
+            viewModelScope.launch {
+                _uiState.update { it.copy(isVerifying = true, verificationError = null) }
+                accountRepository
+                    .findAccount(state.email, state.certificateCode)
+                    .onSuccess { account ->
+                        _uiState.update { it.copy(foundAccount = account) }
+                    }.onFailure { error ->
+                        _uiState.update { it.copy(verificationError = error.message ?: "") }
+                    }
+                _uiState.update { it.copy(isVerifying = false) }
+            }
+        }
+
+        fun onErrorConsumed() = _uiState.update { it.copy(errorMessage = null) }
+
+        private fun startResendCooldown() {
+            // 중복 방지가 아니라 last-wins 재장전 — 이전 카운트다운을 폐기하고 30초를 새로 센다.
+            // 호출부 가드(isSendCodeEnabled)상 보통 이전 잡은 끝나 있지만, "쿨다운 잡 최대 1개" 를
+            // 함수 스스로 보장해 가드가 느슨해져도 2배속 감산이 생기지 않게 한다.
+            cooldownJob?.cancel()
+            cooldownJob =
+                viewModelScope.launch {
+                    _uiState.update { it.copy(resendCooldownSeconds = RESEND_COOLDOWN_SECONDS) }
+                    while (_uiState.value.resendCooldownSeconds > 0) {
+                        delay(MILLIS_PER_SECOND.milliseconds)
+                        _uiState.update { it.copy(resendCooldownSeconds = it.resendCooldownSeconds - 1) }
+                    }
+                }
+        }
+
+        private companion object {
+            // 시안·서버 계약에 없는 클라 관례값 — 회원가입(SignUpViewModel)의 쿨다운과 동일하게 맞춤.
+            const val RESEND_COOLDOWN_SECONDS = 30
+            const val MILLIS_PER_SECOND = 1000L
+        }
+    }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginEntry.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginEntry.kt
@@ -37,6 +37,7 @@ fun LoginEntry(
     onLoginSuccess: () -> Unit,
     onNewUserOnboarding: () -> Unit,
     onSignUpClick: () -> Unit,
+    onFindAccountClick: () -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: LoginViewModel = hiltViewModel(),
@@ -95,6 +96,7 @@ fun LoginEntry(
         onPasswordChange = viewModel::updatePassword,
         onLoginClick = { withClearFocus { viewModel.loginWithEmail() } },
         onSignUpClick = { withClearFocus { onSignUpClick() } },
+        onFindAccountClick = { withClearFocus { onFindAccountClick() } },
         onKakaoLoginClick = {
             withClearFocus {
                 val activity = context.findActivity<Activity>()

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginScreen.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginScreen.kt
@@ -29,10 +29,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -53,8 +50,6 @@ import com.afternote.core.ui.AfternoteTextField
 import com.afternote.core.ui.button.AfternoteButton
 import com.afternote.core.ui.button.AfternoteButtonType
 import com.afternote.core.ui.modifierextention.addFocusCleaner
-import com.afternote.core.ui.popup.Popup
-import com.afternote.core.ui.popup.PopupType
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
 import com.afternote.core.ui.topbar.DetailTopBar
@@ -69,6 +64,7 @@ fun LoginScreen(
     onPasswordChange: (String) -> Unit,
     onLoginClick: () -> Unit,
     onSignUpClick: () -> Unit,
+    onFindAccountClick: () -> Unit,
     onKakaoLoginClick: () -> Unit,
     onGoogleLoginClick: () -> Unit,
     onBackClick: () -> Unit,
@@ -107,6 +103,7 @@ fun LoginScreen(
             ) {
                 SocialLoginGroup(
                     onSignUpClick = onSignUpClick,
+                    onFindAccountClick = onFindAccountClick,
                     onKakaoLoginClick = onKakaoLoginClick,
                     onGoogleLoginClick = onGoogleLoginClick,
                 )
@@ -184,27 +181,16 @@ fun LoginScreen(
  * 로그인 화면 하단 소셜 로그인 그룹.
  *
  * `LoginScreen`에서만 쓰이므로 외부 파일로 분리하지 않고 `private`로 캡슐화한다.
- * `showFindAccountPopup` 상태를 내부에 가두어 부모 화면의 리컴포지션 범위를 줄인다.
  */
 @Composable
 private fun SocialLoginGroup(
     onSignUpClick: () -> Unit,
+    onFindAccountClick: () -> Unit,
     onKakaoLoginClick: () -> Unit,
     onGoogleLoginClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val focusManager = LocalFocusManager.current
-    var showFindAccountPopup by remember { mutableStateOf(false) }
-
-    if (showFindAccountPopup) {
-        Popup(
-            type = PopupType.Default,
-            message = stringResource(R.string.login_find_account_message),
-            onConfirm = { showFindAccountPopup = false },
-            onDismiss = { showFindAccountPopup = false },
-        )
-    }
-
     Column(
         modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -299,7 +285,7 @@ private fun SocialLoginGroup(
             modifier =
                 Modifier.clickable {
                     focusManager.clearFocus()
-                    showFindAccountPopup = true
+                    onFindAccountClick()
                 },
         )
     }
@@ -316,6 +302,7 @@ private fun LoginScreenPreview() {
             onPasswordChange = {},
             onLoginClick = {},
             onSignUpClick = {},
+            onFindAccountClick = {},
             onKakaoLoginClick = {},
             onGoogleLoginClick = {},
             onBackClick = {},

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavActions.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavActions.kt
@@ -40,4 +40,7 @@ interface OnboardingNavActions {
     fun proceedToProfile()
 
     fun navigateToTermsDetail()
+
+    /** 로그인 → 아이디 찾기. */
+    fun navigateToFindId()
 }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
@@ -17,6 +17,9 @@ import com.afternote.core.ui.Route
 import com.afternote.feature.onboarding.presentation.OnboardingProfileEntry
 import com.afternote.feature.onboarding.presentation.R
 import com.afternote.feature.onboarding.presentation.WelcomeScreen
+import com.afternote.feature.onboarding.presentation.findaccount.FindIdScreen
+import com.afternote.feature.onboarding.presentation.findaccount.FindIdUiState
+import com.afternote.feature.onboarding.presentation.findaccount.FindIdViewModel
 import com.afternote.feature.onboarding.presentation.login.LoginEntry
 import com.afternote.feature.onboarding.presentation.signup.SignUpPasswordScreen
 import com.afternote.feature.onboarding.presentation.signup.SignUpResidentNumberScreen
@@ -54,6 +57,34 @@ fun NavGraphBuilder.onboardingNavGraph(
                 onLoginSuccess = actions::replaceOnboardingWithHome,
                 onNewUserOnboarding = actions::replaceLoginWithWelcome,
                 onSignUpClick = actions::replaceLoginWithSignUp,
+                onFindAccountClick = actions::navigateToFindId,
+                onBackClick = actions::popBack,
+            )
+        }
+
+        // ── 아이디 찾기 (인증 → 결과) ──
+        composable<OnboardingRoute.FindIdRoute> {
+            val viewModel = graphScopedFindIdViewModel(graphScopedParentEntry)
+            val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+            val snackbarHostState = rememberFindIdEventHost(viewModel, uiState)
+
+            FindIdScreen(
+                initialEmail = uiState.email,
+                initialCertificateCode = uiState.certificateCode,
+                isSendingCode = uiState.isSendingCode,
+                isVerificationSent = uiState.isVerificationSent,
+                isSendCodeEnabled = uiState.isSendCodeEnabled,
+                isVerifyEnabled = uiState.isVerifyEnabled,
+                isNextEnabled = uiState.isNextEnabled,
+                resendCooldownSeconds = uiState.resendCooldownSeconds,
+                hasVerificationError = uiState.verificationError != null,
+                snackbarHostState = snackbarHostState,
+                onEmailChange = viewModel::updateEmail,
+                onCertificateCodeChange = viewModel::updateCertificateCode,
+                onRequestCode = viewModel::requestVerificationCode,
+                onVerifyCode = viewModel::verifyCode,
+                // 결과 화면 연결은 아이디 찾기 존치 결정(#456 코멘트) 대기 — 확정 전까지 미배선.
+                onNextClick = {},
                 onBackClick = actions::popBack,
             )
         }
@@ -173,6 +204,53 @@ fun NavGraphBuilder.onboardingNavGraph(
 private fun graphScopedSignUpViewModel(graphScopedParentEntry: () -> NavBackStackEntry): SignUpViewModel {
     val parentEntry = remember { graphScopedParentEntry() }
     return hiltViewModel(parentEntry)
+}
+
+/**
+ * `Route.Onboarding` 그래프 스코프에 묶인 [FindIdViewModel]을 가져옵니다.
+ *
+ * [NavBackStackEntry] 는 ViewModelStoreOwner 라서, [hiltViewModel] 에 부모 그래프 엔트리를 넘기면
+ * VM 을 "만드는" 게 아니라 **그 엔트리의 store 에서 조회**한다 — 최초 호출만 생성이고, 같은 엔트리를
+ * 넘기는 모든 화면이 동일 인스턴스를 받는다(인자를 생략하면 현재 화면 엔트리 스코프라 화면 pop 과 함께
+ * 소멸). 수명은 그래프가 백스택에서 내려갈 때까지: 화면을 나갔다 재진입해도 상태가 남는 것은
+ * [graphScopedSignUpViewModel] 과 동일 특성이다. 지금은 인증 화면 단독 소비지만 결과 화면(#474)·
+ * 비밀번호 찾기(#457)가 [FindIdUiState.foundAccount] 등을 이어받는 통로로 이 스코프를 쓴다.
+ * 람다를 [remember] 로 감싸는 건 getBackStackEntry 조회를 컴포지션당 1회로 고정하기 위함.
+ */
+@Composable
+private fun graphScopedFindIdViewModel(graphScopedParentEntry: () -> NavBackStackEntry): FindIdViewModel {
+    val parentEntry = remember { graphScopedParentEntry() }
+    return hiltViewModel(parentEntry)
+}
+
+/**
+ * 아이디 찾기 화면의 Snackbar 호스트 + 단발성 에러 신호 처리.
+ *
+ * 인증번호 불일치는 시안상 인라인 문구라 여기서 다루지 않고([FindIdUiState.verificationError]),
+ * 그 외 실패([FindIdUiState.errorMessage])만 snackbar 로 노출한다.
+ */
+@Composable
+private fun rememberFindIdEventHost(
+    viewModel: FindIdViewModel,
+    uiState: FindIdUiState,
+): SnackbarHostState {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val failedMessage = stringResource(R.string.find_account_failed)
+    val pendingErrorMessage = uiState.errorMessage
+
+    LaunchedEffect(pendingErrorMessage) {
+        if (pendingErrorMessage != null) {
+            snackbarHostState.showSnackbar(
+                // 서버 봉투 message 가 빈 문자열이면 non-null 로 여기까지 온다(requireStatus 의 `?:` 는
+                // null 만 폴백) — 빈 스낵바 방지. 단 message 가 아예 null 인 실패는 위 분기에서 걸러져
+                // 스낵바 자체가 안 뜬다 — VM 이 error.message 를 null 그대로 넘기는 한 이 폴백은 못 잡는다.
+                message = pendingErrorMessage.ifBlank { failedMessage },
+                duration = SnackbarDuration.Short,
+            )
+            viewModel.onErrorConsumed()
+        }
+    }
+    return snackbarHostState
 }
 
 /**

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingNavGraph.kt
@@ -242,8 +242,8 @@ private fun rememberFindIdEventHost(
         if (pendingErrorMessage != null) {
             snackbarHostState.showSnackbar(
                 // 서버 봉투 message 가 빈 문자열이면 non-null 로 여기까지 온다(requireStatus 의 `?:` 는
-                // null 만 폴백) — 빈 스낵바 방지. 단 message 가 아예 null 인 실패는 위 분기에서 걸러져
-                // 스낵바 자체가 안 뜬다 — VM 이 error.message 를 null 그대로 넘기는 한 이 폴백은 못 잡는다.
+                // null 만 폴백) — 빈 스낵바 방지. message 가 아예 null 인 실패도 VM 이 `?: ""` 로 수렴해
+                // 빈 문자열로 여기 도달하므로, null-message 실패 문구는 이 폴백이 책임진다.
                 message = pendingErrorMessage.ifBlank { failedMessage },
                 duration = SnackbarDuration.Short,
             )

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingRoute.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/navigation/OnboardingRoute.kt
@@ -26,4 +26,7 @@ sealed interface OnboardingRoute {
 
     @Serializable
     data object ProfileRoute : OnboardingRoute
+
+    @Serializable
+    data object FindIdRoute : OnboardingRoute
 }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
@@ -121,7 +121,7 @@ class SignUpViewModel
                         startResendCooldown()
                         startExpiryCountdown()
                     }.onFailure { error ->
-                        _uiState.update { it.copy(errorMessage = error.message) }
+                        _uiState.update { it.copy(errorMessage = error.message ?: "") }
                     }
                 _uiState.update { it.copy(isSendingCode = false) }
             }
@@ -214,7 +214,7 @@ class SignUpViewModel
                                 }
                             }
                     }.onFailure { error ->
-                        _uiState.update { it.copy(errorMessage = error.message) }
+                        _uiState.update { it.copy(errorMessage = error.message ?: "") }
                     }
                 _uiState.update { it.copy(isLoading = false) }
             }

--- a/feature/onboarding/presentation/src/main/res/values/strings.xml
+++ b/feature/onboarding/presentation/src/main/res/values/strings.xml
@@ -17,12 +17,26 @@
     <string name="login_kakao">카카오 로그인</string>
     <string name="login_google">Google 계정으로 로그인</string>
     <string name="login_find_account">아이디/비밀번호 찾기</string>
-    <string name="login_find_account_message">아이디/비밀번호 찾기의 경우,\n고객센터로 문의 바랍니다.</string>
     <string name="login_failed">로그인 실패</string>
     <string name="login_kakao_failed">카카오 로그인에 실패했습니다.</string>
     <string name="login_google_failed">구글 로그인에 실패했습니다.</string>
     <string name="login_google_no_credentials">기기에 Google 계정이 없어요.\n설정 &gt; 계정에서 Google 계정을 추가해 주세요.</string>
     <string name="login_screen_unavailable">로그인 화면을 띄울 수 없습니다.</string>
+
+    <string name="find_id_title">아이디 찾기</string>
+    <string name="find_account_verify_email_title">이메일 인증하기</string>
+    <string name="find_account_verify_email_description">가입 시 사용한 이메일을 입력해 주세요</string>
+    <string name="find_account_email_placeholder">이메일 주소</string>
+    <string name="find_account_code_placeholder">인증 번호</string>
+    <string name="find_account_code_request">인증번호 받기</string>
+    <string name="find_account_code_requesting">전송 중…</string>
+    <string name="find_account_code_resend">재전송</string>
+    <string name="find_account_code_resend_cooldown">재전송 (%1$ds)</string>
+    <string name="find_account_code_confirm">확인</string>
+    <string name="find_account_code_sent">인증번호가 전송되었습니다.\n수신 된 인증번호를 입력해 주세요.</string>
+    <string name="find_account_code_mismatch">인증번호가 틀렸습니다.\n다시 확인 후 입력해 주세요.</string>
+    <string name="find_account_next">다음</string>
+    <string name="find_account_failed">요청에 실패했습니다.</string>
     <string name="content_description_google_login">구글 로그인</string>
 
     <string name="onboarding_step_description">회원가입 진행도 4단계 중 %1$d단계</string>

--- a/feature/onboarding/presentation/src/screenshotTest/kotlin/com/afternote/feature/onboarding/presentation/findaccount/FindIdScreenScreenshotTest.kt
+++ b/feature/onboarding/presentation/src/screenshotTest/kotlin/com/afternote/feature/onboarding/presentation/findaccount/FindIdScreenScreenshotTest.kt
@@ -1,0 +1,96 @@
+package com.afternote.feature.onboarding.presentation.findaccount
+
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.tooling.preview.Preview
+import com.afternote.core.ui.theme.AfternoteTheme
+import com.android.tools.screenshot.PreviewTest
+
+/**
+ * [FindIdScreen] 의 시각 회귀 baseline — 아이디 찾기 1단계 (이메일 인증).
+ *
+ * 시안의 세 상태를 가드:
+ * 1. 초기 진입 — 인증번호 필드에 "확인" 없음
+ * 2. 인증번호 전송됨 — "확인" 노출 + 파란 안내 2줄
+ * 3. 인증번호 불일치 — 빨간 에러 2줄 (안내와 배타)
+ *
+ * 의도된 시각 변경 시 `./gradlew :feature:onboarding:presentation:updateScreenshotTest` 로 갱신.
+ */
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+internal fun findIdScreenInitialScreenshot() {
+    AfternoteTheme {
+        FindIdScreen(
+            initialEmail = "",
+            initialCertificateCode = "",
+            isSendingCode = false,
+            isVerificationSent = false,
+            isSendCodeEnabled = false,
+            isVerifyEnabled = false,
+            isNextEnabled = false,
+            resendCooldownSeconds = 0,
+            hasVerificationError = false,
+            snackbarHostState = remember { SnackbarHostState() },
+            onEmailChange = {},
+            onCertificateCodeChange = {},
+            onRequestCode = {},
+            onVerifyCode = {},
+            onNextClick = {},
+            onBackClick = {},
+        )
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+internal fun findIdScreenCodeSentScreenshot() {
+    AfternoteTheme {
+        FindIdScreen(
+            initialEmail = "parkchae01@gmail.com",
+            initialCertificateCode = "",
+            isSendingCode = false,
+            isVerificationSent = true,
+            isSendCodeEnabled = true,
+            isVerifyEnabled = false,
+            isNextEnabled = false,
+            resendCooldownSeconds = 0,
+            hasVerificationError = false,
+            snackbarHostState = remember { SnackbarHostState() },
+            onEmailChange = {},
+            onCertificateCodeChange = {},
+            onRequestCode = {},
+            onVerifyCode = {},
+            onNextClick = {},
+            onBackClick = {},
+        )
+    }
+}
+
+@PreviewTest
+@Preview(showBackground = true)
+@Composable
+internal fun findIdScreenCodeMismatchScreenshot() {
+    AfternoteTheme {
+        FindIdScreen(
+            initialEmail = "parkchae01@gmail.com",
+            initialCertificateCode = "123456",
+            isSendingCode = false,
+            isVerificationSent = true,
+            isSendCodeEnabled = true,
+            isVerifyEnabled = true,
+            isNextEnabled = false,
+            resendCooldownSeconds = 0,
+            hasVerificationError = true,
+            snackbarHostState = remember { SnackbarHostState() },
+            onEmailChange = {},
+            onCertificateCodeChange = {},
+            onRequestCode = {},
+            onVerifyCode = {},
+            onNextClick = {},
+            onBackClick = {},
+        )
+    }
+}

--- a/feature/onboarding/presentation/src/screenshotTest/kotlin/com/afternote/feature/onboarding/presentation/login/LoginScreenScreenshotTest.kt
+++ b/feature/onboarding/presentation/src/screenshotTest/kotlin/com/afternote/feature/onboarding/presentation/login/LoginScreenScreenshotTest.kt
@@ -24,6 +24,7 @@ internal fun loginScreenInitialScreenshot() {
             onPasswordChange = {},
             onLoginClick = {},
             onSignUpClick = {},
+            onFindAccountClick = {},
             onKakaoLoginClick = {},
             onGoogleLoginClick = {},
             onBackClick = {},


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #475 — fix(onboarding): 예외 message null 시 실패 스낵바 무음 케이스 수정

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- FindIdViewModel.requestVerificationCode / SignUpViewModel.requestVerification·signUp 의 `errorMessage = error.message` 를 `?: ""` 로 수렴 (3곳) — null 이 UI state 에 그대로 흘러 스낵바 분기(`!= null`)를 통과 못 하던 무음 실패 봉합 (66d6383d)
- rememberFindIdEventHost 의 ifBlank 폴백 주석을 새 불변식(VM 이 "" 수렴 → 폴백이 null-message 실패 문구 책임)으로 갱신

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 기존 실패 스낵바 경로가 null-message 예외(오프라인 등 transport 계층)에서도 발동하게 되는 동작 수정. 스낵바 문구는 기존 ifBlank 폴백("요청에 실패했습니다." / "회원가입 실패") 재사용

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- stack PR: base 가 feat/456(#476)입니다. 머지 순서 #476 먼저, 이후 develop 으로 retarget 필요
- ApiException 은 message non-null 강제(fallback 주입)라 서버 에러 경로는 원래 무음이 아니고, 이 수정이 잡는 건 ApiException 밖의 예외(transport 계층·message 없이 생성된 Throwable)입니다
- `FindIdViewModel.verifyCode()` 의 `verificationError = error.message ?: ""` 가 기존 선례 — 같은 관례로 수렴했습니다
- 빌드 검증: `./gradlew :feature:onboarding:presentation:compileDebugKotlin` BUILD SUCCESSFUL (stash 인도 시점 실측, 커밋 66d6383d 은 인도분과 동일 3파일·수정 없음)