### PR TITLE
feat(core): Crashlytics non-fatal 오류 계측 — 인증 흐름 handled 실패 기록 (closes 536)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
     implementation(libs.firebase.analytics)
 
     // Core
+    implementation(projects.core.common)
     implementation(projects.core.network)
     implementation(projects.core.ui)
     implementation(projects.core.model)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("afternote.android.navigation")
     alias(libs.plugins.google.services)
     alias(libs.plugins.firebase.app.distribution)
+    alias(libs.plugins.firebase.crashlytics)
     alias(libs.plugins.compose.screenshot)
 }
 
@@ -75,6 +76,11 @@ dependencies {
     // 카카오 OAuth redirect Activity(`com.kakao.sdk.auth.AuthCodeHandlerActivity`)를
     // app 매니페스트에서 직접 참조하므로 컴파일 classpath에 노출 필요.
     implementation(libs.kakao.sdk.auth)
+
+    // Firebase — Crashlytics 는 크래시 자동 수집이라 초기화 코드가 필요 없다.
+    // 버전은 BoM 이 관리하므로 crashlytics 좌표에는 버전을 적지 않는다.
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.crashlytics)
 
     // Core
     implementation(projects.core.network)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,9 +78,12 @@ dependencies {
     implementation(libs.kakao.sdk.auth)
 
     // Firebase — Crashlytics 는 크래시 자동 수집이라 초기화 코드가 필요 없다.
-    // 버전은 BoM 이 관리하므로 crashlytics 좌표에는 버전을 적지 않는다.
+    // 버전은 BoM 이 관리하므로 개별 좌표에는 버전을 적지 않는다.
+    // analytics 는 크래시 직전 사용자 동선(breadcrumb) 수집용 — 없으면 Crashlytics 가
+    // "Could not register handler for breadcrumbs events" 로 기능을 건너뛴다.
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.crashlytics)
+    implementation(libs.firebase.analytics)
 
     // Core
     implementation(projects.core.network)

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -6,6 +6,15 @@
             android:icon="@mipmap/ic_launcher_dev"
             android:roundIcon="@mipmap/ic_launcher_dev"
             tools:replace="android:icon,android:roundIcon">
+        <!--
+          디버그 빌드에서는 크래시·오류 수집을 끕니다.
+          non-fatal 계측(#536) 이후 로그인 실패가 전부 기록되는데, 개발 중 실패(백엔드 미기동,
+          미등록 키 해시 등)까지 배포본과 같은 콘솔에 섞이면 실제 장애 신호를 덮습니다.
+          검증은 release 빌드로 합니다.
+        -->
+        <meta-data
+                android:name="firebase_crashlytics_collection_enabled"
+                android:value="false" />
         <activity
                 android:name="com.afternote.afternote_fe.debug.DebugSettingsActivity"
                 android:exported="true"

--- a/app/src/main/java/com/afternote/afternote_fe/reporting/CrashlyticsErrorReporter.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/reporting/CrashlyticsErrorReporter.kt
@@ -9,11 +9,14 @@ import javax.inject.Inject
 /**
  * [ErrorReporter] 의 Crashlytics 구현.
  *
+ * 채우는 건 [ErrorReporter.writeFailure] 뿐이다 — 무엇을 기록할지 거르는 정책(취소 제외·문구 제거)은
+ * 인터페이스가 이미 태우고 내려보낸다.
+ *
  * Firebase 의존이 app 모듈 밖으로 새지 않도록 구현체를 여기에만 둔다.
  * SDK 싱글톤([Firebase.crashlytics])은 이 어댑터가 직접 잡는다 — 대체가 필요한 층은
  * SDK 핸들이 아니라 [ErrorReporter] 자체이고, 그걸 갈아끼우는 건 Hilt 바인딩에서 한다.
  *
- * [attributes] 의 각 쌍은 이 예외 리포트 하나에 붙는 커스텀 키가 되어, 콘솔에서 이슈를 열고
+ * `attributes` 의 각 쌍은 이 예외 리포트 하나에 붙는 커스텀 키가 되어, 콘솔에서 이슈를 열고
  * 개별 이벤트 리포트까지 들어가면 보인다 — 스택트레이스만으로는 구분 안 되는 "어느 단계·어느
  * 수단에서 깨졌는지"를 남기려는 것이다. 같은 키를 다시 넣으면 값이 덮어써지고,
  * 최대 64쌍·쌍당 1kB 제한이 있다.
@@ -29,7 +32,7 @@ import javax.inject.Inject
 class CrashlyticsErrorReporter
     @Inject
     constructor() : ErrorReporter {
-        override fun recordFailure(
+        override fun writeFailure(
             throwable: Throwable,
             attributes: Map<String, String>,
         ) {

--- a/app/src/main/java/com/afternote/afternote_fe/reporting/CrashlyticsErrorReporter.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/reporting/CrashlyticsErrorReporter.kt
@@ -1,0 +1,47 @@
+package com.afternote.afternote_fe.reporting
+
+import com.afternote.core.common.reporting.ErrorReporter
+import com.google.firebase.Firebase
+import com.google.firebase.crashlytics.crashlytics
+import com.google.firebase.crashlytics.recordException
+import javax.inject.Inject
+
+/**
+ * [ErrorReporter] 의 Crashlytics 구현.
+ *
+ * Firebase 의존이 app 모듈 밖으로 새지 않도록 구현체를 여기에만 둔다.
+ * SDK 싱글톤([Firebase.crashlytics])은 이 어댑터가 직접 잡는다 — 대체가 필요한 층은
+ * SDK 핸들이 아니라 [ErrorReporter] 자체이고, 그걸 갈아끼우는 건 Hilt 바인딩에서 한다.
+ *
+ * [attributes] 의 각 쌍은 이 예외 리포트 하나에 붙는 커스텀 키가 되어, 콘솔에서 이슈를 열고
+ * 개별 이벤트 리포트까지 들어가면 보인다 — 스택트레이스만으로는 구분 안 되는 "어느 단계·어느
+ * 수단에서 깨졌는지"를 남기려는 것이다. 같은 키를 다시 넣으면 값이 덮어써지고,
+ * 최대 64쌍·쌍당 1kB 제한이 있다.
+ * non-fatal 은 즉시 전송이 아니라 다음 fatal 리포트에 실려 가거나 앱 재시작 시 올라간다.
+ * `setCustomKey` 로 전역에 심지 않는 이유는 그렇게 하면 이후에 발생하는 무관한 리포트까지
+ * 그 값을 달고 올라가기 때문이다.
+ * 참고: https://firebase.google.com/docs/crashlytics/android/customize-crash-reports
+ *
+ * `recordException` 의 KDoc 블록 형태는 KTX **최상위 확장 함수**라
+ * `com.google.firebase.crashlytics.recordException` 를 명시적으로 import 해야 잡힌다.
+ * 빠뜨리면 `CustomKeysAndValues` 를 받는 자바 오버로드로 해석돼 인자 타입 불일치로 깨진다.
+ */
+class CrashlyticsErrorReporter
+    @Inject
+    constructor() : ErrorReporter {
+        override fun recordFailure(
+            throwable: Throwable,
+            attributes: Map<String, String>,
+        ) {
+            // 뒤에 붙는 람다는 리시버가 KeyValueBuilder 라 key(..) 를 수식어 없이 부를 수 있다.
+            // key(..) 는 Unit 을 반환하지만 값이 소실되지 않는다 — SDK 가 빌더 인스턴스를 하나
+            // 만들어 이 람다에 넘기고, key(..) 가 거기에 값을 쌓은 뒤 람다가 끝나면 그 빌더를
+            // build 해서 CustomKeysAndValues 로 넘긴다. 반환이 아니라 공유 인스턴스가 전달 경로다.
+            // (name, value) 는 파라미터 둘이 아니라 Map.Entry 하나를 구조 분해한 것 —
+            // 표준 라이브러리가 Map.Entry 에 component1/component2 를 확장으로 제공한다.
+            // https://kotlinlang.org/docs/destructuring-declarations.html
+            Firebase.crashlytics.recordException(throwable) {
+                attributes.forEach { (name, value) -> key(name, value) }
+            }
+        }
+    }

