### PR TITLE
fix(mindrecord): 일기 빈 상태 문구 맥락 정합 — 일기 전용 문구 신설 (closes 522)

### DIFF
--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DiaryScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -30,6 +31,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.afternote.core.ui.asString
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.theme.AfternoteTheme
+import com.afternote.feature.mindrecord.presentation.R
 import com.afternote.feature.mindrecord.presentation.component.DailyCalendar
 import com.afternote.feature.mindrecord.presentation.component.DiaryCard
 import com.afternote.feature.mindrecord.presentation.component.DiaryComponent
@@ -85,7 +87,11 @@ private fun DiaryListContent(
     onYearMonthChanged: (YearMonth) -> Unit = {},
 ) {
     if (isListView && diaries.isEmpty()) {
-        MindRecordEmptyState(modifier = modifier)
+        MindRecordEmptyState(
+            modifier = modifier,
+            title = stringResource(R.string.mindrecord_diary_empty_state_title),
+            description = stringResource(R.string.mindrecord_diary_empty_state_description),
+        )
         return
     }
 

--- a/feature/mindrecord/presentation/src/main/res/values/strings.xml
+++ b/feature/mindrecord/presentation/src/main/res/values/strings.xml
@@ -98,6 +98,8 @@
     <!-- Empty state -->
     <string name="mindrecord_empty_state_title">아직 등록된 답변이 없어요.</string>
     <string name="mindrecord_empty_state_description">답변을 등록해 자신을 알아 보아요.</string>
+    <string name="mindrecord_diary_empty_state_title">아직 등록된 일기가 없어요.</string>
+    <string name="mindrecord_diary_empty_state_description">일기를 작성해 나의 매일을 기록해 보아요.</string>
 
     <!-- Memories card sample question/answer -->
     <string name="mindrecord_memories_card_question">\"내 인생에서 가장 소중했던 순간은?\"</string>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
Closes #522 — fix(mindrecord): 일기 빈 상태 문구가 데일리질문 '답변' 문구를 재사용 — 맥락 불일치

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 일기 전용 빈 상태 문구 리소스 신설: `mindrecord_diary_empty_state_title`("아직 등록된 일기가 없어요."), `mindrecord_diary_empty_state_description`("일기를 작성해 나의 매일을 기록해 보아요.") — 기존 `mindrecord_category_diary_description`("나의 매일을 기록하세요") 톤과 정합
- `DiaryScreen`의 빈 상태 호출에서 신설 리소스를 `title`/`description` 인자로 명시 전달
- `MindRecordEmptyState` 컴포넌트 기본값(`mindrecord_empty_state_title`/`_description`)은 유지 — 데일리질문 화면이 해당 기본값에 의존

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- `./gradlew :feature:mindrecord:presentation:compileDebugKotlin` → BUILD SUCCESSFUL (경고는 기존과 동일한 pre-existing 항목)
- 스크린샷 테스트: `DiaryScreen`/`MindRecordEmptyState`를 참조하는 screenshotTest 소스 없음 — 영향받는 베이스라인 없음

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 신설 문구는 잠정안입니다 — 디자이너 확정 문구가 나오면 리소스 값만 교체하면 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
