### PR TITLE
fix(ci): Review Assign 트리거에 reopened·synchronize 추가 — 생성 이벤트 유실 시 복구 (closes 668)

### DIFF
--- a/.github/workflows/PRassign.yml
+++ b/.github/workflows/PRassign.yml
@@ -1,7 +1,7 @@
 name: Review Assign
 on:
   pull_request:
-    types: [ opened, ready_for_review ]
+    types: [ opened, ready_for_review, reopened, synchronize ]
 
 permissions:
   pull-requests: write
@@ -10,6 +10,12 @@ permissions:
 jobs:
   assign:
     runs-on: ubuntu-latest
+    # opened 가 유실되면 assignee·reviewer 가 영영 안 붙는다 — PR #659 는 그렇게 3일 방치됐다.
+    # synchronize 를 복구용으로 받되 이미 붙어 있으면 건너뛴다. 무조건 태우면 리뷰를 낸 사람에게
+    # push 마다 재리뷰 요청이 나간다.
+    if: >-
+      github.event.action != 'synchronize' ||
+      github.event.pull_request.assignees[0] == null
     steps:
       - uses: hkusu/review-assign-action@v1
         with:


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #668 — fix(ci): PR 생성 이벤트 유실 시 assignee·리뷰어 미지정 — Review Assign 트리거에 synchronize·reopened 추가

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `PRassign.yml` 트리거에 `reopened`·`synchronize` 추가 — `opened` 를 놓쳐도 다음 push 나 reopen 에서 복구된다 (`d9bea103`)
- `synchronize` 는 assignee 가 비어 있을 때만 태우는 job 조건 추가 — 무조건 태우면 리뷰를 낸 사람에게 push 마다 재리뷰 요청이 나간다

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 변경 범위가 GitHub Actions 워크플로 YAML 단독이라 앱 코드·리소스 diff 가 0건이다. screenshotTest·에뮬 실측 대상 아님.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 발단: PR #659 가 assignee 0명·리뷰 요청 0건인 채 3일간 방치됐다. feat/503 브랜치의 워크플로 런을 전수 조회하니 PR 생성 시각(2026-07-31T17:47:16Z)에 런이 **0건**이고, 18분 뒤 18:05:49Z 에 CI 3종만 `pull_request` 로 실행됐다. 생성 이벤트가 유실됐고 뒤이은 push 는 `synchronize` 라 기존 트리거 목록(`opened`, `ready_for_review`)에 없어 끝내 복구되지 않았다. draft 였거나 close→reopen 된 흔적은 없다(`isDraft=false`, timeline 에 해당 이벤트 0건). #659 자체는 수동으로 채워 이미 해소했다.
- `synchronize` 를 조건 없이 넣지 않은 이유: `POST /pulls/{n}/requested_reviewers` 는 이미 리뷰를 제출한 사람을 다시 지정하면 재리뷰 요청이 되어 알림이 간다. CHANGES_REQUESTED 상태에서 push 를 반복하는 게 일상이라 그대로 두면 알림이 계속 나간다. 그래서 `github.event.pull_request.assignees[0] == null` 로 "아직 안 붙은 PR" 에만 태운다.
- 동작 검증 — actionlint 지적 0건, 조건 시뮬레이션 결과: `opened`/`ready_for_review`/`reopened` → 실행, `synchronize`+assignee 있음 → skip, `synchronize`+assignee 없음 → 실행.
- 이 워크플로는 default branch 판이 아니라 **PR base 브랜치 판**이 도므로, 머지 전까지는 기존 동작 그대로다.
- 빌드 검증: 워크플로 YAML 단독 변경이라 Gradle 모듈 대상 없음. `actionlint .github/workflows/*.yml` 전수 PASS 로 갈음했다.