--- a/app/src/main/java/com/afternote/afternote_fe/reporting/ErrorReportingModule.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/reporting/ErrorReportingModule.kt
@@ -1,0 +1,35 @@
+package com.afternote.afternote_fe.reporting
+
+import com.afternote.core.common.reporting.ErrorReporter
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * handled 실패 리포팅 바인딩.
+ *
+ * 다른 모듈은 [ErrorReporter] 추상만 주입받고, 실제 Crashlytics 결선은 여기(app)에서만 일어난다.
+ * 추상을 쓰는 쪽이 구현이 아니라 계약에만 의존하게 하는 배치로, 리포팅 도구를 갈아끼워도
+ * 바뀌는 범위가 이 모듈 안에 갇힌다.
+ * 근거: https://developer.android.com/topic/modularization/patterns
+ *
+ * `@Binds` 만 두고 `@Provides` 는 섞지 않는다 — 같은 모듈에 인스턴스 `@Provides` 를 두면
+ * Dagger 가 거부한다(`@Binds` 는 구현체가 만들어지지 않는 선언이라 호출 대상이 없다).
+ * 둘 다 필요해지면 모듈을 나눠 `includes` 로 엮는 것이 공식 해법이다.
+ * 근거: https://dagger.dev/dev-guide/faq.html
+ */
+@InstallIn(SingletonComponent::class)
+@Module
+interface ErrorReportingModule {
+    /**
+     * 스코프는 구현 클래스가 아니라 이 바인딩에 건다 — 주입받는 쪽은 항상 [ErrorReporter] 타입이라
+     * 여기에 걸어야 실효가 있고, 양쪽에 걸면 같은 객체를 두 번 스코프하는 셈이 된다.
+     * `@Singleton` 이 없으면 요청할 때마다 새 인스턴스가 만들어진다(Hilt 기본은 unscoped).
+     * 근거: https://developer.android.com/training/dependency-injection/hilt-android
+     */
+    @Binds
+    @Singleton
+    fun bindErrorReporter(impl: CrashlyticsErrorReporter): ErrorReporter
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.firebase.app.distribution) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
 }
 
 tasks.register<Exec>("installGitHooks") {

--- a/core/common/src/main/kotlin/com/afternote/core/common/reporting/ErrorReporter.kt
+++ b/core/common/src/main/kotlin/com/afternote/core/common/reporting/ErrorReporter.kt
@@ -1,0 +1,31 @@
+package com.afternote.core.common.reporting
+
+/**
+ * 앱을 죽이지 않고 흡수되는 실패(handled 예외)를 개발자 텔레메트리로 남기는 창구.
+ *
+ * 크래시 리포팅의 자동 수집은 uncaught 예외만 잡는다. 로그인 실패처럼 `Result.failure` 로
+ * 흡수되어 스낵바 한 줄로 끝나는 오류는 이 인터페이스를 거쳐 명시적으로 기록해야
+ * 실기 QA 전까지 미검출로 남지 않는다.
+ *
+ * 구현은 app 모듈에만 두고 여기서는 추상만 노출한다 — presentation·data 레이어가
+ * 크래시 리포팅 SDK 에 직접 의존하지 않게 하기 위함이다.
+ *
+ * 사용자 노출 문구와는 별개 층이다. 여기 기록된 값은 콘솔 전용이고,
+ * 화면에 띄울 문구는 UI 가 따로 정한다.
+ */
+interface ErrorReporter {
+    /**
+     * 실패 [throwable] 을 non-fatal 로 기록한다.
+     *
+     * 사용자가 스스로 취소한 흐름처럼 오류가 아닌 경로는 호출하지 않는다 — 기록되면
+     * 실제 장애의 신호 대 잡음비만 떨어진다.
+     *
+     * @param attributes 이 실패 이벤트에만 붙는 컨텍스트. 어느 단계에서 깨졌는지 구분할
+     *                   최소 정보만 담는다(예: `"stage" to "server_login"`).
+     *                   개인정보·자격증명은 넣지 않는다 — 이메일·토큰·주민번호 금지.
+     */
+    fun recordFailure(
+        throwable: Throwable,
+        attributes: Map<String, String> = emptyMap(),
+    )
+}

--- a/core/common/src/main/kotlin/com/afternote/core/common/reporting/ErrorReporter.kt
+++ b/core/common/src/main/kotlin/com/afternote/core/common/reporting/ErrorReporter.kt
@@ -1,5 +1,7 @@
 package com.afternote.core.common.reporting
 
+import kotlin.coroutines.cancellation.CancellationException
+
 /**
  * 앱을 죽이지 않고 흡수되는 실패(handled 예외)를 개발자 텔레메트리로 남기는 창구.
  *
@@ -15,10 +17,20 @@ package com.afternote.core.common.reporting
  */
 interface ErrorReporter {
     /**
-     * 실패 [throwable] 을 non-fatal 로 기록한다.
+     * 실패 [throwable] 을 non-fatal 로 기록한다. 단 코루틴 취소는 기록하지 않고 반환한다.
      *
      * 사용자가 스스로 취소한 흐름처럼 오류가 아닌 경로는 호출하지 않는다 — 기록되면
      * 실제 장애의 신호 대 잡음비만 떨어진다.
+     *
+     * 취소를 여기서 한 번 더 거르는 이유: 호출부가 넘기는 실패는 대개 `runCatching` 이 만든
+     * `Result` 인데, `runCatching` 은 [CancellationException] 까지 잡아 `Result.failure` 로 만든다.
+     * 그래서 화면 이탈로 스코프가 취소된 정상 경로가 호출부에는 실패로 보인다 — 호출부마다
+     * 걸러 달라고 하면 새 계측 지점이 생길 때마다 빠진다. 정책이므로 창구에서 지킨다.
+     *
+     * 예외 원문도 여기서 버린다: [Throwable.message] 와 cause 체인에는 서버 응답 본문·OAuth
+     * 오류 응답이 그대로 담겨 있을 수 있고, 그 안에 이메일이나 자격증명 조각이 섞이면 콘솔로
+     * 유출된다(실제 로그인 실패 리포트에 서버 문구가 그대로 실린 것을 확인했다). 그래서
+     * [redact] 로 타입·스택트레이스만 남기고, 버린 문구 대신 타입 이름을 속성으로 넘긴다.
      *
      * @param attributes 이 실패 이벤트에만 붙는 컨텍스트. 어느 단계에서 깨졌는지 구분할
      *                   최소 정보만 담는다(예: `"stage" to "server_login"`).
@@ -27,5 +39,54 @@ interface ErrorReporter {
     fun recordFailure(
         throwable: Throwable,
         attributes: Map<String, String> = emptyMap(),
+    ) {
+        if (throwable is CancellationException) return
+        writeFailure(
+            throwable = redact(throwable),
+            attributes = attributes + throwable.typeAttributes(),
+        )
+    }
+
+    /**
+     * 걸러진 실패를 실제 리포팅 백엔드에 쓴다. 구현이 채우는 건 이쪽이고,
+     * 호출부는 정책을 태우는 [recordFailure] 만 쓴다.
+     */
+    fun writeFailure(
+        throwable: Throwable,
+        attributes: Map<String, String>,
     )
 }
+
+/**
+ * 문구를 버리고 타입·스택트레이스만 남긴 사본. 리포팅 백엔드에는 이 사본이 올라간다.
+ *
+ * 원본 클래스를 그대로 쓸 수 없어서(문구가 불변 필드다) 타입 이름을 message 자리에 옮겨
+ * 콘솔에서 어떤 예외였는지 읽히게 하고, 스택트레이스는 원본 것을 복사해 발생 위치를 보존한다.
+ * cause 는 잇지 않는다 — 원인 예외의 문구도 같은 위험을 갖기 때문이다(타입은 아래 속성으로 남는다).
+ */
+private class RedactedFailure(
+    originalType: String,
+) : Throwable(originalType)
+
+private fun redact(throwable: Throwable): Throwable =
+    RedactedFailure(throwable.javaClass.name).apply {
+        stackTrace = throwable.stackTrace
+    }
+
+/**
+ * 버려진 문구 대신 남기는 타입 정보. 콘솔에서 원인 구분·필터에 쓴다.
+ *
+ * `buildMap` 안에서 `javaClass` 를 그냥 쓰면 확장 리시버가 아니라 빌더 자신을 가리키므로
+ * 값은 람다 밖에서 미리 꺼낸다.
+ */
+private fun Throwable.typeAttributes(): Map<String, String> {
+    val type = javaClass.name
+    val causeType = cause?.javaClass?.name
+    return buildMap {
+        put(KEY_ERROR_TYPE, type)
+        causeType?.let { put(KEY_ERROR_CAUSE_TYPE, it) }
+    }
+}
+
+private const val KEY_ERROR_TYPE = "error_type"
+private const val KEY_ERROR_CAUSE_TYPE = "error_cause_type"

--- a/core/common/src/test/java/com/afternote/core/common/reporting/ErrorReporterPolicyTest.kt
+++ b/core/common/src/test/java/com/afternote/core/common/reporting/ErrorReporterPolicyTest.kt
@@ -1,0 +1,97 @@
+package com.afternote.core.common.reporting
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.IOException
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * [ErrorReporter] 창구가 태우는 정책 검증 — 취소 제외, 예외 원문 제거.
+ *
+ * 구현(Crashlytics)이 아니라 인터페이스 기본 구현이 검증 대상이라 fake 로 확인한다.
+ */
+class ErrorReporterPolicyTest {
+    private class FakeErrorReporter : ErrorReporter {
+        val written = mutableListOf<Pair<Throwable, Map<String, String>>>()
+
+        override fun writeFailure(
+            throwable: Throwable,
+            attributes: Map<String, String>,
+        ) {
+            written += throwable to attributes
+        }
+    }
+
+    /** 서버 응답 본문·자격증명 조각이 담길 수 있는 예외를 흉내낸다. */
+    private class ServerFailure(
+        message: String,
+        cause: Throwable? = null,
+    ) : RuntimeException(message, cause)
+
+    @Test
+    fun `코루틴 취소는 기록하지 않는다`() {
+        val reporter = FakeErrorReporter()
+
+        reporter.recordFailure(CancellationException("스코프 취소"))
+
+        assertTrue("취소는 리포팅 백엔드에 도달하면 안 된다", reporter.written.isEmpty())
+    }
+
+    @Test
+    fun `예외 문구는 리포팅 백엔드로 넘어가지 않는다`() {
+        val reporter = FakeErrorReporter()
+        val secret = "user@example.com 계정의 토큰 abc123 이 유효하지 않습니다"
+
+        reporter.recordFailure(ServerFailure(secret))
+
+        val (recorded, _) = reporter.written.single()
+        assertEquals("문구 자리에는 타입 이름만 남는다", ServerFailure::class.java.name, recorded.message)
+        assertTrue("원문이 어디에도 남으면 안 된다", secret !in recorded.toString())
+    }
+
+    @Test
+    fun `원인 예외의 문구도 넘어가지 않는다`() {
+        val reporter = FakeErrorReporter()
+        val causeSecret = "Set-Cookie: session=deadbeef"
+
+        reporter.recordFailure(ServerFailure("래핑된 실패", IOException(causeSecret)))
+
+        val (recorded, _) = reporter.written.single()
+        assertNull("cause 는 잇지 않는다 — 원인 문구도 같은 위험이다", recorded.cause)
+        assertTrue(causeSecret !in recorded.toString())
+    }
+
+    @Test
+    fun `버려진 문구 대신 타입 정보를 속성으로 남긴다`() {
+        val reporter = FakeErrorReporter()
+
+        reporter.recordFailure(ServerFailure("문구", IOException("원인")))
+
+        val (_, attributes) = reporter.written.single()
+        assertEquals(ServerFailure::class.java.name, attributes["error_type"])
+        assertEquals(IOException::class.java.name, attributes["error_cause_type"])
+    }
+
+    @Test
+    fun `발생 위치를 잃지 않도록 스택트레이스는 보존한다`() {
+        val reporter = FakeErrorReporter()
+        val original = ServerFailure("문구")
+
+        reporter.recordFailure(original)
+
+        val (recorded, _) = reporter.written.single()
+        assertEquals(original.stackTrace.first(), recorded.stackTrace.first())
+    }
+
+    @Test
+    fun `호출부가 넘긴 속성은 그대로 유지된다`() {
+        val reporter = FakeErrorReporter()
+
+        reporter.recordFailure(ServerFailure("문구"), mapOf("auth_stage" to "login"))
+
+        val (_, attributes) = reporter.written.single()
+        assertEquals("login", attributes["auth_stage"])
+    }
+}

--- a/core/network/src/main/kotlin/com/afternote/core/network/dto/AuthDto.kt
+++ b/core/network/src/main/kotlin/com/afternote/core/network/dto/AuthDto.kt
@@ -53,7 +53,15 @@ data class LoginRequestDto(
     val password: String,
 )
 
-/** Request for unified social login (POST /auth/social/login). */
+/**
+ * Request for unified social login (POST /auth/social/login).
+ *
+ * @property provider 서버가 토큰을 어느 플랫폼에 검증하러 갈지 정하는 값 — `"KAKAO"` / `"GOOGLE"`.
+ * @property accessToken **이름과 달리 provider 마다 종류가 다르다.** 카카오는 OAuth 액세스 토큰
+ *   (`OAuthToken.accessToken`), 구글은 서명된 ID 토큰(`GoogleIdTokenCredential.idToken`) 이 들어간다.
+ *   전자는 서버가 카카오 API 를 호출해야 신원을 알 수 있고, 후자는 서명 검증만으로 알 수 있다.
+ *   필드명은 서버 계약이라 클라에서 바꿀 수 없다 — 해석 분기는 [provider] 가 맡는다.
+ */
 @Serializable
 data class SocialLoginRequestDto(
     val provider: String,

--- a/feature/onboarding/presentation/build.gradle.kts
+++ b/feature/onboarding/presentation/build.gradle.kts
@@ -47,6 +47,9 @@ dependencies {
     implementation(libs.androidx.credentials.play.services.auth)
     implementation(libs.googleid)
 
+    // ViewModel 코루틴 테스트 — runTest 로 viewModelScope 를 제어한다.
+    testImplementation(libs.coroutines.test)
+
     // Compose Preview Screenshot Testing (#330)
     screenshotTestImplementation(libs.screenshot.validation.api)
     screenshotTestImplementation(libs.androidx.compose.ui.tooling)

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/findaccount/FindIdViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/findaccount/FindIdViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -55,6 +56,8 @@ class FindIdViewModel
                         _uiState.update { it.copy(isVerificationSent = true, verificationError = null) }
                         startResendCooldown()
                     }.onFailure { error ->
+                        // 취소는 장애가 아니다 — 기록·UI 소비 전에 되던져 전파를 보존한다(전수 정정은 #661).
+                        if (error is CancellationException) throw error
                         errorReporter.recordAuthFailure(AuthFailureStage.FIND_ACCOUNT_CODE_SEND, error)
                         _uiState.update { it.copy(errorMessage = error.message ?: "") }
                     }
@@ -77,6 +80,9 @@ class FindIdViewModel
                     .onSuccess { account ->
                         _uiState.update { it.copy(foundAccount = account) }
                     }.onFailure { error ->
+                        // 취소는 장애가 아니다 — 여기는 계측 대상이 아니지만 실패 UI 로 소비하는 것도
+                        // 막아야 해서 되던진다(전수 정정은 #661).
+                        if (error is CancellationException) throw error
                         // 계측하지 않는다 — 이 응답은 인증번호 오타와 서버 장애가 같은 예외로 와서
                         // 구분할 수단이 없다. 자세한 사유는 AuthFailureStage.FIND_ACCOUNT_CODE_SEND KDoc.
                         _uiState.update { it.copy(verificationError = error.message ?: "") }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/findaccount/FindIdViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/findaccount/FindIdViewModel.kt
@@ -2,7 +2,10 @@ package com.afternote.feature.onboarding.presentation.findaccount
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.core.common.reporting.ErrorReporter
 import com.afternote.core.domain.repository.account.AccountRepository
+import com.afternote.feature.onboarding.presentation.reporting.AuthFailureStage
+import com.afternote.feature.onboarding.presentation.reporting.recordAuthFailure
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -26,6 +29,7 @@ class FindIdViewModel
     @Inject
     constructor(
         private val accountRepository: AccountRepository,
+        private val errorReporter: ErrorReporter,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(FindIdUiState())
         val uiState: StateFlow<FindIdUiState> = _uiState.asStateFlow()
@@ -51,6 +55,7 @@ class FindIdViewModel
                         _uiState.update { it.copy(isVerificationSent = true, verificationError = null) }
                         startResendCooldown()
                     }.onFailure { error ->
+                        errorReporter.recordAuthFailure(AuthFailureStage.FIND_ACCOUNT_CODE_SEND, error)
                         _uiState.update { it.copy(errorMessage = error.message ?: "") }
                     }
                 _uiState.update { it.copy(isSendingCode = false) }
@@ -72,6 +77,8 @@ class FindIdViewModel
                     .onSuccess { account ->
                         _uiState.update { it.copy(foundAccount = account) }
                     }.onFailure { error ->
+                        // 계측하지 않는다 — 이 응답은 인증번호 오타와 서버 장애가 같은 예외로 와서
+                        // 구분할 수단이 없다. 자세한 사유는 AuthFailureStage.FIND_ACCOUNT_CODE_SEND KDoc.
                         _uiState.update { it.copy(verificationError = error.message ?: "") }
                     }
                 _uiState.update { it.copy(isVerifying = false) }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginEntry.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginEntry.kt
@@ -22,6 +22,7 @@ import com.afternote.feature.onboarding.presentation.R
 import com.afternote.feature.onboarding.presentation.login.social.UserCancelledAuthException
 import com.afternote.feature.onboarding.presentation.login.social.requestGoogleIdToken
 import com.afternote.feature.onboarding.presentation.login.social.requestKakaoAccessToken
+import com.afternote.feature.onboarding.presentation.reporting.AuthProvider
 import kotlinx.coroutines.launch
 
 /**
@@ -106,7 +107,10 @@ fun LoginEntry(
                             .onSuccess { oauthToken ->
                                 viewModel.loginWithKakao(oauthToken)
                             }.onFailure { exception ->
+                                // 카카오 동의 화면·계정 로그인 창을 사용자가 닫은 경우(ClientErrorCause.Cancelled).
+                                // 장애가 아니라 정상적인 이탈이므로 리포팅하지 않는다.
                                 if (exception is UserCancelledAuthException) return@onFailure
+                                viewModel.onSocialTokenRequestFailed(AuthProvider.KAKAO, exception)
                                 showErrorSnackbar(exception.message ?: kakaoFailedMessage)
                             }
                     }
@@ -127,10 +131,17 @@ fun LoginEntry(
                     }.onFailure { exception ->
                         val message =
                             when (exception) {
+                                // 계정 선택 시트를 사용자가 닫은 경우(GetCredentialCancellationException,
+                                // 내부 타입 TYPE_USER_CANCELED). 정상적인 이탈이라 리포팅하지 않는다.
                                 is UserCancelledAuthException -> return@onFailure
+
+                                // 반면 이건 취소가 아니라 "쓸 계정이 없어 로그인 불가"라 리포팅 대상이다 —
+                                // 배포본 소셜 로그인 불능을 잡아내려면 이쪽이 신호여야 한다.
                                 is NoCredentialException -> googleNoCredentialsMessage
+
                                 else -> exception.message ?: googleFailedMessage
                             }
+                        viewModel.onSocialTokenRequestFailed(AuthProvider.GOOGLE, exception)
                         showErrorSnackbar(message)
                     }
                 }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 
 @HiltViewModel
 class LoginViewModel
@@ -98,6 +99,10 @@ class LoginViewModel
                             }
                         }
                     }.onFailure { exception ->
+                        // 화면 이탈로 스코프가 취소된 것을 장애로 기록하거나 실패 UI 로 소비하지 않는다.
+                        // suspend 호출을 감싼 runCatching 이 취소까지 Result.failure 로 만들기 때문에
+                        // 여기까지 들어온다 — 전파를 끊지 않도록 즉시 되던진다(전수 정정은 #661).
+                        if (exception is CancellationException) throw exception
                         errorReporter.recordAuthFailure(
                             stage = AuthFailureStage.LOGIN,
                             throwable = exception,

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/login/LoginViewModel.kt
@@ -2,8 +2,12 @@ package com.afternote.feature.onboarding.presentation.login
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.core.common.reporting.ErrorReporter
 import com.afternote.core.domain.usecase.auth.LoginType
 import com.afternote.core.domain.usecase.auth.LoginUseCase
+import com.afternote.feature.onboarding.presentation.reporting.AuthFailureStage
+import com.afternote.feature.onboarding.presentation.reporting.AuthProvider
+import com.afternote.feature.onboarding.presentation.reporting.recordAuthFailure
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,6 +20,7 @@ class LoginViewModel
     @Inject
     constructor(
         private val loginUseCase: LoginUseCase,
+        private val errorReporter: ErrorReporter,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(LoginUiState())
         val uiState = _uiState.asStateFlow()
@@ -44,6 +49,23 @@ class LoginViewModel
 
         fun loginWithGoogle(idToken: String) {
             login(LoginType.Google(idToken))
+        }
+
+        /**
+         * 소셜 SDK 에서 토큰을 받아오지 못한 실패를 기록한다.
+         *
+         * 이 단계는 서버 호출 이전이라 [login] 경로를 타지 않아, UI 가 직접 알려주지 않으면
+         * 콘솔에 아무 흔적도 남지 않는다. 사용자 취소는 오류가 아니므로 UI 가 걸러서 호출한다.
+         */
+        fun onSocialTokenRequestFailed(
+            provider: AuthProvider,
+            throwable: Throwable,
+        ) {
+            errorReporter.recordAuthFailure(
+                stage = AuthFailureStage.SOCIAL_TOKEN_REQUEST,
+                throwable = throwable,
+                provider = provider,
+            )
         }
 
         /** UI 가 [LoginUiState.isLoggedIn] 소비 후 reset. */
@@ -76,6 +98,11 @@ class LoginViewModel
                             }
                         }
                     }.onFailure { exception ->
+                        errorReporter.recordAuthFailure(
+                            stage = AuthFailureStage.LOGIN,
+                            throwable = exception,
+                            provider = loginType.authProvider,
+                        )
                         _uiState.update {
                             // message 가 null 이면 빈 문자열로 두어 실패 사실이 소실되지 않게 한다.
                             // (null 은 "에러 없음"과 구분되지 않아 스낵바가 무음 처리되던 버그. UI 가 ifBlank 로 일반 문구 폴백.)
@@ -85,3 +112,11 @@ class LoginViewModel
             }
         }
     }
