### PR TITLE
fix(home): 홈 복귀 시 refetch 부재 수정 — 일기 TOTAL·수신인 배지 stale (closes 504)

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigation.kt
@@ -17,7 +17,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.compose.LifecycleResumeEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -106,13 +107,12 @@ fun AppNavigation(
                 // 최초 진입은 VM 의 init { loadHomeSummary() } 가 이미 로드하므로 첫 resume 은 스킵한다.
                 // (rememberSaveable: 다른 화면 이동으로 컴포지션에서 벗어나도 스킵 플래그가 초기화되지 않도록)
                 var isFirstResume by rememberSaveable { mutableStateOf(true) }
-                LifecycleResumeEffect(Unit) {
+                LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
                     if (isFirstResume) {
                         isFirstResume = false
                     } else {
-                        viewModel.loadHomeSummary(isRefresh = true)
+                        viewModel.refreshOnReturn()
                     }
-                    onPauseOrDispose { }
                 }
 
                 HomeTabScreen(

--- a/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/navigation/AppNavigation.kt
@@ -10,10 +10,14 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -97,6 +101,20 @@ fun AppNavigation(
                         appState = appState,
                         onRetryLoad = { viewModel.loadHomeSummary(isRefresh = true) },
                     )
+
+                // 다른 화면(일기·데일리질문 작성, 수신인 지정 등)에서 홈으로 복귀 시 홈 요약 refetch.
+                // 최초 진입은 VM 의 init { loadHomeSummary() } 가 이미 로드하므로 첫 resume 은 스킵한다.
+                // (rememberSaveable: 다른 화면 이동으로 컴포지션에서 벗어나도 스킵 플래그가 초기화되지 않도록)
+                var isFirstResume by rememberSaveable { mutableStateOf(true) }
+                LifecycleResumeEffect(Unit) {
+                    if (isFirstResume) {
+                        isFirstResume = false
+                    } else {
+                        viewModel.loadHomeSummary(isRefresh = true)
+                    }
+                    onPauseOrDispose { }
+                }
+
                 HomeTabScreen(
                     uiState = uiState,
                     actions = homeTabActions,

--- a/app/src/main/java/com/afternote/afternote_fe/screen/HomeTabViewModel.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/HomeTabViewModel.kt
@@ -32,21 +32,44 @@ class HomeTabViewModel
         }
 
         /**
+         * 사용자가 요청한 로드 — 최초 진입, 당겨서 새로고침, 에러 재시도.
+         *
          * @param isRefresh true이면 기존 데이터를 유지한 채 새로고침 스피너만 표시한다.
          */
         fun loadHomeSummary(isRefresh: Boolean = false) {
-            // Job이 아직 살아 있으면 중복 요청을 막는다.
-            if (fetchJob?.isActive == true) return
-
             // 이미 데이터가 있고 새로고침도 아니면 재요청하지 않는다.
             if (_uiState.value is HomeTabUiState.Success && !isRefresh) return
+
+            fetch(showsRefreshingSpinner = isRefresh, keepsStateOnFailure = false)
+        }
+
+        /**
+         * 다른 화면에서 홈으로 복귀했을 때의 자동 갱신.
+         *
+         * 사용자가 요청한 동작이 아니므로 [loadHomeSummary] 와 두 가지가 다르다.
+         * - 상단 스피너를 띄우지 않는다. 홈은 왕복이 잦아 매번 스피너가 뜨면 체감이 크다.
+         * - 실패해도 보고 있던 화면을 유지한다. 일시적 실패로 잘 보고 있던 홈이
+         *   에러 화면으로 대체되면 사용자 입장에서는 인과가 설명되지 않는다.
+         */
+        fun refreshOnReturn() {
+            fetch(showsRefreshingSpinner = false, keepsStateOnFailure = true)
+        }
+
+        private fun fetch(
+            showsRefreshingSpinner: Boolean,
+            keepsStateOnFailure: Boolean,
+        ) {
+            // Job이 아직 살아 있으면 중복 요청을 막는다.
+            if (fetchJob?.isActive == true) return
 
             fetchJob =
                 viewModelScope.launch {
                     val currentState = _uiState.value
-                    if (isRefresh && currentState is HomeTabUiState.Success) {
-                        // 새로고침: 기존 화면을 유지하고 상단 스피너만 표시한다.
-                        _uiState.value = currentState.copy(isRefreshing = true)
+                    if (currentState is HomeTabUiState.Success) {
+                        // 기존 화면을 유지한다. 스피너는 사용자가 요청한 갱신에서만 표시한다.
+                        if (showsRefreshingSpinner) {
+                            _uiState.value = currentState.copy(isRefreshing = true)
+                        }
                     } else {
                         // 초기 진입 또는 에러 재시도: 캐시된 이름이 있으면 placeholder로 즉시 노출한다.
                         _uiState.value =
@@ -57,7 +80,12 @@ class HomeTabViewModel
                         .onSuccess { summary ->
                             _uiState.value = summary.toHomeTabSuccess()
                         }.onFailure { error ->
-                            _uiState.value = HomeTabUiState.Error(error)
+                            _uiState.value =
+                                if (keepsStateOnFailure && currentState is HomeTabUiState.Success) {
+                                    currentState.copy(isRefreshing = false)
+                                } else {
+                                    HomeTabUiState.Error(error)
+                                }
                         }
                 }
         }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
Closes #504 — fix(home): 홈 복귀 시 refetch 부재 — 일기 TOTAL·수신인 지정 배지 재시작 전까지 stale

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- `AppNavigation.kt` 의 `composable<Route.Home>` 블록에 `LifecycleEventEffect(Lifecycle.Event.ON_RESUME)` 배선 — 홈 복귀 시 홈 요약을 재조회해 일기 TOTAL 카운트·'수신인 지정' 배지 stale 해소
- 최초 진입은 VM 의 `init { loadHomeSummary() }` 가 이미 로드하므로 `rememberSaveable` 플래그로 첫 resume 은 스킵 (plain `remember` 는 다른 화면 이동으로 엔트리가 컴포지션에서 벗어나면 초기화되어 복귀 refetch 를 잘못 스킵함) — PR #523 의 마인드레코드 목록 refresh 패턴과 동일
- **`HomeTabViewModel` 에 자동 갱신 전용 진입점 `refreshOnReturn()` 추가.** 초기 구현은 기존 `loadHomeSummary(isRefresh = true)` 를 그대로 재사용했으나, pull-to-refresh 용 실패 처리가 자동 갱신에는 맞지 않아 분리했습니다. 두 경로가 내부 `fetch(...)` 를 공유하되 아래 두 축이 다릅니다.

| | 사용자 요청 (`loadHomeSummary`) | 자동 갱신 (`refreshOnReturn`) |
|---|---|---|
| 상단 스피너 | `isRefresh` 일 때 표시 | 표시 안 함 |
| 실패 시 | `Error` 로 전환 | 기존 `Success` 유지 |

- 사용자가 요청한 로드(최초 진입 · 당겨서 새로고침 · 에러 재시도)의 동작은 종전 그대로입니다. `Success` 가 아닌 상태(최초 진입 · 에러 화면)에서 복귀한 경우는 자동 갱신도 `Loading` → 실패 시 `Error` 로 갑니다 — 유지할 화면이 없는 상황이라 그게 맞다고 봤습니다

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- 동작 변경만 있고 시각 변경 없음. 검증 CI 4종(ktlint · Android Lint · unit test · screenshot) 통과
- 스크린샷 테스트 영향 없음: `HomeTabScreenScreenshotTest` 는 `HomeTabScreen(uiState)` 만 렌더하며 내비게이션 배선은 렌더 경로 밖

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- **왜 실패 시 상태를 유지하는가** — pull-to-refresh 는 사용자가 직접 당긴 동작이라 에러 화면 전환의 인과가 납득되지만, 이 PR 은 탭 복귀마다 자동 실행이라 사용자가 아무것도 하지 않았는데 잘 보고 있던 홈이 날아갑니다. 스피너를 억제한 것도 홈이 왕복이 잦은 화면이라 체감이 커서입니다
- 실패를 완전히 침묵시키는 대신 스낵바를 띄우는 선택지도 있으나 이 PR 에는 넣지 않았습니다 — 홈에 스낵바 호스트를 새로 배선해야 하고, 자동 갱신 실패는 다음 복귀에 자연히 복구되는 성질입니다. 필요하다고 보시면 별도로 올리겠습니다
- 중복 요청 가드를 `fetch()` 안으로 옮기면서 두 검사(job 활성 / Success·비refresh)의 순서가 바뀌었으나 결과는 동일합니다
- 홈 클러스터 스택의 base PR 입니다 — #505 를 다루는 후속 PR(feat/505, base: feat/504)이 이 PR 위에 스택되어 있으니 이 PR 을 먼저 merge 해 주세요
- 범위는 이슈 노트대로 홈 resume refetch 한정 — mindrecord 목록 자체의 저장 후 갱신은 별건(#523)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
