### PR TITLE
fix(app): 수신자 홈 내려받기 실패 Toast 서버 원문 대신 일반 문구 표시 (closes 652)

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeScreen.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -147,6 +148,7 @@ private fun DownloadDialogHost(
     onEvent: (ReceiverHomeEvent) -> Unit,
 ) {
     val context = LocalContext.current
+    val resources = LocalResources.current
     val currentOnEvent by rememberUpdatedState(onEvent)
 
     val showDialog =
@@ -164,7 +166,7 @@ private fun DownloadDialogHost(
     LaunchedEffect(state) {
         when (state) {
             is ReceiverDownloadState.Failed -> {
-                Toast.makeText(context, state.message, Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, resources.getString(state.messageRes), Toast.LENGTH_SHORT).show()
                 currentOnEvent(ReceiverHomeEvent.ConsumeDownloadResult)
             }
 

--- a/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeViewModel.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/receiver/ReceiverHomeViewModel.kt
@@ -2,6 +2,7 @@ package com.afternote.afternote_fe.screen.receiver
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.afternote_fe.R
 import com.afternote.afternote_fe.reporting.HomeFailureStage
 import com.afternote.afternote_fe.reporting.recordHomeFailure
 import com.afternote.afternote_fe.screen.receiver.model.AfternoteSourceIcon
@@ -143,13 +144,13 @@ class ReceiverHomeViewModel
                             .onFailure { e ->
                                 errorReporter.recordHomeFailure(HomeFailureStage.RECEIVED_EXPORT_SAVE, e)
                                 updateDownload(
-                                    ReceiverDownloadState.Failed(e.message ?: "파일 저장에 실패했습니다."),
+                                    ReceiverDownloadState.Failed(R.string.receiver_home_download_all_save_failed),
                                 )
                             }
                     }.onFailure { e ->
                         errorReporter.recordHomeFailure(HomeFailureStage.RECEIVED_EXPORT_DOWNLOAD, e)
                         updateDownload(
-                            ReceiverDownloadState.Failed(e.message ?: "모든 기록 내려받기에 실패했습니다."),
+                            ReceiverDownloadState.Failed(R.string.receiver_home_download_all_failed),
                         )
                     }
             }

--- a/app/src/main/java/com/afternote/afternote_fe/screen/receiver/model/ReceiverHomeUiState.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/receiver/model/ReceiverHomeUiState.kt
@@ -1,5 +1,6 @@
 package com.afternote.afternote_fe.screen.receiver.model
 
+import androidx.annotation.StringRes
 import androidx.compose.runtime.Immutable
 
 /**
@@ -54,6 +55,6 @@ sealed interface ReceiverDownloadState {
     data object Done : ReceiverDownloadState
 
     data class Failed(
-        val message: String,
+        @param:StringRes val messageRes: Int,
     ) : ReceiverDownloadState
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,4 +28,6 @@
     <string name="receiver_home_afternote_section_button">애프터노트 확인하러 가기</string>
     <string name="receiver_home_download_all_button">모든 기록 내려받기</string>
     <string name="receiver_home_download_all_dialog_message">모든 기록을 내려받으시겠습니까?</string>
+    <string name="receiver_home_download_all_failed">모든 기록 내려받기에 실패했습니다.</string>
+    <string name="receiver_home_download_all_save_failed">파일 저장에 실패했습니다.</string>
 </resources>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #652 — fix(app): 수신자 홈 내려받기 실패 Toast 가 서버 원문(e.message)을 그대로 노출 — 일반 문구 치환

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `ReceiverDownloadState.Failed` 가 raw `e.message` 대신 `@StringRes messageRes` 를 운반하도록 교체 — 실패 지점별 고정 리소스(`receiver_home_download_all_failed`/`_save_failed`) 신설, 서버 원문은 feat/544 계측(non-fatal 기록)이 보존 (89f2600b)
- 수신자 홈 Toast 를 리소스 참조로 전환 + 신규 lint `LocalContextGetResourceValueCall`(compose-ui, **Error 레벨**) 보수 — `LocalContext.current` 유래 `getString` 을 `LocalResources.current` 캡처로 대체 (930b5b5e)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음(실패 문구 리소스화) — 실패 Toast 경로는 #589 data 스텁이 성공만 반환해 현재 발화 불가라 실기기 실측 생략, lint·컴파일 정적 검증으로 갈음. 스크린샷 baseline 무영향(Toast 경로는 Preview 미수집)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- **base=feat/544 스택**(#605 위) — #605 머지 후 base=develop PATCH 예정(#621·#655 와 동일 절차)
- 표시 수단(Toast vs 스낵바·인라인) 통일은 #446 디자이너 회신이 게이트 — 본 PR 은 서버 원문 노출 제거만 하고 수단은 현행 Toast 유지
- 빌드 검증: `./gradlew :app:compileDebugKotlin :app:lintDebug :app:ktlintCheck` BUILD SUCCESSFUL