### PR TITLE
fix(onboarding): 수신자 온보딩 문구 정합 및 낡은 KDoc 정정 (closes 473)

### DIFF
--- a/feature/afternote/presentation/src/main/res/values/strings.xml
+++ b/feature/afternote/presentation/src/main/res/values/strings.xml
@@ -158,11 +158,11 @@
 
     <string name="receiver_verify_title">수신자 인증</string>
     <string name="receiver_verify_self_title">수신자 본인 확인</string>
-    <string name="receiver_verify_intro">고인의 소중한 정보를 보호하기 위해\n가족관계 및 사망 사실 확인이 필요합니다.</string>
+    <string name="receiver_verify_intro">고인의 소중한 정보를 보호하기 위해\n가족 관계 및 사망 사실 확인이 필요합니다.</string>
     <string name="receiver_verify_start_button">인증 시작하기</string>
     <string name="receiver_verify_next_button">다음</string>
     <string name="receiver_verify_confirm_button">인증하기</string>
-    <string name="receiver_verify_email_description">수신자님 본인 확인을 위해\n작성하신 이메일로 인증번호를 보내드립니다.</string>
+    <string name="receiver_verify_email_description">수신자 본인 확인을 위해 이메일 인증이 필요합니다.</string>
     <string name="receiver_verify_email_label">이메일 주소</string>
     <string name="receiver_verify_code_description">입력하신 이메일로 인증번호를 보냈습니다.\n수신된 메일에서 인증번호를 확인하고 입력해주세요.</string>
     <string name="receiver_verify_master_key_required">마스터 키를 입력해주세요.</string>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #473 — fix(onboarding): 수신자 온보딩 문구 정합 및 낡은 KDoc 정정

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- 수신자 인증 관련 문자열 띄어쓰기·문구 간소화 (fb0509cb)
- 수신자 흐름 진입점·시작 화면 KDoc 현행화(docs, bbc342c3)는 브랜치 히스토리 사정상 base 브랜치에 먼저 커밋되어 PR #453 diff 에 포함돼 있습니다 (아래 To Reviewers 참고)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 사용자 노출 문자열 정정과 주석 현행화만 포함

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- stack PR: base 가 feat/439(#453)입니다. 머지 순서 #453 먼저, 이후 develop 으로 retarget 필요
- 이 PR 의 diff 는 fb0509cb(문자열 정정) 1건입니다. #473 범위였던 KDoc 현행화 커밋(bbc342c3)은 feat/439 팁에 커밋되어 PR #453 에서 함께 리뷰됩니다 — #453 리뷰 시 grab-bag 언번들 범위 밖 docs 커밋이 하나 보이는 이유입니다
- 빌드 검증: `./gradlew :feature:onboarding:presentation:compileDebugKotlin` BUILD SUCCESSFUL (fb0509cb 스냅샷 실측)