### PR TITLE
chore(ci): PR 머지 순서 가드 워크플로 추가 — blocked_by 미해소·비develop base 검출 (closes 660)

### DIFF
--- a/.github/workflows/merge-order-guard.yml
+++ b/.github/workflows/merge-order-guard.yml
@@ -13,7 +13,6 @@ on:
     types: [closed, reopened]
 
 permissions:
-  actions: write # refresh 잡의 gh run rerun
   issues: read
   pull-requests: read
 
@@ -28,6 +27,9 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
+          # gh api 실패가 빈 목록으로 위장돼 가드가 초록으로 새는 것 방지(fail-closed)
+          set -euo pipefail
+
           fail=0
 
           # 스택 PR 방호 — base 가 feat 브랜치면 그 브랜치로 머지돼 버린다.
@@ -60,14 +62,22 @@ jobs:
   # blocker 이슈가 닫히면(=선행 PR 머지) 기다리던 PR 의 guard 를 재실행해 초록으로 갱신한다.
   refresh:
     if: github.event_name == 'issues'
+    permissions:
+      actions: write # gh run rerun — 필요한 이 잡에만 job-level 로 한정
+      issues: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: 이 이슈가 blocking 하던 열린 PR 의 guard 재실행
         env:
           GH_TOKEN: ${{ github.token }}
+          # 셸 보간은 없지만 gh CLI 가 소비한다 — checkout 없는 러너에서
+          # gh run list/rerun 의 저장소 컨텍스트가 이 env 로만 잡힌다.
           GH_REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.issue.number }}
         run: |
+          set -euo pipefail
+
           owner="${GITHUB_REPOSITORY%/*}"
           repo="${GITHUB_REPOSITORY#*/}"
 
@@ -85,9 +95,10 @@ jobs:
               --jq '.data.repository.issue.closedByPullRequestsReferences.nodes[].headRefName')
             for h in $heads; do
               run_id=$(gh run list --workflow merge-order-guard.yml --branch "$h" \
-                --limit 1 --json databaseId --jq '.[0].databaseId')
+                --limit 1 --json databaseId --jq '.[0].databaseId // empty')
               if [ -n "$run_id" ]; then
-                gh run rerun "$run_id" || true
+                # 진행 중 런 재실행 거절 등은 치명 아님 — 경고로만 남긴다
+                gh run rerun "$run_id" || echo "::warning::run $run_id 재실행 실패 — 진행 중이거나 권한 문제"
               fi
             done
           done