+
+private val LoginType.authProvider: AuthProvider
+    get() =
+        when (this) {
+            is LoginType.Email -> AuthProvider.EMAIL
+            is LoginType.Kakao -> AuthProvider.KAKAO
+            is LoginType.Google -> AuthProvider.GOOGLE
+        }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/reporting/AuthFailureReporting.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/reporting/AuthFailureReporting.kt
@@ -1,0 +1,74 @@
+package com.afternote.feature.onboarding.presentation.reporting
+
+import com.afternote.core.common.reporting.ErrorReporter
+
+/**
+ * 인증 흐름에서 실패가 발생한 지점.
+ *
+ * [reportingName] 은 리포팅 콘솔의 필터 값이다. 바꾸면 그 시점 이후 기록이 기존 이슈 그룹과
+ * 끊겨 추이를 잃으므로, 단계 자체가 사라지지 않는 한 유지한다.
+ */
+enum class AuthFailureStage(
+    val reportingName: String,
+) {
+    /** 소셜 SDK 에서 토큰을 받아오는 단계 — 서버 호출 이전. */
+    SOCIAL_TOKEN_REQUEST("social_token_request"),
+
+    /** 획득한 자격증명으로 서버 로그인을 호출하는 단계. */
+    LOGIN("login"),
+
+    /** 회원가입 이메일 인증번호 발송. */
+    EMAIL_CODE_SEND("email_code_send"),
+
+    /** 회원가입 이메일 인증번호 검증 — 인증번호 불일치·만료는 제외(사용자 입력 오류). */
+    EMAIL_VERIFY("email_verify"),
+
+    /**
+     * 아이디 찾기 인증번호 발송 — 회원가입용 [EMAIL_CODE_SEND] 와 엔드포인트가 달라 따로 센다.
+     *
+     * 짝이 되는 "인증번호 확인"(`auth/email/find`)은 계측하지 않는다. 그 응답은 인증번호 오타와
+     * 서버 장애가 같은 예외로 와서 클라이언트가 구분할 수단이 없고, 오타까지 기록하면
+     * 보관 한도(최근 8건)를 사용자 오류가 차지한다. 서버가 사유를 구분해 주면 그때 추가한다.
+     */
+    FIND_ACCOUNT_CODE_SEND("find_account_code_send"),
+
+    /** 회원가입 최종 제출. */
+    SIGN_UP("sign_up"),
+
+    /** 가입 성공 직후의 자동 로그인 — 여기서 깨지면 가입은 됐는데 로그인 화면으로 되돌아간다. */
+    AUTO_LOGIN_AFTER_SIGN_UP("auto_login_after_sign_up"),
+}
+
+/** 로그인 수단. 어느 경로에서 실패가 몰리는지 구분한다. */
+enum class AuthProvider(
+    val reportingName: String,
+) {
+    EMAIL("email"),
+    KAKAO("kakao"),
+    GOOGLE("google"),
+}
+
+/**
+ * 인증 흐름의 handled 실패를 공통 키 규격으로 기록한다.
+ *
+ * 사용자 취소처럼 오류가 아닌 경로는 호출부에서 걸러 넘기지 않는다.
+ *
+ * @param provider 수단 구분이 의미 없는 단계(회원가입 등)에서는 생략한다.
+ */
+fun ErrorReporter.recordAuthFailure(
+    stage: AuthFailureStage,
+    throwable: Throwable,
+    provider: AuthProvider? = null,
+) {
+    recordFailure(
+        throwable = throwable,
+        attributes =
+            buildMap {
+                put(KEY_AUTH_STAGE, stage.reportingName)
+                provider?.let { put(KEY_AUTH_PROVIDER, it.reportingName) }
+            },
+    )
+}
+
+private const val KEY_AUTH_STAGE = "auth_stage"
+private const val KEY_AUTH_PROVIDER = "auth_provider"

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -120,6 +121,8 @@ class SignUpViewModel
                         _uiState.update { it.copy(isVerificationSent = true, verificationError = null) }
                         startResendCooldown()
                     }.onFailure { error ->
+                        // 취소는 장애가 아니다 — 기록·UI 소비 전에 되던져 전파를 보존한다(전수 정정은 #661).
+                        if (error is CancellationException) throw error
                         errorReporter.recordAuthFailure(AuthFailureStage.EMAIL_CODE_SEND, error)
                         _uiState.update { it.copy(errorMessage = error.message ?: "") }
                     }
