### PR TITLE
chore(ci): release-distribution 워크플로 workflow_dispatch 트리거 추가 (closes 578)

### DIFF
--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -13,6 +13,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# 트리거가 둘로 늘면서 두 배포 경로가 겹칠 수 있게 됐다 — develop 기준 수동 테스터 배포 도중
+# main 릴리스 push 가 들어오면 러너 둘이 각각 빌드해 같은 App Distribution 앱에 올린다.
+# 한 그룹으로 묶어 직렬화한다. cancel-in-progress 는 기본값(false) 그대로 두어 진행 중인
+# 배포를 죽이지 않고 뒤차를 대기시킨다 — 릴리스 배포가 수동 배포에 밀려 취소되면 안 된다.
+# https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency
+concurrency:
+  group: release-distribution
+
 permissions:
   contents: read
 

--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -1,11 +1,17 @@
 name: Release Distribution (Firebase App Distribution)
 
-# main 브랜치 push 시점에만 실행. PR / 다른 브랜치에서는 트리거되지 않음 —
-# "main 머지된 상태만 배포" 운영 정책에 맞춤. 수동 트리거 (1hyok 머신) 는 fallback 으로 유지.
+# 트리거 둘. 팀 운영은 "main 은 릴리스 때만 머지, 테스터 배포는 develop 기준으로 수시" 이므로
+# 배포 경로도 둘로 나뉜다:
+#   - push: [main]      릴리스 시 자동 배포.
+#   - workflow_dispatch  develop 등 임의 브랜치에서 수동 테스터 배포. 실행할 ref 를 골라 돌린다.
+# workflow_dispatch 는 워크플로 파일이 default branch(= develop) 에 있어야 트리거된다 —
+# https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows
+# PR 에서는 어느 쪽으로도 트리거되지 않는다.
 
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -3,7 +3,7 @@ name: Release Distribution (Firebase App Distribution)
 # 트리거 둘. 팀 운영은 "main 은 릴리스 때만 머지, 테스터 배포는 develop 기준으로 수시" 이므로
 # 배포 경로도 둘로 나뉜다:
 #   - push: [main]      릴리스 시 자동 배포.
-#   - workflow_dispatch  develop 등 임의 브랜치에서 수동 테스터 배포. 실행할 ref 를 골라 돌린다.
+#   - workflow_dispatch  수동 테스터 배포. 실행할 ref 를 고르되 develop·main 만 허용한다(아래 가드).
 # workflow_dispatch 는 워크플로 파일이 default branch(= develop) 에 있어야 트리거된다 —
 # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows
 # PR 에서는 어느 쪽으로도 트리거되지 않는다.
@@ -28,7 +28,29 @@ jobs:
   distribute:
     name: Build Release and Upload to Firebase App Distribution
     runs-on: ubuntu-latest
+    # 배포 secret 을 environment secret 뒤로 옮기고 deployment branch 제한·required reviewer 를
+    # 걸기 위한 연결점. 보호 규칙 자체는 워크플로 파일로 지정할 수 없어 Settings → Environments 몫이고,
+    # 참조만 있으면 environment 는 첫 실행 때 생성된다.
+    # https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments
+    environment: release-distribution
     steps:
+      # workflow_dispatch 는 실행할 ref 를 임의로 고를 수 있는데 이 job 은 release keystore 와
+      # Firebase service account 를 secret 으로 받는다. 보호되지 않은 브랜치의 Gradle 스크립트가
+      # 그 값에 닿으면 secret 반출·변조 APK 배포가 가능하므로 checkout 전에 끊는다.
+      # workflow_dispatch 에는 push 와 달리 branches 필터가 없어 job 안에서 막는 수밖에 없다.
+      - name: Restrict manual runs to deployable branches
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          SELECTED_REF: ${{ github.ref }}
+        run: |
+          case "$SELECTED_REF" in
+            refs/heads/develop|refs/heads/main) ;;
+            *)
+              echo "::error::수동 배포는 develop·main 에서만 허용됩니다 (선택된 ref: $SELECTED_REF)"
+              exit 1
+              ;;
+          esac
+
       - name: Clone repo
         uses: actions/checkout@v4
 

--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -1,23 +1,16 @@
 name: Release Distribution (Firebase App Distribution)
 
-# 트리거 둘. 팀 운영은 "main 은 릴리스 때만 머지, 테스터 배포는 develop 기준으로 수시" 이므로
-# 배포 경로도 둘로 나뉜다:
-#   - push: [main]      릴리스 시 자동 배포.
-#   - workflow_dispatch  수동 테스터 배포. 실행할 ref 를 고르되 develop·main 만 허용한다(아래 가드).
-# workflow_dispatch 는 워크플로 파일이 default branch(= develop) 에 있어야 트리거된다 —
+# main 은 릴리스 때만 머지하고 테스터 배포는 수시로 도는 팀 운영이라 배포 경로를 둘로 나눴다.
+# workflow_dispatch 는 워크플로 파일이 default branch(develop) 에 있어야 실행 목록에 뜬다 —
 # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows
