### PR TITLE
feat(app): Firebase Crashlytics 도입 — 배포 빌드 크래시 리포팅 (closes 534)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("afternote.android.navigation")
     alias(libs.plugins.google.services)
     alias(libs.plugins.firebase.app.distribution)
+    alias(libs.plugins.firebase.crashlytics)
     alias(libs.plugins.compose.screenshot)
 }
 
@@ -75,6 +76,11 @@ dependencies {
     // 카카오 OAuth redirect Activity(`com.kakao.sdk.auth.AuthCodeHandlerActivity`)를
     // app 매니페스트에서 직접 참조하므로 컴파일 classpath에 노출 필요.
     implementation(libs.kakao.sdk.auth)
+
+    // Firebase — Crashlytics 는 크래시 자동 수집이라 초기화 코드가 필요 없다.
+    // 버전은 BoM 이 관리하므로 crashlytics 좌표에는 버전을 적지 않는다.
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.crashlytics)
 
     // Core
     implementation(projects.core.network)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,9 +78,12 @@ dependencies {
     implementation(libs.kakao.sdk.auth)
 
     // Firebase — Crashlytics 는 크래시 자동 수집이라 초기화 코드가 필요 없다.
-    // 버전은 BoM 이 관리하므로 crashlytics 좌표에는 버전을 적지 않는다.
+    // 버전은 BoM 이 관리하므로 개별 좌표에는 버전을 적지 않는다.
+    // analytics 는 크래시 직전 사용자 동선(breadcrumb) 수집용 — 없으면 Crashlytics 가
+    // "Could not register handler for breadcrumbs events" 로 기능을 건너뛴다.
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.crashlytics)
+    implementation(libs.firebase.analytics)
 
     // Core
     implementation(projects.core.network)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.INTERNET" />
+
+    <!--
+      광고 SDK 미사용 — Analytics 는 Crashlytics breadcrumb 목적뿐이므로,
+      firebase-analytics(play-services-measurement)가 병합해 오는 광고 ID 권한을 제거한다.
+      https://developer.android.com/build/manage-manifests#node_markers
+    -->
+    <uses-permission
+            android:name="com.google.android.gms.permission.AD_ID"
+            tools:node="remove" />
+    <uses-permission
+            android:name="android.permission.ACCESS_ADSERVICES_AD_ID"
+            tools:node="remove" />
 
     <application
             android:name=".GlobalApplication"
@@ -14,6 +27,17 @@
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
             android:theme="@style/Theme.Afternotefe.Main">
+        <!--
+          광고 ID 수집·광고 개인화 신호 비활성화 — Analytics 는 breadcrumb 전용.
+          https://firebase.google.com/docs/analytics/android/configure-data-collection
+        -->
+        <meta-data
+                android:name="google_analytics_adid_collection_enabled"
+                android:value="false" />
+        <meta-data
+                android:name="google_analytics_default_allow_ad_personalization_signals"
+                android:value="false" />
+
         <activity
                 android:name=".MainActivity"
                 android:exported="true"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.firebase.app.distribution) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
 }
 
 tasks.register<Exec>("installGitHooks") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -112,6 +112,7 @@ screenshot-validation-api = { group = "com.android.tools.screenshot", name = "sc
 konsist = { group = "com.lemonappdev", name = "konsist", version.ref = "konsist" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,8 @@ paging = "3.5.0"
 screenshot = "0.0.1-alpha15"
 googleServices = "4.4.4"
 firebaseAppDistribution = "5.2.1"
+firebaseCrashlytics = "3.0.7"
+firebaseBom = "34.16.0"
 konsist = "0.17.3"
 
 [libraries]
@@ -108,6 +110,8 @@ androidx-paging-runtime = { group = "androidx.paging", name = "paging-runtime", 
 androidx-paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging" }
 screenshot-validation-api = { group = "com.android.tools.screenshot", name = "screenshot-validation-api", version.ref = "screenshot" }
 konsist = { group = "com.lemonappdev", name = "konsist", version.ref = "konsist" }
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -121,3 +125,4 @@ ktlint-gradle = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGra
 compose-screenshot = { id = "com.android.compose.screenshot", version.ref = "screenshot" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 firebase-app-distribution = { id = "com.google.firebase.appdistribution", version.ref = "firebaseAppDistribution" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlytics" }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #534 — feat(app): Firebase Crashlytics 도입 — 배포 빌드 크래시 리포팅

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- Crashlytics Gradle 플러그인 3.0.7 + firebase-bom 34.16.0 을 버전 카탈로그에 등록하고 루트에 `apply false`, app 모듈에 적용 (5f80ee6f)
- `firebase-crashlytics` 의존성 추가 — 크래시 자동 수집이라 별도 초기화 코드 없음 (5f80ee6f)
- `firebase-analytics` 의존성 추가 — 크래시 직전 사용자 동선(breadcrumb) 수집용. 없으면 Crashlytics 가 리시버 등록을 건너뛴다 (82943f90)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 빌드 설정·의존성 추가만. 동작 검증은 아래 실측 로그로 대체.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 빌드 검증: `./gradlew :app:compileDebugKotlin` BUILD SUCCESSFUL. `:app:assembleDebug` · `:app:assembleRelease` 도 성공.
- 버전 근거: 공식 가이드(https://firebase.google.com/docs/crashlytics/android/get-started)의 플러그인 3.0.7 · BoM 34.16.0 표기와 Google Maven 메타데이터 release 값이 일치. 최소 요건(Gradle 8.0 / AGP 8.1.0 / google-services 4.4.1)은 현 Gradle 9.6.1 · AGP 9.2.1 · google-services 4.4.4 로 충족.
- R8 mapping 자동 업로드 확인: release 빌드에서 `:app:uploadCrashlyticsMappingFileRelease` 가 실행·성공. debug 는 minify 를 쓰지 않아 `mappingFileUploadEnabled` 별도 설정은 넣지 않았다.
- E2E 실측: 에뮬에서 강제 크래시 → `Sending report through Google DataTransport` → `crashlyticsreports-pa.googleapis.com` 전송 `Status Code: 200` → Firebase 콘솔 대시보드에 `RuntimeException: Test Crash` 수신 확인. 검증용 코드는 커밋에 포함하지 않았다.
- Analytics 연동 실측: 의존성 추가 후 런타임 로그가 `Could not register handler for breadcrumbs events` → `Registered Firebase Analytics event receiver for breadcrumbs` 로 전환.
- **커밋에 안 잡히는 변경 있음**: `app/google-services.json` 을 콘솔 최신본으로 교체했다(SHA-1 지문 기반 OAuth client 2개 누락분 반영). `.gitignore` 대상이라 diff 에 안 나오니, 각자 로컬 파일도 콘솔에서 최신본을 받아야 한다. 팀 노션 "로컬 빌드 설정 파일" 페이지에도 최신본을 올릴 예정.
- non-fatal(handled 실패) 계측은 이 PR 범위 밖 — #536 에서 진행.
