### PR TITLE
fix(setting): 공지사항 빈 목록 시 빈 상태 안내 표시 (closes 528)

### DIFF
--- a/feature/setting/presentation/src/main/kotlin/com/afternote/feature/setting/presentation/screen/NoticeListScreen.kt
+++ b/feature/setting/presentation/src/main/kotlin/com/afternote/feature/setting/presentation/screen/NoticeListScreen.kt
@@ -1,16 +1,22 @@
 package com.afternote.feature.setting.presentation.screen
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.topbar.DetailTopBar
 import com.afternote.feature.setting.domain.Notice
+import com.afternote.feature.setting.presentation.R
 import com.afternote.feature.setting.presentation.component.NoticeListItem
 import java.time.LocalDate
 
@@ -24,22 +30,47 @@ fun NoticeListScreen(
     Scaffold(
         topBar = {
             DetailTopBar(
-                title = "공지사항",
+                title = stringResource(R.string.settings_support_notice),
                 onBackClick = onBackClick,
             )
         },
         containerColor = Color.Transparent,
     ) { innerPadding ->
-        LazyColumn(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding),
-        ) {
-            items(notices) { notice ->
-                NoticeListItem(notice = notice)
+        if (notices.isEmpty()) {
+            NoticeEmptyState(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+            )
+        } else {
+            LazyColumn(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+            ) {
+                items(notices) { notice ->
+                    NoticeListItem(notice = notice)
+                }
             }
         }
+    }
+}
+
+@Composable
+private fun NoticeEmptyState(modifier: Modifier = Modifier) {
+    Box(
+        modifier =
+            modifier
+                .padding(horizontal = 20.dp)
+                .padding(top = 24.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.settings_notice_empty),
+            style = AfternoteDesign.typography.bodyLargeR,
+            color = AfternoteDesign.colors.gray8,
+        )
     }
 }
 
@@ -61,5 +92,14 @@ private fun NoticeListScreenPrev() {
                     content = "개인정보 처리방침이 변경되었습니다.",
                 ),
             ),
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NoticeListScreenEmptyPrev() {
+    NoticeListScreen(
+        onBackClick = {},
+        notices = emptyList(),
     )
 }

--- a/feature/setting/presentation/src/main/res/values/strings.xml
+++ b/feature/setting/presentation/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="settings_support_faq">FAQ</string>
     <string name="settings_support_inquiry">고객센터</string>
     <string name="settings_support_notice">공지사항</string>
+    <string name="settings_notice_empty">등록된 공지사항이 없어요.</string>
     <string name="settings_support_terms">이용약관</string>
     <string name="settings_support_privacy">개인정보 취급방침</string>
     <string name="settings_support_service_info">애프터노트 서비스 안내</string>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- Closes #528 — fix(setting): 공지사항 빈 목록 시 안내 문구 없이 완전 빈 화면

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `NoticeListScreen`에 빈 목록 분기 추가: `notices.isEmpty()`일 때 LazyColumn 대신 빈 상태 안내 UI(`NoticeEmptyState`) 표시
- 빈 상태 스타일은 기존 타임레터(`EmptyTimeLetterContent`)/마인드레코드(`MindRecordEmptyState`) 패턴을 미러링 — `bodyLargeR` 타이포, `gray8` 컬러, horizontal 20dp / top 24dp 패딩 (크로스 모듈 의존성 추가 없이 setting 모듈 내 로컬 컴포저블로 구현)
- 안내 문구 `settings_notice_empty`("등록된 공지사항이 없어요.") 리소스를 feature/setting/presentation `strings.xml`에 추가
- 상단바 타이틀 하드코딩 리터럴 `"공지사항"` → 기존 `settings_support_notice` 리소스로 교체 (이슈 Note 반영)
- 빈 상태 프리뷰 `NoticeListScreenEmptyPrev` 추가

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- `./gradlew :feature:setting:presentation:compileDebugKotlin` 통과 확인
- 기존 목록 프리뷰 + 신규 빈 상태 프리뷰로 렌더 검증
- 스크린샷 테스트 베이스라인 영향 없음: `NoticeListScreen`을 참조하는 스크린샷 테스트가 없고, feature/setting 모듈에는 screenshotTest 소스셋이 존재하지 않음 (app / core:ui / onboarding / afternote 모듈만 보유)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 빈 상태 문구 "등록된 공지사항이 없어요."는 잠정안입니다. 디자이너 확정 문구가 나오면 `settings_notice_empty` 리소스만 수정하면 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
