### PR TITLE
chore(app): debug 빌드 공유 keystore 서명 배선 (closes 533)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🚀 신규 팀원 빌드 셋업
 
-`local.properties` 는 `.gitignore` 에 등록되어 있어 **git 으로 받아지지 않는다**. clone 직후 다음 두 키를 루트 `local.properties` 에 직접 채워야 카카오·구글 로그인이 정상 동작한다.
+`local.properties` 는 `.gitignore` 에 등록되어 있어 **git 으로 받아지지 않는다**. clone 직후 다음 두 키를 루트 `local.properties` 에 직접 채워야 카카오·구글 로그인이 정상 동작한다. 추가로 아래 **공유 debug keystore** 섹션까지 마치면 카카오 키 해시를 본인 머신용으로 따로 등록할 필요가 없다.
 
 ## 필요 키
 
@@ -32,9 +32,32 @@ GOOGLE_WEB_CLIENT_ID=<구글 OAuth web client id>.apps.googleusercontent.com
 - `AndroidManifest.xml` 의 `android:scheme="kakao${KAKAO_NATIVE_APP_KEY}"` 가 빈 scheme 으로 등록 → 카카오 로그인 콜백 intent-filter 매칭 안 됨
 - `requestGoogleIdToken(serverClientId = "")` → Credential Manager 가 invalid request 로 실패
 
+## 공유 debug keystore
+
+debug 빌드는 기본적으로 머신마다 다른 `~/.android/debug.keystore` 로 서명되어, 카카오 로그인 키 해시를 팀원 머신별로 콘솔에 등록해야 한다. 팀 공유 debug keystore 를 배치하면 전 머신이 동일 키 해시로 서명되어 콘솔 등록이 keystore 1개로 끝난다. (미배치 시에도 빌드는 정상 — 기본 debug keystore 폴백 — 대신 본인 머신 키 해시를 직접 등록해야 카카오 로그인이 동작한다.)
+
+1. **keystore 수령·배치** — `afternote-debug-shared.jks` 를 **Slack DM 으로 1hyok 에게 요청** 후 홈 디렉토리에 배치 (예: `~/afternote-debug-shared.jks`)
+
+2. **`local.properties` 끝에 4개 키 추가** (경로는 `~` 없이 **절대경로** — Gradle `file()` 은 `~` 를 확장하지 않는다)
+
+    ```properties
+    DEBUG_STORE_FILE=/Users/<you>/afternote-debug-shared.jks
+    DEBUG_STORE_PASSWORD=<keystore 비밀번호 — keystore 와 함께 전달>
+    DEBUG_KEY_ALIAS=afternote-debug-shared
+    DEBUG_KEY_PASSWORD=<key 비밀번호 — keystore 와 함께 전달>
+    ```
+
+3. **적용 확인** — `./gradlew :app:signingReport` 출력의 `Variant: debug` 에서 `Store:` 가 공유 keystore 경로를 가리키는지 확인
+
+공유 keystore 의 카카오 키 해시 추출 명령 (Kakao Developers → 앱 → 플랫폼 → Android → 키 해시 등록·재확인용):
+
+```bash
+keytool -exportcert -alias afternote-debug-shared -keystore ~/afternote-debug-shared.jks | openssl sha1 -binary | openssl base64
+```
+
 # 📦 비개발자 APK 배포 (Firebase App Distribution)
 
-디자이너·PM·QA·외부 베타테스터에게 release APK 를 자동 배포하는 흐름. Firebase 프로젝트 `afternote-b4d3c` + 테스터 그룹 `afternote` 사용.
+디자이너·PM·QA·외부 베타테스터에게 release APK 를 자동 배포하는 흐름. Firebase 프로젝트 `afternote-android` + 테스터 그룹 `afternote` 사용.
 
 ## 셋업 (1hyok 만 1회 — 신규 인계자도 동일)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,7 +52,7 @@ android {
         //
         // opt-in 이다. AGP 는 debug keystore 를 머신마다 자동 생성하는 것이 기본이고
         // (https://developer.android.com/studio/publish/app-signing), 그 모델을 없애지 않는다 —
-        // `DEBUG_STORE_FILE` 이 없는 머신은 아래 if 를 그냥 건너뛰어 `~/.android/debug.keystore`
+        // `DEBUG_*` 를 적지 않은 머신은 아래 when 의 첫 갈래로 빠져 `~/.android/debug.keystore`
         // 로 서명된다. 빌드·로그인 동작에 차이는 없고, 카카오 콘솔에 본인 해시를 등록하면 된다
         // (카카오는 원래 "모든 개발자의 디버그 키 해시" 등록을 요구:
         //  https://developers.kakao.com/docs/latest/ko/android/getting-started).
