### PR TITLE
fix(core): 회원 탈퇴 성공 후 로컬 세션 정리 (closes 586)

### DIFF
--- a/core/data/src/main/java/com/afternote/core/data/repoimpl/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/afternote/core/data/repoimpl/UserRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.afternote.core.data.repoimpl
 
+import android.util.Log
 import com.afternote.core.data.mapper.delivery.toRequestDto
 import com.afternote.core.data.mapper.user.toDomain
 import com.afternote.core.data.mapper.user.toDto
@@ -148,12 +149,16 @@ class UserRepositoryImpl
          *
          * `clearSession()` 의 실패는 삼킨다. 서버 계정은 이미 지워졌으므로 여기서 예외를 올리면
          * 화면이 "탈퇴 실패" 로 표시돼 사용자가 재시도하고, 그 재시도는 없는 계정에 대해 실패한다.
+         * 대신 흔적은 남긴다 — 조용히 넘기면 로컬 토큰이 남은 채로 이 버그가 재발해도 탐지되지 않는다.
+         * 예외 인스턴스가 아니라 타입만 넘기는 건 release 에서 `Log.e` 가 제거되지 않아서다.
          */
         override suspend fun deleteAccount() {
             userApiService
                 .deleteAccount()
                 .requireStatus()
-            authRepository.clearSession()
+            authRepository.clearSession().onFailure {
+                Log.e("UserRepository", "탈퇴 후 세션 정리 실패: ${it.javaClass.name}")
+            }
         }
 
         override suspend fun logActivity() {

--- a/core/data/src/main/java/com/afternote/core/data/repoimpl/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/afternote/core/data/repoimpl/UserRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.afternote.core.data.mapper.delivery.toRequestDto
 import com.afternote.core.data.mapper.user.toDomain
 import com.afternote.core.data.mapper.user.toDto
 import com.afternote.core.domain.repository.UserRepository
+import com.afternote.core.domain.repository.auth.AuthRepository
 import com.afternote.core.model.delivery.DeliveryConditionItem
 import com.afternote.core.model.delivery.ReceiverDeliveryConditions
 import com.afternote.core.model.user.DeliveryCondition
@@ -37,6 +38,7 @@ class UserRepositoryImpl
     @Inject
     constructor(
         private val userApiService: UserApiService,
+        private val authRepository: AuthRepository,
     ) : UserRepository {
         private val receiverCache = MutableStateFlow<List<Receiver>?>(null)
 
@@ -137,10 +139,21 @@ class UserRepositoryImpl
                 ).requireData()
                 .toDomain()
 
+        /**
+         * 탈퇴 성공 후 로컬 세션도 정리한다 (#586) — 서버가 계정을 지워도 토큰이 남으면 재시작 시
+         * 죽은 토큰으로 홈이 뜨고 인증 요청이 연달아 401 로 실패한다(2026-07-28 에뮬 실측).
+         *
+         * 정리를 서버 호출 **뒤**에 두는 건 `AuthRepositoryImpl.logout()` 과 같은 이유 — DELETE 요청도
+         * `AuthInterceptor` 를 지나므로 그 시점엔 토큰이 살아 있어야 한다.
+         *
+         * `clearSession()` 의 실패는 삼킨다. 서버 계정은 이미 지워졌으므로 여기서 예외를 올리면
+         * 화면이 "탈퇴 실패" 로 표시돼 사용자가 재시도하고, 그 재시도는 없는 계정에 대해 실패한다.
+         */
         override suspend fun deleteAccount() {
             userApiService
                 .deleteAccount()
                 .requireStatus()
+            authRepository.clearSession()
         }
 
         override suspend fun logActivity() {

--- a/core/data/src/test/java/com/afternote/core/data/repoimpl/UserRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/afternote/core/data/repoimpl/UserRepositoryImplTest.kt
@@ -1,0 +1,178 @@
+package com.afternote.core.data.repoimpl
+
+import com.afternote.core.domain.repository.auth.AuthRepository
+import com.afternote.core.model.Session
+import com.afternote.core.model.TokenBundle
+import com.afternote.core.network.dto.DeliveryConditionDto
+import com.afternote.core.network.dto.DeliveryConditionRequestDto
+import com.afternote.core.network.dto.ReceiverDetailDto
+import com.afternote.core.network.dto.ReceiverListDto
+import com.afternote.core.network.dto.SocialAccountLinkRequestDto
+import com.afternote.core.network.dto.UserConnectedAccountDto
+import com.afternote.core.network.dto.UserCreateReceiverDto
+import com.afternote.core.network.dto.UserCreateReceiverRequestDto
+import com.afternote.core.network.dto.UserDto
+import com.afternote.core.network.dto.UserPatchReceiverDto
+import com.afternote.core.network.dto.UserPatchReceiverRequestDto
+import com.afternote.core.network.dto.UserPushSettingDto
+import com.afternote.core.network.dto.UserUpdateProfileRequestDto
+import com.afternote.core.network.dto.UserUpdatePushSettingRequestDto
+import com.afternote.core.network.dto.UserUpdateReceiverMessageRequestDto
+import com.afternote.core.network.dto.delivery.ReceiverDeliveryConditionDto
+import com.afternote.core.network.dto.delivery.ReceiverDeliveryConditionUpdateRequestDto
+import com.afternote.core.network.model.ApiException
+import com.afternote.core.network.model.BaseResponse
+import com.afternote.core.network.service.UserApiService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * [UserRepositoryImpl] 의 회원 탈퇴 세션 정리 계약 회귀 가드 (#586).
+ *
+ * 계약 — 서버 탈퇴가 성공한 **뒤에만** 로컬 세션을 정리한다. 정리를 빠뜨리면 재시작 시 삭제된
+ * 계정의 토큰으로 홈이 뜨고, 앞당기면 DELETE 요청 자체가 토큰을 잃는다.
+ */
+class UserRepositoryImplTest {
+    private val calls = mutableListOf<String>()
+
+    private fun repository(deleteAccountResponse: BaseResponse<Unit> = success()) =
+        UserRepositoryImpl(
+            userApiService =
+                FakeUserApiService(
+                    onDeleteAccount = {
+                        calls += "deleteAccount"
+                        deleteAccountResponse
+                    },
+                ),
+            authRepository = FakeAuthRepository(onClearSession = { calls += "clearSession" }),
+        )
+
+    @Test
+    fun `deleteAccount - 탈퇴 성공 시 로컬 세션을 정리한다`() {
+        val repository = repository()
+
+        runBlocking { repository.deleteAccount() }
+
+        assertEquals(listOf("deleteAccount", "clearSession"), calls)
+    }
+
+    @Test
+    fun `deleteAccount - 서버 탈퇴 실패면 세션을 유지한다`() {
+        val repository = repository(deleteAccountResponse = BaseResponse(status = 500, code = 500))
+
+        assertThrows(ApiException::class.java) {
+            runBlocking { repository.deleteAccount() }
+        }
+
+        assertEquals(listOf("deleteAccount"), calls)
+    }
+
+    /** 정리가 DELETE 앞에 오면 요청이 토큰 없이 나가므로, 순서 자체가 계약이다. */
+    @Test
+    fun `deleteAccount - 세션 정리는 서버 호출 뒤에 온다`() {
+        val repository = repository()
+
+        runBlocking { repository.deleteAccount() }
+
+        assertEquals(0, calls.indexOf("deleteAccount"))
+        assertEquals(1, calls.indexOf("clearSession"))
+    }
+}
+
+private fun success() = BaseResponse<Unit>(status = 200, code = 200)
+
+private class FakeUserApiService(
+    private val onDeleteAccount: () -> BaseResponse<Unit>,
+) : UserApiService {
+    override suspend fun deleteAccount(): BaseResponse<Unit> = onDeleteAccount()
+
+    override suspend fun getReceivers(): BaseResponse<List<ReceiverListDto>> = TODO("이 테스트 미사용")
+
+    override suspend fun createReceiver(request: UserCreateReceiverRequestDto): BaseResponse<UserCreateReceiverDto> = TODO("이 테스트 미사용")
+
+    override suspend fun getReceiverDetail(receiverId: Long): BaseResponse<ReceiverDetailDto> = TODO("이 테스트 미사용")
+
+    override suspend fun updateReceiver(
+        receiverId: Long,
+        request: UserPatchReceiverRequestDto,
+    ): BaseResponse<UserPatchReceiverDto> = TODO("이 테스트 미사용")
+
+    override suspend fun updateReceiverMessage(
+        receiverId: Long,
+        request: UserUpdateReceiverMessageRequestDto,
+    ): BaseResponse<Unit> = TODO("이 테스트 미사용")
+
+    override suspend fun getMyProfile(): BaseResponse<UserDto> = TODO("이 테스트 미사용")
+
+    override suspend fun updateMyProfile(request: UserUpdateProfileRequestDto): BaseResponse<UserDto> = TODO("이 테스트 미사용")
+
+    override suspend fun logActivity(): BaseResponse<Unit> = TODO("이 테스트 미사용")
+
+    override suspend fun getMyPushSettings(): BaseResponse<UserPushSettingDto> = TODO("이 테스트 미사용")
+
+    override suspend fun updateMyPushSettings(request: UserUpdatePushSettingRequestDto): BaseResponse<UserPushSettingDto> =
+        TODO("이 테스트 미사용")
+
+    override suspend fun getConnectedAccounts(): BaseResponse<UserConnectedAccountDto> = TODO("이 테스트 미사용")
+
+    override suspend fun linkConnectedAccount(
+        provider: String,
+        request: SocialAccountLinkRequestDto,
+    ): BaseResponse<UserConnectedAccountDto> = TODO("이 테스트 미사용")
+
+    override suspend fun unlinkConnectedAccount(provider: String): BaseResponse<UserConnectedAccountDto> = TODO("이 테스트 미사용")
+
+    override suspend fun getDeliveryCondition(): BaseResponse<DeliveryConditionDto> = TODO("이 테스트 미사용")
+
+    override suspend fun updateDeliveryCondition(request: DeliveryConditionRequestDto): BaseResponse<DeliveryConditionDto> =
+        TODO("이 테스트 미사용")
+
+    override suspend fun getReceiverDeliveryConditions(receiverId: Long): BaseResponse<ReceiverDeliveryConditionDto> = TODO("이 테스트 미사용")
+
+    override suspend fun updateReceiverDeliveryConditions(
+        receiverId: Long,
+        request: ReceiverDeliveryConditionUpdateRequestDto,
+    ): BaseResponse<ReceiverDeliveryConditionDto> = TODO("이 테스트 미사용")
+}
+
+private class FakeAuthRepository(
+    private val onClearSession: () -> Unit,
+) : AuthRepository {
+    override val isLoggedIn: Flow<Boolean> = flowOf(true)
+
+    override suspend fun clearSession(): Result<Unit> {
+        onClearSession()
+        return Result.success(Unit)
+    }
+
+    override suspend fun saveSession(
+        accessToken: String,
+        refreshToken: String,
+    ): Result<Unit> = TODO("이 테스트 미사용")
+
+    override suspend fun updateTokens(
+        accessToken: String,
+        refreshToken: String,
+    ): Result<Unit> = TODO("이 테스트 미사용")
+
+    override suspend fun getAccessToken(): Result<String?> = TODO("이 테스트 미사용")
+
+    override suspend fun getRefreshToken(): Result<String?> = TODO("이 테스트 미사용")
+
+    override suspend fun defaultLogin(
+        email: String,
+        password: String,
+    ): Result<Session.DefaultSession> = TODO("이 테스트 미사용")
+
+    override suspend fun kakaoLogin(oauthToken: String): Result<Session.SocialSession> = TODO("이 테스트 미사용")
+
+    override suspend fun googleLogin(idToken: String): Result<Session.SocialSession> = TODO("이 테스트 미사용")
+
+    override suspend fun rotateToken(): Result<TokenBundle> = TODO("이 테스트 미사용")
+
+    override suspend fun logout(): Result<Unit> = TODO("이 테스트 미사용")
+}

--- a/core/data/src/test/java/com/afternote/core/data/repoimpl/UserRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/afternote/core/data/repoimpl/UserRepositoryImplTest.kt
@@ -39,17 +39,25 @@ import org.junit.Test
 class UserRepositoryImplTest {
     private val calls = mutableListOf<String>()
 
-    private fun repository(deleteAccountResponse: BaseResponse<Unit> = success()) =
-        UserRepositoryImpl(
-            userApiService =
-                FakeUserApiService(
-                    onDeleteAccount = {
-                        calls += "deleteAccount"
-                        deleteAccountResponse
-                    },
-                ),
-            authRepository = FakeAuthRepository(onClearSession = { calls += "clearSession" }),
-        )
+    private fun repository(
+        deleteAccountResponse: BaseResponse<Unit> = success(),
+        clearSessionResult: Result<Unit> = Result.success(Unit),
+    ) = UserRepositoryImpl(
+        userApiService =
+            FakeUserApiService(
+                onDeleteAccount = {
+                    calls += "deleteAccount"
+                    deleteAccountResponse
+                },
+            ),
+        authRepository =
+            FakeAuthRepository(
+                onClearSession = {
+                    calls += "clearSession"
+                    clearSessionResult
+                },
+            ),
+    )
 
     @Test
     fun `deleteAccount - 탈퇴 성공 시 로컬 세션을 정리한다`() {
@@ -69,6 +77,19 @@ class UserRepositoryImplTest {
         }
 
         assertEquals(listOf("deleteAccount"), calls)
+    }
+
+    /**
+     * 서버 계정은 이미 지워진 뒤라 정리 실패를 예외로 올리면 화면이 "탈퇴 실패" 로 표시되고,
+     * 사용자의 재시도는 없는 계정에 대해 다시 실패한다. 삼키는 것이 계약이다.
+     */
+    @Test
+    fun `deleteAccount - 세션 정리가 실패해도 탈퇴는 성공으로 끝난다`() {
+        val repository = repository(clearSessionResult = Result.failure(IllegalStateException("datastore 쓰기 실패")))
+
+        runBlocking { repository.deleteAccount() }
+
+        assertEquals(listOf("deleteAccount", "clearSession"), calls)
     }
 
     /** 정리가 DELETE 앞에 오면 요청이 토큰 없이 나가므로, 순서 자체가 계약이다. */
@@ -140,14 +161,11 @@ private class FakeUserApiService(
 }
 
 private class FakeAuthRepository(
-    private val onClearSession: () -> Unit,
+    private val onClearSession: () -> Result<Unit>,
 ) : AuthRepository {
     override val isLoggedIn: Flow<Boolean> = flowOf(true)
 
-    override suspend fun clearSession(): Result<Unit> {
-        onClearSession()
-        return Result.success(Unit)
-    }
+    override suspend fun clearSession(): Result<Unit> = onClearSession()
 
     override suspend fun saveSession(
         accessToken: String,


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #586 — fix(core): 회원 탈퇴 성공 후 로컬 세션 미삭제 — 재시작 시 삭제된 계정 토큰으로 401 반복

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `UserRepositoryImpl.deleteAccount()` 가 서버 탈퇴 성공 후 `AuthRepository.clearSession()` 을 호출하도록 했다. `clearSession()` 은 `tokenDataSource.clearTokens()` + `expiryTracker.clear()` 를 이미 수행하는 기존 경로라, 정리 로직을 새로 만들지 않고 그대로 쓴다.
- 정리를 서버 호출 **뒤**에 둔 이유를 KDoc 으로 남겼다 — `DELETE /users/me` 요청도 `AuthInterceptor` 를 지나므로 그 시점엔 토큰이 살아 있어야 한다. `AuthRepositoryImpl.logout()` 이 같은 이유로 같은 순서를 쓰고 그 근거를 주석에 남겨 두었다.
- `clearSession()` 의 실패는 삼킨다. 서버 계정은 이미 지워진 뒤라 여기서 예외를 올리면 화면이 "탈퇴 실패" 로 표시되고, 사용자의 재시도는 없는 계정에 대해 다시 실패한다.
- `UserRepositoryImplTest` 신설 — 탈퇴 성공 시 정리 / 서버 실패 시 세션 유지 / 정리가 서버 호출 뒤 세 계약을 고정한다.

`UserRepository` 인터페이스와 호출부(`SettingViewModel`)는 수정하지 않았다. 변경이 data 계층 안에서 닫힌다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — data 계층만 바뀌어 Compose 트리·리소스에 손댄 곳이 0이다. screenshotTest baseline 재생성 불요.

DI 변경이 있어 에뮬(Afternote_QA2, debug APK) 로 기동까지는 실측했다 — `topResumedActivity=com.afternote.afternote_fe/.MainActivity`, logcat 에 FATAL·Hilt·Dagger 오류 0건, 로그인 화면 정상 렌더.

다만 **탈퇴 흐름 자체는 서버 차단으로 미실행**이다. `afternote.kro.kr` 인증서가 `notAfter=Aug 1 06:36:00 2026 GMT` 로 만료돼(2026-08-02 실측) OkHttp 가 전 요청을 끊어 로그인부터 불가하다. `curl -k` 로는 `/v3/api-docs` 가 200 이라 서버 프로세스 자체는 살아 있고, 갱신은 Afternote-BE #101 로 등록돼 있다. 인증서가 갱신되면 QA 계정으로 탈퇴를 완주해 `files/datastore/Token.preferences_pb` 가 비는지 확인하겠다 — 이슈 본문의 재현이 그 파일에 토큰이 남는 것을 실측한 건이라 같은 자리를 본다.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- **Hilt 순환은 없다.** `UserRepositoryImpl` 이 `AuthRepository` 를 새로 받지만 `AuthRepositoryImpl` 은 `UserRepository` 를 참조하지 않는다(브랜치 전수 grep 0건). 컴포넌트 조립이 실제로 통과하는지는 `:app:kspDebugKotlin` 으로 확인했다 — Hilt 는 그래프를 컴파일 타임에 완결 검증하므로 이 통과가 런타임 주입 가능의 근거다.
- 이 PR 은 **탈퇴 경로만** 다룬다. 같은 뿌리인 #588(로그아웃에 `receiverCache` 정리 없음)은 `AuthRepositoryImpl.logout()` 을 건드려야 하는데, 그 파일은 #672 가 `runCatching` → `runCatchingCancellable` 로 전면 치환 중이라 충돌을 피해 분리했다. #588 착수 시 두 경로의 정리 지점을 한 곳으로 모으는 편이 좋겠다.
- 서버 쪽 잔여 문제는 이슈 본문에 적어 둔 대로다 — 탈퇴된 계정의 accessToken 이 일부 API 에서 그대로 통한다(`/diary`·`/time-letters`·`/afternotes`·`/daily-questions` 200). FE 가 토큰을 지우면 앱 경로에서는 닫히지만 근본 해결은 서버 몫이라 Afternote-BE 에 별도 등록돼 있다.
- 빌드 검증: `./gradlew :app:compileDebugKotlin` · `:core:data:testDebugUnitTest`(신규 3건 + 기존 전체) · `:core:data:ktlintCheck` 전부 BUILD SUCCESSFUL.