-# PR 에서는 어느 쪽으로도 트리거되지 않는다.
 
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
-# 트리거가 둘로 늘면서 두 배포 경로가 겹칠 수 있게 됐다 — develop 기준 수동 테스터 배포 도중
-# main 릴리스 push 가 들어오면 러너 둘이 각각 빌드해 같은 App Distribution 앱에 올린다.
-# 한 그룹으로 묶어 직렬화한다. cancel-in-progress 는 기본값(false) 그대로 두어 진행 중인
-# 배포를 죽이지 않고 뒤차를 대기시킨다 — 릴리스 배포가 수동 배포에 밀려 취소되면 안 된다.
-# https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency
+# 수동 배포 도중 main 릴리스 push 가 들어오면 러너 둘이 같은 App Distribution 앱에 올린다.
+# cancel-in-progress 는 기본값(false) 그대로 — 릴리스 배포가 수동 배포에 밀려 취소되면 안 된다.
 concurrency:
   group: release-distribution
 
@@ -28,16 +21,12 @@ jobs:
   distribute:
     name: Build Release and Upload to Firebase App Distribution
     runs-on: ubuntu-latest
-    # 배포 secret 을 environment secret 뒤로 옮기고 deployment branch 제한·required reviewer 를
-    # 걸기 위한 연결점. 보호 규칙 자체는 워크플로 파일로 지정할 수 없어 Settings → Environments 몫이고,
-    # 참조만 있으면 environment 는 첫 실행 때 생성된다.
-    # https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments
+    # 보호 규칙(deployment branch 제한·required reviewer·environment secret)은 워크플로 파일로
+    # 지정할 수 없다 — 여긴 연결점만 만들고 실제 설정은 Settings → Environments 에서 한다.
     environment: release-distribution
     steps:
-      # workflow_dispatch 는 실행할 ref 를 임의로 고를 수 있는데 이 job 은 release keystore 와
-      # Firebase service account 를 secret 으로 받는다. 보호되지 않은 브랜치의 Gradle 스크립트가
-      # 그 값에 닿으면 secret 반출·변조 APK 배포가 가능하므로 checkout 전에 끊는다.
-      # workflow_dispatch 에는 push 와 달리 branches 필터가 없어 job 안에서 막는 수밖에 없다.
+      # 이 job 은 release keystore·Firebase service account 를 받으므로 임의 ref 실행이 곧 secret 반출이다.
+      # workflow_dispatch 엔 push 와 달리 branches 필터가 없어 checkout 앞에서 직접 막는다.
       - name: Restrict manual runs to deployable branches
         if: github.event_name == 'workflow_dispatch'
         env:


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #578 — chore(ci): release-distribution 워크플로 workflow_dispatch 수동 트리거 추가 — develop 기준 테스터 배포·배포 경로 검증

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `.github/workflows/release-distribution.yml` `on:` 에 `workflow_dispatch` 추가. 기존 `push: [main]` 은 릴리스 자동 배포로 그대로 유지 (858353f2)
- 파일 상단 주석의 운영 정책 서술 교정 — 기존 문구는 "main 머지된 상태만 배포" 였으나, 팀 합의는 main 은 릴리스 때만 머지하고 테스터 배포는 develop 기준으로 수시 실행하는 쪽이다. 배포 경로가 둘로 나뉜다는 점을 주석에 명시

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — CI 워크플로 정의 파일만 변경.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- Kotlin 소스 변경이 없어 Gradle 컴파일 검증 대상이 없다. 대신 YAML 파싱으로 `on` 에 `push`·`workflow_dispatch` 두 트리거가 모두 인식되는 것을 확인했다.
- 이 레포의 default branch 가 `develop` 이므로 `workflow_dispatch` 의 요구조건("This event will only trigger a workflow run if the workflow file exists on the default branch", https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)은 이 PR 머지 시점에 충족된다.
- 이 워크플로는 main 이 05-26 이후 정지 상태라 **실행 이력이 0건**이다(`gh run list` 실측). 머지 후 `gh workflow run release-distribution.yml --ref develop` 으로 첫 실행을 돌려 secret 디코드 → 서명 → App Distribution 업로드 전 구간을 검증할 예정이다.
- #575 가 이 이슈에 `blocked by` 로 걸려 있다. 위 첫 실행 성공이 #575 의 완료 판정이 된다. #575 쪽 사전 조건(배포 secret 8종, App Distribution 그룹·테스터)은 07-28 기준 갖춰져 있다.
- 범위 밖 관찰: 같은 파일 27행 스텝 이름이 `Set up JDK 17` 인데 `java-version` 은 `'21'` 이다. 이름만 스테일한 것으로 동작에는 영향이 없어 이 PR 에서는 건드리지 않았다.
