### PR TITLE
fix(onboarding): 로그인 예외 message null 시 실패 스낵바 무음 (closes 502)

### DIFF
--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginViewModel.kt
@@ -77,7 +77,9 @@ class LoginViewModel
                         }
                     }.onFailure { exception ->
                         _uiState.update {
-                            it.copy(isLoading = false, errorMessage = exception.message)
+                            // message 가 null 이면 빈 문자열로 두어 실패 사실이 소실되지 않게 한다.
+                            // (null 은 "에러 없음"과 구분되지 않아 스낵바가 무음 처리되던 버그. UI 가 ifBlank 로 일반 문구 폴백.)
+                            it.copy(isLoading = false, errorMessage = exception.message.orEmpty())
                         }
                     }
             }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #502 — fix(onboarding): 로그인 예외 message null 시 실패 스낵바 무음 (#475 패턴 login 미커버분)

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- 로그인 실패 시 `LoginViewModel` 이 `errorMessage = exception.message`(nullable)로 담아, 예외 message 가 null 이면 `errorMessage == null` → `LoginEntry` 의 `pendingErrorMessage != null` 가드에 걸려 스낵바가 무음 처리되던 버그 수정 (90991706)
- `exception.message.orEmpty()` 로 발생 지점에서 null 을 빈 문자열로 수렴 — 빈 문자열은 `!= null` 을 통과하고 UI 의 `ifBlank { loginFailedMessage }` 가 일반 실패 문구로 폴백해 실패 사실이 소실되지 않음
- #475(아이디 찾기/회원가입)가 고친 것과 동일 패턴의 login 미커버분

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

정적 UI 변경 없음 — message==null 실패 예외의 스낵바 노출 경로만 보정하는 로직 수정.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- QA #5(401 무음)의 표면 증상은 현 develop 에서 재현되지 않음 — 401 은 `ApiException` 이 항상 non-null message 를 주어 스낵바가 이미 노출된다(에뮬·curl 실측). 본 PR 은 그 아래 계층의 message==null(비-`ApiException`: 네트워크 IO·런타임) 예외 무음을 예방적으로 방어하는 것 — 근거는 이슈 #502 본문 참고.
- 로그인 대기 로딩 인디케이터(#516)와 네트워크 예외 원문 노출(#517)은 별개 관심사로 분리됨.
- 빌드 검증: `./gradlew :feature:onboarding:presentation:compileDebugKotlin` BUILD SUCCESSFUL
