### PR TITLE
fix(afternote): 추억 플레이리스트 곡 수 기본값 16→0 — 빈 목록 유령 곡수 제거 (closes 507)

### DIFF
--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/AfternoteEditorViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/AfternoteEditorViewModel.kt
@@ -93,7 +93,7 @@ private data class EditorFormSnapshot(
     val funeralVideoUrl: String? = null,
     val funeralThumbnailUrl: String? = null,
     val memorialPhotoUrl: String? = null,
-    val playlistSongCount: Int = 16,
+    val playlistSongCount: Int = 0,
     val memorialPlaylistSongs: List<Song> = emptyList(),
     val albumCovers: List<AlbumSnap> = emptyList(),
     val editorMessages: List<MessageBlockSnap> = emptyList(),

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/state/AfternoteEditorState.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/state/AfternoteEditorState.kt
@@ -80,7 +80,7 @@ class AfternoteEditorState(
     /** 신규 작성 진입 시 폼에 남은 추억 플레이리스트 스냅샷을 비운다 (호스트 SSOT clear는 호출부에서). */
     fun resetMemorialPlaylistFormSnapshot() {
         updateForm {
-            it.copy(memorialPlaylistSongs = emptyList(), playlistSongCount = 16)
+            it.copy(memorialPlaylistSongs = emptyList(), playlistSongCount = 0)
         }
     }
 

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/state/EditorFormState.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/author/editor/state/EditorFormState.kt
@@ -18,6 +18,13 @@ private const val LAST_WISH_DEFAULT_BRIGHT = "슬퍼 하지 말고 밝고 따뜻
 
 /**
  * 에디터 **비즈니스/도메인** 폼 상태.
+ *
+ * 필드를 개별 스트림으로 쪼개지 않고 하나의 불변 data class로 묶은 근거는 UI 레이어 가이드의
+ * "Use a single UI state object to handle states that are related to each other" 다.
+ * 쪼개는 편이 나은 경우는 가이드가 함께 못박은 예외 "Unrelated data types"(서로 독립적이고
+ * 갱신 빈도까지 다른 상태)인데, 이 폼은 카테고리 선택·검증·저장 payload 가 서로를 읽으므로 해당하지 않는다.
+ * https://developer.android.com/topic/architecture/ui-layer#define-ui-state
+ *
  * [com.afternote.feature.afternote.presentation.author.editor.AfternoteEditorViewModel]의
  * [kotlinx.coroutines.flow.StateFlow]가 SSOT이며,
  * 프로세스 종료 대비 스냅샷은 [androidx.lifecycle.SavedStateHandle]에 JSON으로 저장한다.
@@ -51,7 +58,8 @@ data class EditorFormState(
     val funeralVideoUrl: String? = null,
     val funeralThumbnailUrl: String? = null,
     val memorialPhotoUrl: String? = null,
-    val playlistSongCount: Int = 16,
+    /** 추모(PLAYLIST) 곡 수 폴백. 그래프·스냅샷 곡 목록이 모두 비면 이 값이 노출되므로 기본은 0(유령 곡수 방지). */
+    val playlistSongCount: Int = 0,
     /** 추모(PLAYLIST) 곡 목록 — 홀더와 양방향 동기화 후 스냅샷에 저장. */
     val memorialPlaylistSongs: List<Song> = emptyList(),
     val playlistAlbumCovers: List<AlbumCover> = emptyList(),


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #507 — fix(afternote): 추억 플레이리스트 카드 곡 수 하드코딩(16) — 빈 목록에 유령 곡수 표기

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `EditorFormState.playlistSongCount` 기본값 `16` → `0` (6e9bbc32). 이 값은 `livePlaylistSongCount()` 의 최종 폴백이라, 그래프 SSOT·폼 스냅샷 곡 목록이 모두 비면 그대로 화면에 노출된다.
- `AfternoteEditorState.resetMemorialPlaylistFormSnapshot()` 의 리셋값도 `16` → `0`. 신규 작성 진입 시 이전 세션 잔여 곡 수가 되살아나지 않게.
- `AfternoteEditorViewModel` 의 SavedState 스냅샷(`EditorFormSnapshot.playlistSongCount`) 기본값도 동일하게 `0`. 세 지점이 같은 값을 물고 있어 한 곳만 고치면 복원 경로에서 되돌아온다.
- `EditorFormState` KDoc 에 폴백 의미와 "왜 폼 필드를 단일 불변 data class 로 묶는가" 근거를 남김 (UI 레이어 가이드 `#define-ui-state`).

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 코드 변경 없음 — 상태 기본값과 KDoc 만 바뀌어 Compose Preview 스크린샷 baseline 재생성 대상이 아니다(렌더 트리 동일). 표기 문구 자체는 `MemorialPlaylist` 카드가 주입값을 그대로 쓰므로, 빈 목록에서 "현재 0개의 노래가 담겨 있습니다" 로 바뀐다.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- **범위 밖으로 남긴 잔여 경로 하나** — 곡을 전부 삭제하고 에디터로 돌아오면 유령 곡 수가 여전히 뜬다. `AfternoteEditorState.syncMemorialPlaylistSongs()` 가 빈 목록을 받으면 이전 카운트를 유지하기 때문(`playlistSongCount = if (songs.isNotEmpty()) songs.size else it.playlistSongCount`). 그 가드는 SavedState 복원 시 스냅샷 곡 목록이 host SSOT 의 빈 값에 덮이는 것을 막는 용도로 보여, 떼면 #580(재진입 시 곡 소실)을 악화시킨다. 이슈 #507 본문도 "곡수 표기만, 이중 수정 주의" 로 경계를 그어 뒀으므로 이 PR 에서는 건드리지 않았다. 별도 이슈로 올릴지 판단 필요.
- 겹침: `EditorFormState.kt`·`AfternoteEditorState.kt` 를 #490 과 공유한다. #490 은 아직 PR 이 없어(브랜치 스텁만) 이 PR 은 develop 기준으로 뒀다. #490 착수 시 리베이스 필요.
- "곡 추가 진입점 부재" 는 #465 소관이라 이 PR 범위 밖.
- 빌드 검증: `./gradlew :feature:afternote:presentation:compileDebugKotlin :feature:afternote:presentation:ktlintCheck` BUILD SUCCESSFUL
- 관련 위치: [노션 1차 QA(2026-07-19) #14](https://app.notion.com/p/1-QA-3a209829378780f5be6ffca4c483502b) · [노션 2차 QA(2026-07-28) 26번](https://app.notion.com/p/3ab09829378780f09666dd379d878e5e)
