### PR TITLE
fix(mindrecord): 주간리포트 기록일수 집계 보정 — 데일리질문 기록일 누락 (closes 521)

### DIFF
--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportRecordedDays.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportRecordedDays.kt
@@ -1,0 +1,42 @@
+package com.afternote.feature.mindrecord.presentation.viewmodel
+
+import com.afternote.feature.mindrecord.domain.model.WeeklyReportDay
+import java.time.LocalDate
+
+internal const val WEEK_LENGTH = 7
+
+/**
+ * `week[]` 는 월~일 7칸이 아니라 **기록이 있는 날만** 담겨 오는 sparse 배열이라
+ * index 가 요일 오프셋이 아니다. 각 원소는 일자(`day`, 1~31)만 들고 있으므로
+ * 월 경계를 넘는 주에는 monday 의 월을 그대로 붙일 수도 없다.
+ *
+ * 해당 주(월~일) 안에서 일자가 일치하는 날짜를 찾는다 — 7일 창 안에서 일자는 유일하다.
+ * 범위 밖 일자면 null 을 돌려 집계에서 제외한다.
+ */
+internal fun resolveDateInWeek(
+    monday: LocalDate,
+    dayOfMonth: Int,
+): LocalDate? =
+    (0 until WEEK_LENGTH)
+        .map { monday.plusDays(it.toLong()) }
+        .firstOrNull { it.dayOfMonth == dayOfMonth }
+
+/**
+ * 기록일수 = 일기가 있는 날 + 주간 범위 내 데일리질문 답변 날짜의 합집합(중복 제거).
+ *
+ * 두 출처를 모두 `LocalDate` 로 복원한 뒤 합쳐야 같은 날의 일기·데일리질문이
+ * `distinct()` 로 1일로 접힌다.
+ */
+internal fun countRecordedDays(
+    monday: LocalDate,
+    week: List<WeeklyReportDay>,
+    dailyQuestionDates: List<LocalDate>,
+): Int {
+    val sunday = monday.plusDays(WEEK_LENGTH - 1L)
+    val diaryDates =
+        week.mapNotNull { day ->
+            day.takeIf { it.isDiary }?.let { resolveDateInWeek(monday, it.day) }
+        }
+    val questionDatesInWeek = dailyQuestionDates.filter { it in monday..sunday }
+    return (diaryDates + questionDatesInWeek).distinct().size
+}

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportViewModel.kt
@@ -167,23 +167,19 @@ class WeeklyReportViewModel
             }
 
         private fun LoadPhase.Loaded.toSuccessUiState(): WeeklyReportUiState.Success {
-            val sunday = monday.plusDays(6)
-            // 기록일수 = 일기가 있는 요일 + 주간 범위 내 데일리질문 답변 날짜의 합집합(중복 제거).
-            // week 리스트는 월요일부터 순서대로 내려오므로 index로 실제 날짜(LocalDate)를 복원해 합친다.
-            val diaryDates =
-                report.week.mapIndexedNotNull { index, day ->
-                    monday.plusDays(index.toLong()).takeIf { day.isDiary }
-                }
-            val dailyQuestionDates =
-                report.dailyQuestions
-                    .mapNotNull { parseLocalDateOrNull(it.date) }
-                    .filter { it in monday..sunday }
+            val sunday = monday.plusDays(WEEK_LENGTH - 1L)
+            val dailyQuestionDates = report.dailyQuestions.mapNotNull { parseLocalDateOrNull(it.date) }
             return WeeklyReportUiState.Success(
                 selectedMonday = monday,
                 weekOptions = weekOptions,
                 dateRange = "${monday.format(RANGE_FORMATTER)} - ${sunday.format(RANGE_FORMATTER)}",
                 userName = userName,
-                recordedDays = (diaryDates + dailyQuestionDates).distinct().size,
+                recordedDays =
+                    countRecordedDays(
+                        monday = monday,
+                        week = report.week,
+                        dailyQuestionDates = dailyQuestionDates,
+                    ),
                 counts =
                     listOf(
                         report.dailyQuestionAmount to MindRecordCategoryUi.DailyQuestion,
@@ -198,7 +194,6 @@ class WeeklyReportViewModel
 
         companion object {
             private const val WEEK_OPTION_COUNT = 5
-            private const val WEEK_LENGTH = 7
 
             private val API_DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
             private val RANGE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd.")

--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportViewModel.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportViewModel.kt
@@ -168,12 +168,22 @@ class WeeklyReportViewModel
 
         private fun LoadPhase.Loaded.toSuccessUiState(): WeeklyReportUiState.Success {
             val sunday = monday.plusDays(6)
+            // 기록일수 = 일기가 있는 요일 + 주간 범위 내 데일리질문 답변 날짜의 합집합(중복 제거).
+            // week 리스트는 월요일부터 순서대로 내려오므로 index로 실제 날짜(LocalDate)를 복원해 합친다.
+            val diaryDates =
+                report.week.mapIndexedNotNull { index, day ->
+                    monday.plusDays(index.toLong()).takeIf { day.isDiary }
+                }
+            val dailyQuestionDates =
+                report.dailyQuestions
+                    .mapNotNull { parseLocalDateOrNull(it.date) }
+                    .filter { it in monday..sunday }
             return WeeklyReportUiState.Success(
                 selectedMonday = monday,
                 weekOptions = weekOptions,
                 dateRange = "${monday.format(RANGE_FORMATTER)} - ${sunday.format(RANGE_FORMATTER)}",
                 userName = userName,
-                recordedDays = report.week.count { it.isDiary },
+                recordedDays = (diaryDates + dailyQuestionDates).distinct().size,
                 counts =
                     listOf(
                         report.dailyQuestionAmount to MindRecordCategoryUi.DailyQuestion,
@@ -224,12 +234,14 @@ class WeeklyReportViewModel
                     DateTimeFormatter.ISO_DATE,
                 )
 
-            private fun parseLocalDate(raw: String): LocalDate {
+            private fun parseLocalDate(raw: String): LocalDate = parseLocalDateOrNull(raw) ?: LocalDate.now()
+
+            private fun parseLocalDateOrNull(raw: String): LocalDate? {
                 val datePart = raw.substringBefore(' ').trim()
                 for (formatter in DATE_FORMATTERS) {
                     runCatching { return LocalDate.parse(datePart, formatter) }
                 }
-                return LocalDate.now()
+                return null
             }
         }
     }

--- a/feature/mindrecord/presentation/src/test/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportRecordedDaysTest.kt
+++ b/feature/mindrecord/presentation/src/test/kotlin/com/afternote/feature/mindrecord/presentation/viewmodel/WeeklyReportRecordedDaysTest.kt
@@ -1,0 +1,130 @@
+package com.afternote.feature.mindrecord.presentation.viewmodel
+
+import com.afternote.feature.mindrecord.domain.model.TodayMood
+import com.afternote.feature.mindrecord.domain.model.WeeklyReportDay
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.LocalDate
+
+class WeeklyReportRecordedDaysTest {
+    @Test
+    fun `sparse week 원소는 index 가 아니라 day 로 날짜가 복원된다`() {
+        // week 는 기록이 있는 날만 담겨 오므로 index 0 이 월요일을 뜻하지 않는다.
+        val monday = LocalDate.of(2026, 7, 27)
+        val week = listOf(diaryDay(day = 28))
+
+        val recordedDays =
+            countRecordedDays(
+                monday = monday,
+                week = week,
+                dailyQuestionDates = emptyList(),
+            )
+
+        assertEquals(1, recordedDays)
+        assertEquals(LocalDate.of(2026, 7, 28), resolveDateInWeek(monday, 28))
+    }
+
+    @Test
+    fun `같은 날 일기와 데일리질문은 1일로 합쳐진다`() {
+        // 리뷰 #524 회귀 시나리오 — 2026-07-28(화) 일기 1건 + 데일리질문 1건 → 1일.
+        val monday = LocalDate.of(2026, 7, 27)
+
+        val recordedDays =
+            countRecordedDays(
+                monday = monday,
+                week = listOf(diaryDay(day = 28)),
+                dailyQuestionDates = listOf(LocalDate.of(2026, 7, 28)),
+            )
+
+        assertEquals(1, recordedDays)
+    }
+
+    @Test
+    fun `서로 다른 날의 일기와 데일리질문은 각각 세어진다`() {
+        val monday = LocalDate.of(2026, 7, 27)
+
+        val recordedDays =
+            countRecordedDays(
+                monday = monday,
+                week = listOf(diaryDay(day = 28), diaryDay(day = 30)),
+                dailyQuestionDates = listOf(LocalDate.of(2026, 7, 29)),
+            )
+
+        assertEquals(3, recordedDays)
+    }
+
+    @Test
+    fun `월 경계를 넘는 주에도 day 가 올바른 달로 복원된다`() {
+        // 2026-06-29(월) ~ 2026-07-05(일) — day=1 은 6월 1일이 아니라 7월 1일이다.
+        val monday = LocalDate.of(2026, 6, 29)
+
+        assertEquals(LocalDate.of(2026, 6, 30), resolveDateInWeek(monday, 30))
+        assertEquals(LocalDate.of(2026, 7, 1), resolveDateInWeek(monday, 1))
+        assertEquals(LocalDate.of(2026, 7, 5), resolveDateInWeek(monday, 5))
+
+        val recordedDays =
+            countRecordedDays(
+                monday = monday,
+                week = listOf(diaryDay(day = 30), diaryDay(day = 1)),
+                dailyQuestionDates = listOf(LocalDate.of(2026, 7, 1)),
+            )
+
+        assertEquals(2, recordedDays)
+    }
+
+    @Test
+    fun `주 범위 밖 일자는 집계에서 제외된다`() {
+        val monday = LocalDate.of(2026, 7, 27)
+
+        assertNull(resolveDateInWeek(monday, 26))
+
+        val recordedDays =
+            countRecordedDays(
+                monday = monday,
+                week = listOf(diaryDay(day = 26), diaryDay(day = 28)),
+                dailyQuestionDates = listOf(LocalDate.of(2026, 7, 20)),
+            )
+
+        assertEquals(1, recordedDays)
+    }
+
+    @Test
+    fun `isDiary 가 false 인 원소는 일기 기록일로 세지 않는다`() {
+        val monday = LocalDate.of(2026, 7, 27)
+
+        val recordedDays =
+            countRecordedDays(
+                monday = monday,
+                week = listOf(diaryDay(day = 28, isDiary = false)),
+                dailyQuestionDates = emptyList(),
+            )
+
+        assertEquals(0, recordedDays)
+    }
+
+    @Test
+    fun `빈 week 응답은 데일리질문만으로 집계된다`() {
+        val monday = LocalDate.of(2026, 7, 27)
+
+        val recordedDays =
+            countRecordedDays(
+                monday = monday,
+                week = emptyList(),
+                dailyQuestionDates = listOf(LocalDate.of(2026, 7, 28), LocalDate.of(2026, 7, 28)),
+            )
+
+        assertEquals(1, recordedDays)
+    }
+
+    private fun diaryDay(
+        day: Int,
+        isDiary: Boolean = true,
+    ): WeeklyReportDay =
+        WeeklyReportDay(
+            diaryId = day.toLong(),
+            day = day,
+            isDiary = isDiary,
+            emotion = TodayMood.HAPPY,
+        )
+}


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
Closes #521 — fix(mindrecord): 주간리포트 기록일수가 일기만 집계 — 데일리질문 기록일 누락으로 상단 카운트와 불일치

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `WeeklyReportViewModel.toSuccessUiState()`의 `recordedDays` 집계를 `report.week.count { it.isDiary }`(일기 요일만)에서 **일기 요일 + 주간 범위 내 데일리질문 답변 날짜의 합집합(중복 제거)** 크기로 변경
- 일기 요일은 week 리스트가 월요일부터 순서대로 내려오는 점을 이용해 `monday.plusDays(index)`로 실제 `LocalDate`로 복원하고, 데일리질문 날짜도 `LocalDate`로 파싱해 합집합을 계산 — day-of-month 충돌 여지 없이 날짜 기준으로 안전하게 중복 제거
- 데일리질문 `date`는 기존 `parseLocalDate`와 동일한 포맷 허용("yyyy.MM.dd 요일" / ISO)으로 관대하게 파싱하되, 파싱 실패 건은 집계에서 제외하고 `[monday, monday+6]` 범위 밖 날짜도 제외 (`parseLocalDateOrNull` 추출, 기존 `parseLocalDate`는 이를 재사용)
- 그 외 UI 상태 매핑 로직은 변경 없음

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- `./gradlew :feature:mindrecord:presentation:compileDebugKotlin` → BUILD SUCCESSFUL (경고는 기존과 동일한 pre-existing 항목)
- WeeklyReportViewModel 대상 기존 단위 테스트는 존재하지 않아 별도 수정 없음

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 이슈 Note의 서버 측 `week[].isDiary` 정합 의심(QA 사례에서 일기 1건인데도 isDiary가 안 내려온 정황)은 이 PR에서 건드리지 않았습니다 — 서버 확인이 필요하며, 본 클라 집계 보정은 데일리질문 기록일 누락만 해소합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