@@ -65,13 +65,57 @@ android {
         // 앱은 스토어 배포가 불가능하다("insecure by design", 위 Android 문서). 실수 커밋은
         // 루트 `.gitignore` 의 `*.jks`·`*.keystore` 가 막지만, 전달 경로는 개인 채널로 유지한다.
         // 이 리스크를 받아들이기 싫으면 위 opt-out(프로퍼티 미기재)을 쓰면 된다.
+        //
+        // 네 키는 하나의 단위로 다룬다. `DEBUG_STORE_FILE` 만 보고 진입하면 storeFile 은 공유
+        // keystore 로 바뀌는데 자격 값은 기본 keystore 의 `android` 가 아니라 null 로 덮여,
+        // 폴백도 아니고 원인도 안 보이는 서명 실패가 난다. 부분 기재·경로 오류는 서명 단계까지
+        // 가지 않고 configuration 단계에서 누락 항목을 알리며 끊는다.
         getByName("debug") {
-            val debugStoreFile = localProperties.getProperty("DEBUG_STORE_FILE")
-            if (debugStoreFile != null) {
-                storeFile = file(debugStoreFile)
-                storePassword = localProperties.getProperty("DEBUG_STORE_PASSWORD")
-                keyAlias = localProperties.getProperty("DEBUG_KEY_ALIAS")
-                keyPassword = localProperties.getProperty("DEBUG_KEY_PASSWORD")
+            val debugSigningKeys =
+                listOf(
+                    "DEBUG_STORE_FILE",
+                    "DEBUG_STORE_PASSWORD",
+                    "DEBUG_KEY_ALIAS",
+                    "DEBUG_KEY_PASSWORD",
+                )
+            val provided =
+                debugSigningKeys
+                    .mapNotNull { key ->
+                        localProperties.getProperty(key)?.takeIf { it.isNotBlank() }?.let { key to it }
+                    }.toMap()
+
+            when (provided.size) {
+                0 -> {
+                    // 전부 미기재 — AGP 기본 debug keystore 로 서명(공유 keystore 미수령 머신·CI).
+                }
+
+                debugSigningKeys.size -> {
+                    val sharedKeystore = file(provided.getValue("DEBUG_STORE_FILE"))
+                    if (!sharedKeystore.isFile) {
+                        throw GradleException(
+                            """
+                            |DEBUG_STORE_FILE 이 가리키는 공유 debug keystore 를 찾을 수 없습니다: $sharedKeystore
+                            |파일을 해당 경로에 두거나, DEBUG_* 네 키를 모두 지워 기본 debug keystore 로 되돌리세요.
+                            |설정 방법은 README '공유 debug keystore' 섹션 참고.
+                            """.trimMargin(),
+                        )
+                    }
+                    storeFile = sharedKeystore
+                    storePassword = provided.getValue("DEBUG_STORE_PASSWORD")
+                    keyAlias = provided.getValue("DEBUG_KEY_ALIAS")
+                    keyPassword = provided.getValue("DEBUG_KEY_PASSWORD")
+                }
+
+                else -> {
+                    throw GradleException(
+                        """
+                        |공유 debug keystore 설정이 불완전합니다.
+                        |루트 local.properties 누락 항목: ${(debugSigningKeys - provided.keys).joinToString()}
+                        |네 키는 하나의 단위입니다 — 모두 채우거나 모두 지우세요(모두 지우면 기본 debug keystore 로 서명).
+                        |설정 방법은 README '공유 debug keystore' 섹션 참고.
+                        """.trimMargin(),
+                    )
+                }
             }
         }
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,6 +48,32 @@ android {
                 keyPassword = localProperties.getProperty("RELEASE_KEY_PASSWORD")
             }
         }
+        // 팀 공유 debug keystore 로 서명해 카카오 키 해시를 머신 간 통일.
+        //
+        // opt-in 이다. AGP 는 debug keystore 를 머신마다 자동 생성하는 것이 기본이고
+        // (https://developer.android.com/studio/publish/app-signing), 그 모델을 없애지 않는다 —
+        // `DEBUG_STORE_FILE` 이 없는 머신은 아래 if 를 그냥 건너뛰어 `~/.android/debug.keystore`
+        // 로 서명된다. 빌드·로그인 동작에 차이는 없고, 카카오 콘솔에 본인 해시를 등록하면 된다
+        // (카카오는 원래 "모든 개발자의 디버그 키 해시" 등록을 요구:
+        //  https://developers.kakao.com/docs/latest/ko/android/getting-started).
+        // 공유 keystore 는 그 등록 건수를 1개로 줄이려는 선택지이지 강제가 아니다.
+        // CI 도 프로퍼티가 없으므로 같은 경로로 폴백한다.
+        //
+        // 트레이드오프: 이 keystore 의 해시가 카카오·구글 콘솔에 등록되므로, 파일이 유출되면
+        // 제3자가 같은 키 해시로 우리 앱 행세를 하며 소셜 로그인을 호출할 수 있다. 영향은
+        // debug 한정이다 — release 는 별도 keystore(`RELEASE_*`) 이고, debug 인증서로 서명한
+        // 앱은 스토어 배포가 불가능하다("insecure by design", 위 Android 문서). 실수 커밋은
+        // 루트 `.gitignore` 의 `*.jks`·`*.keystore` 가 막지만, 전달 경로는 개인 채널로 유지한다.
+        // 이 리스크를 받아들이기 싫으면 위 opt-out(프로퍼티 미기재)을 쓰면 된다.
+        getByName("debug") {
+            val debugStoreFile = localProperties.getProperty("DEBUG_STORE_FILE")
+            if (debugStoreFile != null) {
+                storeFile = file(debugStoreFile)
+                storePassword = localProperties.getProperty("DEBUG_STORE_PASSWORD")
+                keyAlias = localProperties.getProperty("DEBUG_KEY_ALIAS")
+                keyPassword = localProperties.getProperty("DEBUG_KEY_PASSWORD")
+            }
+        }
     }
 
     buildTypes {


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #533 — chore(app): debug 빌드 서명 공유 keystore 통일 — 카카오 키 해시 머신별 등록 해소

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `app/build.gradle.kts` 에 `signingConfigs.debug` 추가 — `local.properties` 의 `DEBUG_STORE_FILE`·`DEBUG_STORE_PASSWORD`·`DEBUG_KEY_ALIAS`·`DEBUG_KEY_PASSWORD` 4키가 있을 때만 공유 keystore 로 서명하고, 없으면 AGP 기본 `~/.android/debug.keystore` 로 폴백
- README 에 "공유 debug keystore" 셋업 섹션 추가 — keystore 수령·배치, `local.properties` 4키(절대경로), `./gradlew :app:signingReport` 로 적용 확인, 카카오 키 해시 추출 명령
- README 의 배포 대상 Firebase 프로젝트를 `afternote-b4d3c` → `afternote-android` 로 정정 (아래 참고)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 빌드 설정과 문서만 변경.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

**"debug 키는 머신마다 달라야 하는 것 아니냐"에 대한 답을 코드 주석으로 남겼습니다.** 논점이 있는 결정이라 README 가 아니라 `signingConfigs.debug` 블록 바로 위에 적었습니다. 요지는 셋입니다.

1. **이 배선은 opt-in 이고, 머신별 키 모델을 없애지 않습니다.** AGP 가 debug keystore 를 머신마다 자동 생성하는 것이 기본이며(https://developer.android.com/studio/publish/app-signing), `DEBUG_STORE_FILE` 을 `local.properties` 에 적지 않은 머신은 `if` 를 그대로 건너뛰어 기존과 동일하게 `~/.android/debug.keystore` 로 서명됩니다. 빌드·로그인 동작에 차이가 없습니다. CI 도 프로퍼티가 없으므로 같은 경로로 폴백합니다.
2. **공유는 강제가 아니라 등록 건수를 줄이는 선택지입니다.** 카카오는 원래 "모든 개발자의 디버그 키 해시" 등록을 요구하므로(https://developers.kakao.com/docs/latest/ko/android/getting-started) 개인 keystore 를 유지하려면 본인 해시를 콘솔에 등록하면 됩니다. 공유 keystore 는 그 등록을 1건으로 줄이려는 것입니다.
3. **트레이드오프는 인정하고 주석에 명시했습니다.** 이 keystore 의 해시가 카카오·구글 콘솔에 등록되므로 파일이 유출되면 제3자가 같은 키 해시로 앱 행세를 하며 소셜 로그인을 호출할 수 있습니다. 영향은 debug 한정입니다 — release 는 별도 keystore(`RELEASE_*`)이고, debug 인증서로 서명한 앱은 스토어 배포가 불가능합니다("insecure by design", 위 Android 문서). 실수 커밋은 루트 `.gitignore` 의 `*.jks`·`*.keystore` 가 막고, 전달은 개인 채널로만 합니다. 이 리스크를 받아들이기 싫으면 1번의 opt-out 을 쓰면 됩니다.

**이 작업은 #288 로 2026-05 에 한 번 머지됐지만 develop 에 도달하지 못했습니다.** #289 의 base 가 `feat/286` 이었는데, `feat/286 → develop` 인 #287 이 23:57:48 에 먼저 머지되고 #289 가 23:58:07 에 `feat/286` 으로 들어가면서 develop 으로 갈 경로가 사라졌습니다. `git log --all -S 'DEBUG_STORE_FILE' -- app/build.gradle.kts` 가 0건인 것으로 확인했습니다. 그래서 같은 내용을 다시 올립니다.

**범위 밖 1줄:** README 의 배포 섹션이 Firebase 프로젝트를 `afternote-b4d3c` 로 적고 있었는데, 이 프로젝트는 07-26 교체로 삭제됐습니다. 같은 파일을 이미 건드리는 김에 `afternote-android` 로 정정했습니다.

**검증**
- `./gradlew :app:compileDebugKotlin` BUILD SUCCESSFUL
- 두 시나리오 확인 — `DEBUG_*` 기재 시 `signingReport` 의 `Variant: debug` 가 공유 keystore 를 가리키고, 미기재 시 기본 debug keystore 로 폴백