@@ -159,6 +162,8 @@ class SignUpViewModel
                     ).onSuccess {
                         _uiState.update { it.copy(shouldNavigateToResidentNumber = true) }
                     }.onFailure { error ->
+                        // 취소는 장애가 아니다 — 기록·UI 소비 전에 되던져 전파를 보존한다(전수 정정은 #661).
+                        if (error is CancellationException) throw error
                         if (error is EmailVerificationException) {
                             // 표시 문구는 화면의 고정 리소스 — 이 값은 인라인 표시 트리거 + 디버깅용 원문.
                             // 인증번호 불일치·만료는 정상적인 사용자 입력 오류라 리포팅하지 않는다.
@@ -200,6 +205,8 @@ class SignUpViewModel
                             .onSuccess {
                                 _uiState.update { it.copy(isSignedUp = true) }
                             }.onFailure { error ->
+                                // 취소는 장애가 아니다 — 기록·UI 소비 전에 되던져 전파를 보존한다(전수 정정은 #661).
+                                if (error is CancellationException) throw error
                                 errorReporter.recordAuthFailure(
                                     stage = AuthFailureStage.AUTO_LOGIN_AFTER_SIGN_UP,
                                     throwable = error,
@@ -212,6 +219,8 @@ class SignUpViewModel
                                 }
                             }
                     }.onFailure { error ->
+                        // 취소는 장애가 아니다 — 기록·UI 소비 전에 되던져 전파를 보존한다(전수 정정은 #661).
+                        if (error is CancellationException) throw error
                         errorReporter.recordAuthFailure(AuthFailureStage.SIGN_UP, error)
                         _uiState.update { it.copy(errorMessage = error.message ?: "") }
                     }

--- a/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
+++ b/feature/onboarding/presentation/src/main/java/com/afternote/feature/onboarding/presentation/signup/SignUpViewModel.kt
@@ -2,10 +2,14 @@ package com.afternote.feature.onboarding.presentation.signup
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.core.common.reporting.ErrorReporter
 import com.afternote.core.domain.error.EmailVerificationException
 import com.afternote.core.domain.repository.account.AccountRepository
 import com.afternote.core.domain.usecase.auth.LoginType
 import com.afternote.core.domain.usecase.auth.LoginUseCase
+import com.afternote.feature.onboarding.presentation.reporting.AuthFailureStage
+import com.afternote.feature.onboarding.presentation.reporting.AuthProvider
+import com.afternote.feature.onboarding.presentation.reporting.recordAuthFailure
 import com.afternote.feature.onboarding.presentation.signup.SignUpViewModel.Companion.RESEND_COOLDOWN_SECONDS
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -16,6 +20,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * 회원가입 플로우 전체에서 공유되는 뷰모델.
@@ -35,6 +40,7 @@ class SignUpViewModel
     constructor(
         private val accountRepository: AccountRepository,
         private val loginUseCase: LoginUseCase,
+        private val errorReporter: ErrorReporter,
     ) : ViewModel() {
         companion object {
             /** "재전송" 클릭 후 다음 요청까지 강제 대기 초. 서버 비용 · SMS 발송량 보호. */
@@ -114,6 +120,7 @@ class SignUpViewModel
                         _uiState.update { it.copy(isVerificationSent = true, verificationError = null) }
                         startResendCooldown()
                     }.onFailure { error ->
+                        errorReporter.recordAuthFailure(AuthFailureStage.EMAIL_CODE_SEND, error)
                         _uiState.update { it.copy(errorMessage = error.message ?: "") }
                     }
                 _uiState.update { it.copy(isSendingCode = false) }
@@ -127,7 +134,7 @@ class SignUpViewModel
                 viewModelScope.launch {
                     _uiState.update { it.copy(resendCooldownSeconds = RESEND_COOLDOWN_SECONDS) }
                     while (_uiState.value.resendCooldownSeconds > 0) {
-                        delay(1000)
+                        delay(1000.milliseconds)
                         _uiState.update { it.copy(resendCooldownSeconds = it.resendCooldownSeconds - 1) }
                     }
                 }
@@ -154,8 +161,10 @@ class SignUpViewModel
                     }.onFailure { error ->
                         if (error is EmailVerificationException) {
                             // 표시 문구는 화면의 고정 리소스 — 이 값은 인라인 표시 트리거 + 디버깅용 원문.
+                            // 인증번호 불일치·만료는 정상적인 사용자 입력 오류라 리포팅하지 않는다.
                             _uiState.update { it.copy(verificationError = error.serverMessage ?: "") }
                         } else {
+                            errorReporter.recordAuthFailure(AuthFailureStage.EMAIL_VERIFY, error)
                             _uiState.update { it.copy(errorMessage = error.message ?: "이메일 인증 실패") }
                         }
                     }
@@ -191,6 +200,11 @@ class SignUpViewModel
                             .onSuccess {
                                 _uiState.update { it.copy(isSignedUp = true) }
                             }.onFailure { error ->
+                                errorReporter.recordAuthFailure(
+                                    stage = AuthFailureStage.AUTO_LOGIN_AFTER_SIGN_UP,
+                                    throwable = error,
+                                    provider = AuthProvider.EMAIL,
+                                )
                                 _uiState.update {
                                     it.copy(
                                         errorMessage = error.message ?: "자동 로그인에 실패했어요. 로그인 화면에서 다시 시도해주세요.",
@@ -198,6 +212,7 @@ class SignUpViewModel
                                 }
                             }
                     }.onFailure { error ->
+                        errorReporter.recordAuthFailure(AuthFailureStage.SIGN_UP, error)
                         _uiState.update { it.copy(errorMessage = error.message ?: "") }
                     }
                 _uiState.update { it.copy(isLoading = false) }

--- a/feature/onboarding/presentation/src/test/java/com/afternote/feature/onboarding/presentation/login/LoginViewModelReportingTest.kt
+++ b/feature/onboarding/presentation/src/test/java/com/afternote/feature/onboarding/presentation/login/LoginViewModelReportingTest.kt
@@ -1,0 +1,150 @@
+package com.afternote.feature.onboarding.presentation.login
+
+import com.afternote.core.common.reporting.ErrorReporter
+import com.afternote.core.domain.repository.auth.AuthRepository
+import com.afternote.core.domain.usecase.auth.LoginUseCase
+import com.afternote.core.model.Session
+import com.afternote.core.model.TokenBundle
+import com.afternote.feature.onboarding.presentation.reporting.AuthProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * 로그인 실패가 어떤 키로 기록되는지, 그리고 코루틴 취소가 실패로 취급되지 않는지 검증한다.
+ *
+ * 리포팅은 실패했을 때만 동작하므로 [FakeAuthRepository] 는 모든 로그인 경로를 실패로 고정한다.
+ */
+class LoginViewModelReportingTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        // viewModelScope 가 Dispatchers.Main 을 쓰므로 테스트 디스패처로 바꿔 실행 시점을 제어한다.
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private class FakeErrorReporter : ErrorReporter {
+        val written = mutableListOf<Map<String, String>>()
+
+        override fun writeFailure(
+            throwable: Throwable,
+            attributes: Map<String, String>,
+        ) {
+            written += attributes
+        }
+    }
+
+    /** 로그인 3경로를 [failure] 로 고정한다. 나머지는 이 테스트에서 호출되지 않는다. */
+    private class FakeAuthRepository(
+        private val failure: Throwable,
+    ) : AuthRepository {
+        override val isLoggedIn: Flow<Boolean> get() = error("미사용")
+
+        override suspend fun defaultLogin(
+            email: String,
+            password: String,
+        ): Result<Session.DefaultSession> = Result.failure(failure)
+
+        override suspend fun kakaoLogin(oauthToken: String): Result<Session.SocialSession> = Result.failure(failure)
+
+        override suspend fun googleLogin(idToken: String): Result<Session.SocialSession> = Result.failure(failure)
+
+        override suspend fun saveSession(
+            accessToken: String,
+            refreshToken: String,
+        ): Result<Unit> = error("미사용")
+
+        override suspend fun updateTokens(
+            accessToken: String,
+            refreshToken: String,
+        ): Result<Unit> = error("미사용")
+
+        override suspend fun clearSession(): Result<Unit> = error("미사용")
+
+        override suspend fun getAccessToken(): Result<String?> = error("미사용")
+
+        override suspend fun getRefreshToken(): Result<String?> = error("미사용")
+
+        override suspend fun rotateToken(): Result<TokenBundle> = error("미사용")
+
+        override suspend fun logout(): Result<Unit> = error("미사용")
+    }
+
+    private fun viewModelWith(
+        failure: Throwable,
+        reporter: ErrorReporter,
+    ) = LoginViewModel(
+        loginUseCase = LoginUseCase(FakeAuthRepository(failure)),
+        errorReporter = reporter,
+    )
+
+    @Test
+    fun `카카오 로그인 실패는 login 단계와 kakao 수단으로 기록된다`() =
+        runTest(dispatcher) {
+            val reporter = FakeErrorReporter()
+            val viewModel = viewModelWith(RuntimeException("서버 거절"), reporter)
+
+            viewModel.loginWithKakao("oauth-token")
+            advanceUntilIdle()
+
+            val attributes = reporter.written.single()
+            assertEquals("login", attributes["auth_stage"])
+            assertEquals("kakao", attributes["auth_provider"])
+        }
+
+    @Test
+    fun `이메일 로그인 실패는 email 수단으로 기록된다`() =
+        runTest(dispatcher) {
+            val reporter = FakeErrorReporter()
+            val viewModel = viewModelWith(RuntimeException("서버 거절"), reporter)
+
+            viewModel.loginWithEmail()
+            advanceUntilIdle()
+
+            assertEquals("email", reporter.written.single()["auth_provider"])
+        }
+
+    @Test
+    fun `소셜 토큰 획득 실패는 social_token_request 단계로 기록된다`() =
+        runTest(dispatcher) {
+            val reporter = FakeErrorReporter()
+            val viewModel = viewModelWith(RuntimeException("미사용"), reporter)
+
+            viewModel.onSocialTokenRequestFailed(AuthProvider.GOOGLE, RuntimeException("SDK 실패"))
+
+            val attributes = reporter.written.single()
+            assertEquals("social_token_request", attributes["auth_stage"])
+            assertEquals("google", attributes["auth_provider"])
+        }
+
+    @Test
+    fun `코루틴 취소는 기록하지도 실패 상태로 소비하지도 않는다`() =
+        runTest(dispatcher) {
+            val reporter = FakeErrorReporter()
+            // 화면 이탈로 스코프가 취소되면 runCatching 이 이걸 Result.failure 로 만들어 넘긴다.
+            val viewModel = viewModelWith(CancellationException("스코프 취소"), reporter)
+
+            viewModel.loginWithKakao("oauth-token")
+            advanceUntilIdle()
+
+            assertTrue("취소는 리포팅 대상이 아니다", reporter.written.isEmpty())
+            assertNull("취소를 실패 문구로 띄우면 안 된다", viewModel.uiState.value.errorMessage)
+        }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -112,6 +112,7 @@ screenshot-validation-api = { group = "com.android.tools.screenshot", name = "sc
 konsist = { group = "com.lemonappdev", name = "konsist", version.ref = "konsist" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,8 @@ paging = "3.5.0"
 screenshot = "0.0.1-alpha15"
 googleServices = "4.4.4"
 firebaseAppDistribution = "5.2.1"
+firebaseCrashlytics = "3.0.7"
+firebaseBom = "34.16.0"
 konsist = "0.17.3"
 
 [libraries]
@@ -108,6 +110,8 @@ androidx-paging-runtime = { group = "androidx.paging", name = "paging-runtime", 
 androidx-paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging" }
 screenshot-validation-api = { group = "com.android.tools.screenshot", name = "screenshot-validation-api", version.ref = "screenshot" }
 konsist = { group = "com.lemonappdev", name = "konsist", version.ref = "konsist" }
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -121,3 +125,4 @@ ktlint-gradle = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGra
 compose-screenshot = { id = "com.android.compose.screenshot", version.ref = "screenshot" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 firebase-app-distribution = { id = "com.google.firebase.appdistribution", version.ref = "firebaseAppDistribution" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlytics" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -100,6 +100,7 @@ coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref 
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 compose-wheel-picker = { group = "com.github.zj565061763", name = "compose-wheel-picker", version.ref = "composeWheelPicker" }
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
+coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
 androidx-startup-runtime = { group = "androidx.startup", name = "startup-runtime", version.ref = "startupRuntime" }
 androidx-navigation-common-ktx = { group = "androidx.navigation", name = "navigation-common-ktx", version.ref = "navigationCommonKtx" }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #536 — feat(core): Crashlytics non-fatal 오류 계측 — 소셜 로그인 등 handled 실패 기록

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `core:common` 에 `ErrorReporter` 추상 정의 — presentation·data 가 Firebase SDK 에 직접 의존하지 않도록 계약만 노출 (e62bd86)
- `app` 에 `CrashlyticsErrorReporter` + `ErrorReportingModule(@Binds)` — Firebase 의존을 app 모듈 안에 가둠 (e62bd86)
- 인증 흐름 7개 지점에 단계별 실패 기록 (eae3295) — 소셜 SDK 토큰 획득, 서버 로그인, 회원가입 인증번호 발송·검증, 가입 제출, 가입 후 자동 로그인, 아이디 찾기 인증번호 발송
- 리포트에 붙는 키 규격을 `AuthFailureStage`·`AuthProvider` enum 으로 고정 (`auth_stage` / `auth_provider`) — 콘솔 필터 값이라 문자열 표류 방지
- debug 빌드 크래시·오류 수집 차단 (`firebase_crashlytics_collection_enabled=false`)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 계측 호출과 주석만 추가했고 화면 출력·레이아웃은 그대로입니다. Compose Preview 스크린샷 baseline 변경 없음.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- **stack base 의존**: 이 PR 의 base 는 `feat/534`(#543)입니다. #543 이 먼저 머지돼야 하고, 머지 시 base 를 develop 으로 바꿔야 합니다.
- **이슈 범위 밖 판단 2건**을 포함했습니다. 빼는 게 낫다면 알려주세요.
  1. debug 빌드 수집 차단 — 계측 후에는 개발 중 실패(백엔드 미기동, 미등록 카카오 키 해시)가 전부 배포본과 같은 콘솔로 올라가 실제 장애 신호를 덮습니다.
  2. 아이디 찾기 인증번호 발송 계측 — 이슈 본문은 "로그인/회원가입" 이지만 회원가입의 `sendEmailCode` 와 성격이 같아 함께 넣었습니다.
- **의도적으로 제외한 경로**: 사용자 취소(카카오 `ClientErrorCause.Cancelled`, 구글 `GetCredentialCancellationException`), 회원가입 인증번호 불일치·만료, 아이디 찾기 인증번호 확인. 마지막 것은 오타와 서버 장애가 같은 예외로 와서 구분할 수단이 없기 때문이고, Crashlytics 가 최근 8건만 보관해 잡음이 실제 장애를 밀어냅니다.
- **계측 확대는 #544 로 분리**했습니다(홈·애프터노트 13개 파일). `ErrorReporter` 가 `core:common` 에 있어 주입만 하면 됩니다.
- **실측 검증**: debug 수집 플래그를 임시로 켠 빌드에서 로그인 실패 → logcat `Persisting non-fatal event for session ...` + `disk worker: log non-fatal event to persistence` 확인 후 원복. 기기에 저장된 리포트 JSON 에서 `exception.type`·`exception.reason`·`customAttributes(auth_stage=login, auth_provider=email)` 동봉 확인.
- 빌드 검증: `./gradlew :core:common:compileDebugKotlin :core:network:compileDebugKotlin :feature:onboarding:presentation:compileDebugKotlin :app:compileDebugKotlin ktlintCheck` BUILD SUCCESSFUL
