### PR TITLE
fix(build): ProGuard 도메인 예외 클래스 이름 유지 — Crashlytics 리포트 식별성 확보 (closes 606)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -42,3 +42,10 @@
 # 보호하지 않아 NoSuchFieldException 발생.
 -keep class com.kakao.sdk.**.model.** { *; }
 -keep enum com.kakao.sdk.** { *; }
+
+# 도메인 예외 — Crashlytics 리포트에서 예외 타입을 식별하기 위해 이름만 유지.
+# 스택 프레임은 mapping 으로 복원되지만 예외 타입 문자열에는 적용되지 않아,
+# 난독화되면 이슈 제목이 `nq` 같은 축약명으로 떠 어떤 실패인지 알 수 없고
+# 같은 지점의 실패가 서로 다른 이슈로 그룹핑된다.
+# 이름만 필요하므로 멤버 난독화와 미사용 클래스 제거는 그대로 둔다.
+-keepnames class com.afternote.** extends java.lang.Throwable


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #606 — fix(build): Crashlytics release 리포트의 예외 타입이 R8 난독화명으로 표시 — 이슈 식별·그룹핑 저해

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `app/proguard-rules.pro` 에 `-keepnames class com.afternote.** extends java.lang.Throwable` 추가 (02899983)
- 이름만 유지하는 `-keepnames` 를 썼다. 멤버 난독화와 미사용 클래스 제거는 그대로 두고, 콘솔 표시에 필요한 클래스명만 남긴다

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 빌드 설정(ProGuard 규칙)만 변경.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 배경: release 빌드가 올린 non-fatal 리포트에서 이슈 제목이 `nq - 아이디 또는 비밀번호가 일치하지 않습니다.` 로 떴다. `nq` 는 `ApiException` 의 난독화명이다. 같은 이벤트의 스택 프레임은 `ApiErrorInterceptor.intercept (ApiErrorInterceptor.kt:48)` 로 정상 복원되므로 mapping 업로드 자체는 동작하고 있고, 예외 타입 문자열에만 적용되지 않는다.
- 그 결과 동일 지점의 실패가 debug 이벤트(`com.afternote.core.network.model.ApiException`)와 **다른 이슈로 그룹핑**됐다.
- 검증: 규칙 적용 후 `mapping.txt` 에서 도메인 예외가 전부 identity 매핑으로 남는 것을 확인했다.
  ```
  com.afternote.core.network.model.ApiException -> com.afternote.core.network.model.ApiException:
  com.afternote.core.domain.error.EmailVerificationException -> com.afternote.core.domain.error.EmailVerificationException:
  com.afternote.feature.afternote.domain.error.ReceiverMasterKeyException -> ...
  ```
- 콘솔 확인까지 마쳤다. 규칙 적용 빌드로 로그인 실패 → 앱 재시작 → 업로드 `Status Code: 200` → Crashlytics 이슈가 `Non-fatal Exception: com.afternote.core.network.model.ApiException` 로 표시되고 기존 이슈와 합쳐졌다(이벤트 2건).
- 이 검증은 계측 코드가 필요해 `feat/544`(#605) 위에 규칙을 얹어 수행했다. 이 브랜치 자체는 `develop` 기준이며 규칙 파일 한 줄만 담는다.
- 빌드 검증: `./gradlew :app:assembleRelease` BUILD SUCCESSFUL (R8 이 규칙을 파싱하므로 문법 오류는 이 단계에서 걸린다. `compileDebugKotlin` 은 minify 를 타지 않아 이 변경을 검증하지 못한다.)
