### PR TITLE
fix(afternote): 수신자 요약·상세 UiState 의 raw e.message 운반 제거 (closes 653)

### DIFF
--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/detail/ReceivedAfternoteDetailUiState.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/detail/ReceivedAfternoteDetailUiState.kt
@@ -11,7 +11,6 @@ sealed interface ReceivedAfternoteDetailUiState {
     ) : ReceivedAfternoteDetailUiState
 
     data class Error(
-        val rawMessage: String? = null,
         @param:StringRes val messageRes: Int? = null,
     ) : ReceivedAfternoteDetailUiState
 }

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/detail/ReceivedAfternoteDetailViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/detail/ReceivedAfternoteDetailViewModel.kt
@@ -79,7 +79,6 @@ class ReceivedAfternoteDetailViewModel
                             it.copy(
                                 loadPhase =
                                     LoadPhase.Failed(
-                                        rawMessage = e.message,
                                         messageRes = R.string.afternote_detail_load_error,
                                     ),
                             )
@@ -105,7 +104,6 @@ class ReceivedAfternoteDetailViewModel
             ) : LoadPhase
 
             data class Failed(
-                val rawMessage: String? = null,
                 val messageRes: Int? = null,
             ) : LoadPhase
         }
@@ -125,7 +123,6 @@ class ReceivedAfternoteDetailViewModel
 
                 is LoadPhase.Failed -> {
                     ReceivedAfternoteDetailUiState.Error(
-                        rawMessage = phase.rawMessage,
                         messageRes = phase.messageRes,
                     )
                 }

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/summary/ReceiverAfternoteScreen.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/summary/ReceiverAfternoteScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -53,15 +54,16 @@ fun ReceiverAfterNoteEntry(
 ) {
     val downloadUiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    val resources = LocalResources.current
 
     LaunchedEffect(downloadUiState.downloadSuccess) {
         if (downloadUiState.downloadSuccess) {
             viewModel.onEvent(ReceiverDownloadAllEvent.DownloadSuccessConsumed)
         }
     }
-    LaunchedEffect(downloadUiState.errorMessage) {
-        downloadUiState.errorMessage?.let { message ->
-            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+    LaunchedEffect(downloadUiState.errorMessageRes) {
+        downloadUiState.errorMessageRes?.let { messageRes ->
+            Toast.makeText(context, resources.getString(messageRes), Toast.LENGTH_SHORT).show()
             viewModel.onEvent(ReceiverDownloadAllEvent.ErrorConsumed)
         }
     }

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/summary/ReceiverDownloadAllUiState.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/summary/ReceiverDownloadAllUiState.kt
@@ -1,10 +1,12 @@
 package com.afternote.feature.afternote.presentation.receiver.summary
 
+import androidx.annotation.StringRes
+
 /**
  * 모든 기록 내려받기 다이얼로그/화면 UI 상태.
  */
 data class ReceiverDownloadAllUiState(
     val isLoading: Boolean = false,
-    val errorMessage: String? = null,
+    @param:StringRes val errorMessageRes: Int? = null,
     val downloadSuccess: Boolean = false,
 )

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/summary/ReceiverDownloadAllViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/summary/ReceiverDownloadAllViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.afternote.core.common.reporting.ErrorReporter
 import com.afternote.feature.afternote.domain.repository.receiver.ReceiverRepository
+import com.afternote.feature.afternote.presentation.R
 import com.afternote.feature.afternote.presentation.reporting.AfternoteFailureStage
 import com.afternote.feature.afternote.presentation.reporting.recordAfternoteFailure
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -38,7 +39,7 @@ class ReceiverDownloadAllViewModel
         private fun handleConfirmDownload() {
             viewModelScope.launch {
                 _uiState.update {
-                    it.copy(isLoading = true, errorMessage = null, downloadSuccess = false)
+                    it.copy(isLoading = true, errorMessageRes = null, downloadSuccess = false)
                 }
                 receiverRepository
                     .downloadReceivedExport()
@@ -54,7 +55,7 @@ class ReceiverDownloadAllViewModel
                                 _uiState.update {
                                     it.copy(
                                         isLoading = false,
-                                        errorMessage = e.message ?: "파일 저장에 실패했습니다.",
+                                        errorMessageRes = R.string.receiver_download_all_save_failed,
                                     )
                                 }
                             }
@@ -63,7 +64,7 @@ class ReceiverDownloadAllViewModel
                         _uiState.update {
                             it.copy(
                                 isLoading = false,
-                                errorMessage = e.message ?: "모든 기록 내려받기에 실패했습니다.",
+                                errorMessageRes = R.string.receiver_download_all_failed,
                             )
                         }
                     }
@@ -75,6 +76,6 @@ class ReceiverDownloadAllViewModel
         }
 
         private fun handleClearError() {
-            _uiState.update { it.copy(errorMessage = null) }
+            _uiState.update { it.copy(errorMessageRes = null) }
         }
     }

--- a/feature/afternote/presentation/src/main/res/values/strings.xml
+++ b/feature/afternote/presentation/src/main/res/values/strings.xml
@@ -58,6 +58,8 @@
     <string name="receiver_timeletter_sort_unread_first">읽지 않은 순</string>
     <string name="receiver_download_all_button">모든 기록 내려받기</string>
     <string name="receiver_download_all_dialog_message">모든 기록을 내려받으시겠습니까?</string>
+    <string name="receiver_download_all_failed">모든 기록 내려받기에 실패했습니다.</string>
+    <string name="receiver_download_all_save_failed">파일 저장에 실패했습니다.</string>
     <string name="receiver_hero_default_message">가족들에게…\n내가 없어도 너무 슬퍼하지마.</string>
     <string name="receiver_mindrecord_section_title">마음의 기록</string>
     <string name="receiver_mindrecord_section_desc">고인의 일상적인 생각과 감정, 일기들입니다.</string>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #653 — fix(afternote): 수신자 요약·상세 UiState 가 raw e.message 를 운반 — 배선 시 서버 원문 그대로 노출

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- 요약(모든 기록 내려받기): `ReceiverDownloadAllUiState` 가 raw `e.message` 대신 `@StringRes` 를 운반하도록 교체 — 실패 지점별 고정 리소스 신설, Toast 는 `LocalResources.current` 캡처로 전환해 신규 lint `LocalContextGetResourceValueCall`(compose-ui, **Error 레벨**) 게이트 통과 (534c0f83)
- 상세: 어디에도 렌더되지 않던 `rawMessage` 운반을 UiState·ViewModel 에서 제거 — 추후 배선 시 서버 원문이 그대로 노출될 잠재 경로 차단
- 서버 원문 자체는 feat/544 계측(non-fatal 기록)이 보존하므로 진단 정보 손실 없음

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 두 경로 모두 현재 미발화 상태(요약 화면은 NavGraph 미배선(#546/#615 계열), 실패 데이터 경로는 #589 스텁이 성공만 반환)라 실기기 실측이 불가능해 정적 검증(compile·ktlint·lint)으로 갈음. 스크린샷 baseline 무영향(해당 경로 Preview 미수집)

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- **base=feat/544 스택**(#605 위) — #605 머지 후 base=develop PATCH 예정(#621·#655·#657 과 동일 절차)
- 표시 수단(Toast vs 스낵바·인라인) 통일은 #446 디자이너 회신이 게이트 — 본 PR 은 서버 원문 노출 제거만 수행
- `ReceiverAfterNoteEntry` 의 IDE "never used" 경고는 NavGraph 미배선 상태(#546/#615 계열 몫)로 본 PR 스코프 아님
- 빌드 검증: `./gradlew :feature:afternote:presentation:compileDebugKotlin :feature:afternote:presentation:ktlintCheck :feature:afternote:presentation:lintDebug` BUILD SUCCESSFUL