### PR TITLE
fix(mindrecord): 오늘 질문 있음·답변 0개 상태 공백 렌더 수정 — 빈 상태 가드 정리 (closes 443)

### DIFF
--- a/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionAnswerListScreen.kt
+++ b/feature/mindrecord/presentation/src/main/kotlin/com/afternote/feature/mindrecord/presentation/screen/sender/DailyQuestionAnswerListScreen.kt
@@ -31,7 +31,6 @@ import com.afternote.feature.mindrecord.presentation.model.DailyQuestion
 import com.afternote.feature.mindrecord.presentation.model.MindRecordCategoryUi
 import com.afternote.feature.mindrecord.presentation.viewmodel.DailyQuestionListUiState
 import com.afternote.feature.mindrecord.presentation.viewmodel.DailyQuestionListViewModel
-import com.afternote.feature.mindrecord.presentation.viewmodel.TodayQuestionUi
 import java.time.YearMonth
 
 @Composable
@@ -55,7 +54,6 @@ fun DailyQuestionAnswerListScreen(
             DailyQuestionListContent(
                 modifier = modifier,
                 isListView = isListView,
-                todayQuestion = state.todayQuestion,
                 answers = state.answers,
                 onDelete = viewModel::delete,
             )
@@ -66,7 +64,6 @@ fun DailyQuestionAnswerListScreen(
 @Composable
 private fun DailyQuestionListContent(
     isListView: Boolean,
-    todayQuestion: TodayQuestionUi?,
     answers: List<DailyQuestion>,
     modifier: Modifier = Modifier,
     onDelete: (Long) -> Unit = {},
@@ -74,7 +71,7 @@ private fun DailyQuestionListContent(
     var yearMonth by remember { mutableStateOf(YearMonth.now()) }
     val onYearMonthChanged: (YearMonth) -> Unit = { yearMonth = it }
 
-    if (isListView && todayQuestion == null && answers.isEmpty()) {
+    if (isListView && answers.isEmpty()) {
         MindRecordEmptyState(modifier = modifier)
         return
     }
@@ -133,7 +130,6 @@ private fun DailyQuestionAnswerListScreenPreviewFalse() {
         DailyQuestionListContent(
             modifier = Modifier,
             isListView = false,
-            todayQuestion = null,
             answers = emptyList(),
         )
     }
@@ -146,7 +142,6 @@ private fun DailyQuestionAnswerListScreenPreviewTrue() {
         DailyQuestionListContent(
             modifier = Modifier,
             isListView = true,
-            todayQuestion = null,
             answers = emptyList(),
         )
     }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
Closes #443 — fix(mindrecord): 오늘 질문 있음·답변 0개 상태에서 데일리 답변 리스트가 공백으로 렌더됨

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `DailyQuestionAnswerListScreen`의 빈 상태 조기반환 가드를 `if (isListView && todayQuestion == null && answers.isEmpty())` → `if (isListView && answers.isEmpty())` 로 변경. PR #438이 리스트 뷰 header 카드(`DailyQuestionWriteHeaderCard`)를 제거한 뒤 남아 있던 `todayQuestion == null` 잔재 조건 때문에, "오늘 질문 있음 + 답변 0개" 상태에서 빈 상태 UI 대신 탭 전체가 공백으로 렌더되던 회귀 수정
- 가드 변경으로 `DailyQuestionListContent`의 `todayQuestion` 파라미터가 이 파일 내에서 완전히 미사용이 되어, 파라미터·호출부·프리뷰 2곳의 전달값 및 `TodayQuestionUi` import 제거 (화면 로컬 정리만 수행, UiState/ViewModel은 미변경)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- `./gradlew :feature:mindrecord:presentation:compileDebugKotlin` 통과 확인
- 스크린샷 테스트 영향 없음: `feature/mindrecord`에는 screenshotTest 소스셋이 없고, 다른 모듈 screenshotTest에서도 이 화면/프리뷰를 참조하지 않아 갱신 대상 베이스라인 없음. 이 파일 내 프리뷰 2개(`DailyQuestionAnswerListScreenPreviewFalse/True`)는 `todayQuestion = null` 전달만 제거되어 렌더 결과 동일

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- `DailyQuestionListUiState.Success.todayQuestion`은 이제 모듈 내 소비처가 없습니다(정의: `DailyQuestionListUiState.kt`, 생성: `DailyQuestionListViewModel.kt`만 남음). 이슈 범위를 벗어나므로 이번 PR에서는 건드리지 않았습니다 — 후속 정리 여부는 판단 부탁드립니다
- 리스트 뷰(`isListView = true`)에서 답변 0개면 이제 항상 `MindRecordEmptyState`가 표시됩니다. 캘린더 뷰(`isListView = false`)는 기존과 동일하게 가드에 걸리지 않습니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)