--- a/.github/workflows/merge-order-guard.yml
+++ b/.github/workflows/merge-order-guard.yml
@@ -1,0 +1,93 @@
+# PR 머지 순서 가드 (#660)
+#
+# GitHub 는 이슈 Relationships(blocked_by)를 표시만 하고 머지 버튼을 잠그지 않는다.
+# 이 워크플로는 PR 의 closing 이슈에 아직 열린 blocked_by 가 있거나, base 가
+# develop/main 이 아니면(스택 PR 미PATCH 상태) check 를 실패시킨다.
+# branch protection 에서 required check 로 지정하면 머지 버튼이 실제로 잠긴다.
+name: merge-order-guard
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+  issues:
+    types: [closed, reopened]
+
+permissions:
+  actions: write # refresh 잡의 gh run rerun
+  issues: read
+  pull-requests: read
+
+jobs:
+  guard:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: closing 이슈 blocked_by · base 검사
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          fail=0
+
+          # 스택 PR 방호 — base 가 feat 브랜치면 그 브랜치로 머지돼 버린다.
+          case "$BASE_REF" in
+            develop|main) ;;
+            *)
+              echo "::error::base 가 '$BASE_REF' — 스택 PR 은 base 를 develop 로 PATCH 한 뒤 머지할 것"
+              fail=1
+              ;;
+          esac
+
+          owner="${GITHUB_REPOSITORY%/*}"
+          repo="${GITHUB_REPOSITORY#*/}"
+          issues=$(gh api graphql \
+            -f query='query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){closingIssuesReferences(first:20){nodes{number}}}}}' \
+            -f owner="$owner" -f repo="$repo" -F pr="$PR_NUMBER" \
+            --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[].number')
+
+          for n in $issues; do
+            open_blockers=$(gh api "repos/$GITHUB_REPOSITORY/issues/$n/dependencies/blocked_by" \
+              --jq '.[] | select(.state == "open") | .number')
+            for b in $open_blockers; do
+              echo "::error::#$n 이 아직 열린 #$b 에 blocked — 머지 순서 위반. 선행 PR 부터 머지할 것"
+              fail=1
+            done
+          done
+
+          exit "$fail"
+
+  # blocker 이슈가 닫히면(=선행 PR 머지) 기다리던 PR 의 guard 를 재실행해 초록으로 갱신한다.
+  refresh:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 이 이슈가 blocking 하던 열린 PR 의 guard 재실행
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          owner="${GITHUB_REPOSITORY%/*}"
+          repo="${GITHUB_REPOSITORY#*/}"
+
+          blocked=$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE/dependencies/blocking" \
+            --jq '.[].number')
+          if [ -z "$blocked" ]; then
+            echo "이 이슈가 blocking 하는 이슈 없음 — 재실행 대상 없음"
+            exit 0
+          fi
+
+          for n in $blocked; do
+            heads=$(gh api graphql \
+              -f query='query($owner:String!,$repo:String!,$n:Int!){repository(owner:$owner,name:$repo){issue(number:$n){closedByPullRequestsReferences(first:10,includeClosedPrs:false){nodes{headRefName}}}}}' \
+              -f owner="$owner" -f repo="$repo" -F n="$n" \
+              --jq '.data.repository.issue.closedByPullRequestsReferences.nodes[].headRefName')
+            for h in $heads; do
+              run_id=$(gh run list --workflow merge-order-guard.yml --branch "$h" \
+                --limit 1 --json databaseId --jq '.[0].databaseId')
+              if [ -n "$run_id" ]; then
+                gh run rerun "$run_id" || true
+              fi
+            done
+          done


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #660 — chore(ci): PR 머지 순서 가드 — blocked_by 미해소·비develop base 시 check 실패

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `merge-order-guard` 워크플로 추가 (1c9454c3)
  - **guard** (pull_request): PR 의 closing 이슈에 아직 열린 blocked_by 가 있으면 실패(머지 순서 위반), base 가 develop/main 이 아니어도 실패(스택 PR 은 develop 로 PATCH 후 머지)
  - **refresh** (issues closed/reopened): blocker 이슈가 닫히면 그 이슈가 blocking 하던 열린 PR 의 guard 런을 `gh run rerun` 으로 재실행해 check 를 초록으로 갱신

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — CI 워크플로 추가만.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- GitHub 는 이슈 Relationships(blocked_by)를 표시만 하고 머지 버튼을 잠그지 않아, 스택 순서(#543→#545→#605 류)를 사람이 기억해야 했던 것의 자동화입니다.
- **이 PR 자체가 guard 의 첫 실측입니다** — closing 이슈 #660 은 blocked_by 없음 + base=develop 이라 초록이 정상. GITHUB_TOKEN 으로 dependencies REST API 가 읽히는지도 이 런에서 확인됩니다.
- refresh 잡은 issues 이벤트 트리거라 default 브랜치의 워크플로만 실행됩니다 — 머지 후부터 동작.
- 워크플로가 쓰는 GraphQL 쿼리 2종(closingIssuesReferences / closedByPullRequestsReferences)은 로컬에서 실측 검증했습니다(PR #543→#534, 이슈 #536→feat/536 정확).
- check 를 required 로 승격해 머지 버튼을 실제로 잠그려면 Settings → Branches 의 develop 보호 규칙에 `guard` 지정이 필요합니다(admin 설정, 워크플로 밖).
- 빌드 검증: Kotlin 변경 없음 — YAML 파싱 검증 통과(actionlint 미설치, 셸 스크립트 구문은 이 PR 의 첫 런이 검증).
