### PR TITLE
fix(afternote): 수신자 이메일 인증 KDoc 에러 코드 정정 — 불일치는 1903, 1902 는 만료/미존재 (closes 654)

### DIFF
--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/service/ReceiverAuthApiService.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/service/ReceiverAuthApiService.kt
@@ -35,7 +35,7 @@ interface ReceiverAuthApiService {
         @Body body: ReceiverAuthCodeEmailSendRequestDto,
     ): BaseResponse<Unit>
 
-    /** 발송된 6자리 인증번호 검증. 만료/불일치는 400 (code 1902). */
+    /** 발송된 6자리 인증번호 검증. 만료/미존재는 400 (code 1902), 불일치는 400 (code 1903). */
     @POST("receiver-auth/email/verify")
     suspend fun verifyEmailAuthCode(
         @Body body: ReceiverEmailAuthVerifyRequestDto,

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverEmailAuthContractTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/dto/ReceiverEmailAuthContractTest.kt
@@ -21,7 +21,7 @@ import org.junit.Test
  * `accessCode` 를 응답에서 제거할 예정이라([ReceiverEmailAuthVerifyDto] 참고), 제거 배포가 언제 나가든
  * 파싱이 깨지지 않아야 한다 (#454).
  *
- * 에러 응답(404 code 1901 / 400 code 1902)은 HTTP 4xx 라 `ApiErrorInterceptor` 가 가로채는 경로 —
+ * 에러 응답(404 code 1901 / 400 code 1902·1903)은 HTTP 4xx 라 `ApiErrorInterceptor` 가 가로채는 경로 —
  * 그 이후의 도메인 예외 변환은 `ReceiverAuthRepositoryImplEmailAuthTest` 가 가드한다.
  */
 class ReceiverEmailAuthContractTest {

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImplEmailAuthTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImplEmailAuthTest.kt
@@ -54,7 +54,7 @@ class ReceiverAuthRepositoryImplEmailAuthTest {
     }
 
     @Test
-    fun `verifyEmailAuthCode - 만료·불일치 1902 ApiException 을 도메인 예외로 변환`() {
+    fun `verifyEmailAuthCode - 만료·미존재 1902 ApiException 을 도메인 예외로 변환`() {
         val repository =
             ReceiverAuthRepositoryImpl(
                 FakeReceiverAuthApiService(

--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/error/ReceiverEmailAuthException.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/error/ReceiverEmailAuthException.kt
@@ -11,7 +11,8 @@ package com.afternote.feature.afternote.domain.error
  *   (예: `"등록된 수신자 이메일이 아닙니다."`, `"인증번호가 만료되었거나 존재하지 않습니다. 다시 요청해주세요."`).
  *   **null 이면 서버가 message 미제공** — 호출처는 도메인 fallback (정적 R.string) 으로 폴백.
  * @property serverCode 서버 에러 body 의 `code` (예: 1901 = 수신자 이메일 미등록(404 동반),
- *   1902 = 인증번호 만료/불일치(400 동반)). body 파싱 실패 시 HTTP status 폴백 값이 들어온다.
+ *   1902 = 인증번호 만료/미존재(400 동반), 1903 = 인증번호 불일치(400 동반)).
+ *   body 파싱 실패 시 HTTP status 폴백 값이 들어온다.
  *   향후 "특정 code 일 때만 분기" 요구 시 사용 — message 문자열 매칭 회귀 회피.
  */
 class ReceiverEmailAuthException(


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #654 — fix(afternote): 수신자 이메일 인증 KDoc 에러 코드 정정 — 불일치는 1903, 1902 는 만료/미존재

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `ReceiverAuthApiService.verifyEmailAuthCode` KDoc 정정 — "만료/불일치는 400 (code 1902)" → "만료/미존재는 400 (code 1902), 불일치는 400 (code 1903)" (1ad9e0b2)
- `ReceiverEmailAuthException.serverCode` KDoc — 1902 서술을 만료/미존재로 정정하고 1903(인증번호 불일치, 400 동반) 추가
- `ReceiverAuthRepositoryImplEmailAuthTest` 테스트명 — "만료·불일치 1902" → "만료·미존재 1902" (캡처 값 1902 자체는 정확, 명칭만 정정)
- `ReceiverEmailAuthContractTest` 클래스 KDoc — 에러 응답 열거에 1903 추가

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — KDoc·테스트명 문서 정정만이라 동작 변경 없음 (`serverCode` 를 분기에 쓰는 로직 현재 없음)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 서버 계약 근거(2026-07-31 실서버 실측 + BE 배포 소스): 1902/1903 정의는 [ErrorCode.java#L174-L175](https://github.com/Afternote/Afternote-BE/blob/bbe8ccb2576c47421b76c4b0230a7c8b95811d5f/src/main/java/com/afternote/global/exception/ErrorCode.java#L174-L175), 만료·미존재가 같은 1902 분기인 근거는 [ReceiverAuthService.java#L169-L191](https://github.com/Afternote/Afternote-BE/blob/bbe8ccb2576c47421b76c4b0230a7c8b95811d5f/src/main/java/com/afternote/domain/receiver/service/ReceiverAuthService.java#L169-L191)
- feat/544 스택이 `ReceiverAuthApiService.kt` 를 수정하지만 다른 헝크(verify→verifyMasterKey 리네임)라 충돌 없음 — base=develop 독립
- 빌드 검증: `./gradlew :feature:afternote:domain:compileDebugKotlin :feature:afternote:data:compileDebugKotlin :feature:afternote:data:testDebugUnitTest`(변경 테스트 2클래스 실행) BUILD SUCCESSFUL
