### PR TITLE
fix(app): release 서명 자격 4키 원자 검증 및 실패 시점 조기화 (closes 663) [base: develop]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,37 +38,66 @@ android {
     }
 
     signingConfigs {
+        // 네 키를 하나의 단위로 다루는 근거는 아래 debug 주석과 같다. 다른 점은 폴백 대상이
+        // 없다는 것뿐이라, 전부 미기재면 release 빌드만 끊는다.
         create("release") {
-            val releaseStoreFile = localProperties.getProperty("RELEASE_STORE_FILE")
-            if (releaseStoreFile != null) {
-                storeFile = file(releaseStoreFile)
-                storePassword = localProperties.getProperty("RELEASE_STORE_PASSWORD")
-                keyAlias = localProperties.getProperty("RELEASE_KEY_ALIAS")
-                keyPassword = localProperties.getProperty("RELEASE_KEY_PASSWORD")
+            val releaseSigningKeys =
+                listOf(
+                    "RELEASE_STORE_FILE",
+                    "RELEASE_STORE_PASSWORD",
+                    "RELEASE_KEY_ALIAS",
+                    "RELEASE_KEY_PASSWORD",
+                )
+            val provided =
+                releaseSigningKeys
+                    .mapNotNull { key ->
+                        localProperties.getProperty(key)?.takeIf { it.isNotBlank() }?.let { key to it }
+                    }.toMap()
+
+            when (provided.size) {
+                0 -> {
+                    requireReleaseSigningForReleaseBuild(releaseSigningKeys)
+                }
+
+                releaseSigningKeys.size -> {
+                    val releaseKeystore = file(provided.getValue("RELEASE_STORE_FILE"))
+                    if (!releaseKeystore.isFile) {
+                        throw GradleException(
+                            """
+                            |RELEASE_STORE_FILE 이 가리키는 release keystore 를 찾을 수 없습니다: $releaseKeystore
+                            |파일을 해당 경로에 두거나, RELEASE_* 네 키를 모두 지우세요.
+                            |생성·설정 방법은 README '비개발자 APK 배포' 섹션 참고.
+                            """.trimMargin(),
+                        )
+                    }
+                    storeFile = releaseKeystore
+                    storePassword = provided.getValue("RELEASE_STORE_PASSWORD")
+                    keyAlias = provided.getValue("RELEASE_KEY_ALIAS")
+                    keyPassword = provided.getValue("RELEASE_KEY_PASSWORD")
+                }
+
+                else -> {
+                    throw GradleException(
+                        """
+                        |release 서명 설정이 불완전합니다.
+                        |루트 local.properties 누락 항목: ${(releaseSigningKeys - provided.keys).joinToString()}
+                        |네 키는 하나의 단위입니다 — 모두 채우거나 모두 지우세요.
+                        |생성·설정 방법은 README '비개발자 APK 배포' 섹션 참고.
+                        """.trimMargin(),
+                    )
+                }
             }
         }
-        // 팀 공유 debug keystore 로 서명해 카카오 키 해시를 머신 간 통일.
+        // 팀 공유 debug keystore 로 서명해 카카오 키 해시를 머신 간 통일한다. opt-in 이라
+        // `DEBUG_*` 미기재 머신·CI 는 AGP 기본 `~/.android/debug.keystore` 로 폴백하고, 그때는
+        // 본인 해시를 카카오 콘솔에 등록하면 된다(https://developer.android.com/studio/publish/app-signing).
         //
-        // opt-in 이다. AGP 는 debug keystore 를 머신마다 자동 생성하는 것이 기본이고
-        // (https://developer.android.com/studio/publish/app-signing), 그 모델을 없애지 않는다 —
-        // `DEBUG_*` 를 적지 않은 머신은 아래 when 의 첫 갈래로 빠져 `~/.android/debug.keystore`
-        // 로 서명된다. 빌드·로그인 동작에 차이는 없고, 카카오 콘솔에 본인 해시를 등록하면 된다
-        // (카카오는 원래 "모든 개발자의 디버그 키 해시" 등록을 요구:
-        //  https://developers.kakao.com/docs/latest/ko/android/getting-started).
-        // 공유 keystore 는 그 등록 건수를 1개로 줄이려는 선택지이지 강제가 아니다.
-        // CI 도 프로퍼티가 없으므로 같은 경로로 폴백한다.
+        // 트레이드오프: 파일이 유출되면 제3자가 같은 키 해시로 우리 앱 행세를 할 수 있다. 영향은
+        // debug 한정이고(release 는 별도 keystore, debug 서명 앱은 스토어 배포 불가) 실수 커밋은
+        // `.gitignore` 가 막지만, 전달 경로는 개인 채널로 유지한다.
         //
-        // 트레이드오프: 이 keystore 의 해시가 카카오·구글 콘솔에 등록되므로, 파일이 유출되면
-        // 제3자가 같은 키 해시로 우리 앱 행세를 하며 소셜 로그인을 호출할 수 있다. 영향은
-        // debug 한정이다 — release 는 별도 keystore(`RELEASE_*`) 이고, debug 인증서로 서명한
-        // 앱은 스토어 배포가 불가능하다("insecure by design", 위 Android 문서). 실수 커밋은
-        // 루트 `.gitignore` 의 `*.jks`·`*.keystore` 가 막지만, 전달 경로는 개인 채널로 유지한다.
-        // 이 리스크를 받아들이기 싫으면 위 opt-out(프로퍼티 미기재)을 쓰면 된다.
-        //
-        // 네 키는 하나의 단위로 다룬다. `DEBUG_STORE_FILE` 만 보고 진입하면 storeFile 은 공유
-        // keystore 로 바뀌는데 자격 값은 기본 keystore 의 `android` 가 아니라 null 로 덮여,
-        // 폴백도 아니고 원인도 안 보이는 서명 실패가 난다. 부분 기재·경로 오류는 서명 단계까지
-        // 가지 않고 configuration 단계에서 누락 항목을 알리며 끊는다.
+        // 네 키는 하나의 단위로 다룬다. `DEBUG_STORE_FILE` 만 보고 진입하면 자격 값이 null 로
+        // 덮여 폴백도 아니고 원인도 안 보이는 서명 실패가 난다.
         getByName("debug") {
             val debugSigningKeys =
                 listOf(

--- a/build-logic/src/main/kotlin/ReleaseKeyGuard.kt
+++ b/build-logic/src/main/kotlin/ReleaseKeyGuard.kt
@@ -45,22 +45,63 @@ fun Project.requireKeyForReleaseBuild(
         keyName.split("_").joinToString("") { word ->
             word.lowercase().replaceFirstChar { it.uppercase() }
         }
+    registerReleaseBuildGuard(
+        taskName = "check${taskSuffix}ForRelease",
+        taskDescription = "release 빌드 전에 $keyName 주입 여부를 검증한다.",
+        isMissing = value.isBlank(),
+        failureMessage =
+            """
+            |$keyName 가 비어 있어 release 빌드를 중단합니다.
+            |빈 키로 빌드된 release APK 는 소셜 로그인이 동작하지 않습니다.
+            |루트 local.properties 또는 CI 환경변수 $keyName 를 설정한 뒤 다시 빌드하세요.
+            |발급·설정 방법은 README '신규 팀원 빌드 셋업' 섹션 참고.
+            """.trimMargin(),
+    )
+}
+
+/**
+ * release 서명 자격 네 키가 하나도 없을 때 release variant 빌드를 시작 시점에 끊는다.
+ *
+ * 두지 않아도 AGP 가 `packageRelease` 에서 실패시키기는 한다. 다만 R8·lintVital 을 모두 마친
+ * 뒤라 느리고(실측 1분 31초) 무엇을 채워야 하는지도 알리지 않는다.
+ *
+ * [missingKeys] 가 비어 있으면 통과한다. 일부만 기재된 경우는 debug 빌드에서도 잘못된 상태라
+ * 호출부가 configuration 단계에서 끊는다.
+ */
+fun Project.requireReleaseSigningForReleaseBuild(missingKeys: List<String>) {
+    registerReleaseBuildGuard(
+        taskName = "checkReleaseSigningForRelease",
+        taskDescription = "release 빌드 전에 서명 자격 네 키 주입 여부를 검증한다.",
+        isMissing = missingKeys.isNotEmpty(),
+        failureMessage =
+            """
+            |release 서명 자격이 없어 release 빌드를 중단합니다.
+            |루트 local.properties 누락 항목: ${missingKeys.joinToString()}
+            |네 키는 하나의 단위입니다 — 모두 채우세요. debug 와 달리 release 에는 폴백 keystore 가 없습니다.
+            |생성·설정 방법은 README '비개발자 APK 배포' 섹션 참고.
+            """.trimMargin(),
+    )
+}
+
+/**
+ * `preReleaseBuild` 에 매달아 release variant 를 실제로 빌드할 때만 도는 검증 태스크를 등록한다.
+ *
+ * 판정과 메시지를 값으로 받는 이유는 configuration cache 다 — 태스크 상태가 직렬화되므로 액션
+ * 람다가 [Project] 를 캡처하면 안 된다.
+ */
+private fun Project.registerReleaseBuildGuard(
+    taskName: String,
+    taskDescription: String,
+    isMissing: Boolean,
+    failureMessage: String,
+) {
     val guard =
-        tasks.register("check${taskSuffix}ForRelease") {
+        tasks.register(taskName) {
             group = "verification"
-            description = "release 빌드 전에 $keyName 주입 여부를 검증한다."
-            // configuration cache 가 태스크 상태를 직렬화하므로 Project 참조 없이 값만 캡처한다.
-            val isMissing = value.isBlank()
+            description = taskDescription
             doFirst {
                 if (isMissing) {
-                    throw GradleException(
-                        """
-                        |$keyName 가 비어 있어 release 빌드를 중단합니다.
-                        |빈 키로 빌드된 release APK 는 소셜 로그인이 동작하지 않습니다.
-                        |루트 local.properties 또는 CI 환경변수 $keyName 를 설정한 뒤 다시 빌드하세요.
-                        |발급·설정 방법은 README '신규 팀원 빌드 셋업' 섹션 참고.
-                        """.trimMargin(),
-                    )
+                    throw GradleException(failureMessage)
                 }
             }
         }

--- a/build-logic/src/test/kotlin/ReleaseKeyGuardTest.kt
+++ b/build-logic/src/test/kotlin/ReleaseKeyGuardTest.kt
@@ -96,6 +96,37 @@ class ReleaseKeyGuardTest {
         assertTrue(result.output.contains("TEST_SOCIAL_KEY 가 비어 있어 release 빌드를 중단합니다"))
     }
 
+    @Test
+    fun `서명 자격이 없으면 release 경로가 누락 항목과 함께 실패한다`() {
+        writeStubProject(
+            """requireReleaseSigningForReleaseBuild(listOf("RELEASE_STORE_FILE", "RELEASE_KEY_ALIAS"))""",
+        )
+
+        val result = runner("assembleRelease").buildAndFail()
+
+        assertEquals(TaskOutcome.FAILED, result.task(":checkReleaseSigningForRelease")?.outcome)
+        assertTrue(result.output.contains("release 서명 자격이 없어 release 빌드를 중단합니다"))
+        assertTrue(result.output.contains("RELEASE_STORE_FILE, RELEASE_KEY_ALIAS"))
+    }
+
+    @Test
+    fun `서명 자격이 갖춰지면 release 경로가 통과한다`() {
+        writeStubProject("""requireReleaseSigningForReleaseBuild(emptyList<String>())""")
+
+        val result = runner("assembleRelease").build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":checkReleaseSigningForRelease")?.outcome)
+    }
+
+    @Test
+    fun `서명 자격이 없어도 debug 경로는 가드를 태우지 않는다`() {
+        writeStubProject("""requireReleaseSigningForReleaseBuild(listOf("RELEASE_STORE_FILE"))""")
+
+        val result = runner("assembleDebug").build()
+
+        assertNull(result.task(":checkReleaseSigningForRelease"))
+    }
+
     private fun writeStubProject(guardWiring: String) {
         val classpathLiteral =
             guardClasspath()


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #663 — fix(app): release 서명 자격이 부분 기재 시 null 로 덮여 서명 실패 — RELEASE_* 4키 원자 검증 부재

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `signingConfigs.release` 를 `RELEASE_STORE_FILE` 단독 진입에서 네 키 원자 판정으로 전환 — debug 와 같은 3갈래 `when`(전부 미기재 / 전부 기재 / 부분 기재)
- 부분 기재와 keystore 경로 오류는 configuration 단계에서 누락 항목·경로를 알리며 중단
- 네 키 전부 미기재는 `requireReleaseSigningForReleaseBuild` 로 `preReleaseBuild` 앞에서 중단
- 두 가드가 공유하는 태스크 등록 로직을 `registerReleaseBuildGuard` private 헬퍼로 추출 (기존 public 시그니처 유지)
- `ReleaseKeyGuardTest` 회귀 테스트 3건 추가
- 같은 블록의 debug 주석 22줄 → 9줄 정리 (중복 서술과 README 가 이미 담은 내용 제거)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 변경 파일이 `app/build.gradle.kts` 와 `build-logic` 둘뿐이다. Compose 본문·리소스·디자인 토큰 변경이 0건이라 screenshotTest baseline 갱신과 에뮬레이터 실측 모두 대상이 아니다.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- **0키 갈래는 "실패로 승격"이 아니라 "실패 시점 조기화"입니다.** 이슈 Note 가 요구한 현행 동작을 먼저 실측했더니, 네 키가 없어도 서명 안 된 APK 가 나가지는 않고 AGP 가 `packageRelease` 에서 `SigningConfig "release" is missing required property "storeFile"` 로 중단시켰습니다. 다만 R8·lintVital·리소스 최적화를 모두 마친 뒤라 **1분 31초(953 태스크)** 를 쓰고, 무엇을 채워야 하는지도 알리지 않았습니다. 그래서 결과는 그대로 두고 시점만 당겼습니다 — 같은 조건에서 **10초(21 태스크)** 로 끊깁니다.
- **CI 는 영향받지 않습니다.** `lint.yml`·`unit-test.yml`·`screenshot.yml` 이 전부 debug variant(`lintDebug`·`testDebugUnitTest`)만 돌고, release 를 도는 `release-distribution.yml` 은 `RELEASE_*` 4키를 주입합니다.
- 시나리오 5종 실측 결과:

| 조건 | 결과 |
|---|---|
| 4키 미기재 + `assembleRelease` | `checkReleaseSigningForRelease` 에서 10초 중단, 누락 4키 명시 |
| 3키 누락(부분 기재) | configuration 4초 중단, 누락 항목 명시 |
| 4키 기재 + keystore 파일 없음 | configuration 4초 중단, 경로 명시 |
| 4키 미기재 + `assembleDebug` | 성공 — debug 개발 경로 영향 없음 |
| 4키 정상 + `assembleRelease` | 성공, APK 서명 인증서 SHA-256 이 keystore 지문과 일치 |

- IDE 가 `requireReleaseSigningForReleaseBuild` 를 "never used" 로 표시하는데 오탐입니다. 유일한 실제 호출부가 `app/build.gradle.kts` 라, included build(`build-logic`)에 선언된 함수가 빌드 스크립트에서 쓰이는 것을 IDE 가 참조로 인덱싱하지 못합니다. 옆의 `requireKeyForReleaseBuild` 에 같은 경고가 안 뜨는 건 `socialLoginKey` 가 같은 파일 안에서 Kotlin 코드로 부르기 때문이고, 테스트 3건의 호출도 TestKit 스텁의 문자열 리터럴이라 잡히지 않습니다. 실제로는 쓰이는 함수라 `@Suppress` 는 붙이지 않았습니다.
- 빌드 검증: `./gradlew :app:compileDebugKotlin :build-logic:test :app:ktlintCheck` BUILD SUCCESSFUL (`:build-logic:test` 10건 — 기존 7건 회귀 없음 + 신규 3건)
