### PR TITLE
chore(ci): 배포 릴리스 노트에 포함 이슈·QA 포인트 필수화 (closes 726) [base: develop]

### DIFF
--- a/.github/scripts/collect-deployment-decision-context.mjs
+++ b/.github/scripts/collect-deployment-decision-context.mjs
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const MAX_PULL_REQUEST_PAGES = 10;
+const MAX_PULL_REQUESTS = 50;
+const MAX_ISSUES_PER_PULL_REQUEST = 20;
+const MAX_BODY_LENGTH = 8_000;
+
+function truncate(value, limit = MAX_BODY_LENGTH) {
+    const text = String(value ?? "");
+    return text.length <= limit ? text : `${text.slice(0, limit)}\n...[truncated]`;
+}
+
+export function assertMergedDevelopPullRequest(pullRequest) {
+    if (!pullRequest?.merged_at || !pullRequest?.merge_commit_sha) {
+        throw new Error(`PR #${pullRequest?.number ?? "?"} is not merged`);
+    }
+    if (pullRequest.base?.ref !== "develop") {
+        throw new Error(
+            `PR #${pullRequest.number} targets ${pullRequest.base?.ref ?? "<unknown>"}, not develop`,
+        );
+    }
+}
+
+export function extractClosingIssueNumbers(body) {
+    const numbers = new Set();
+    const pattern = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?[ \t]*(?:[\w.-]+\/[\w.-]+)?#([1-9][0-9]*)/gi;
+    let match;
+    while ((match = pattern.exec(String(body ?? ""))) !== null) {
+        numbers.add(Number(match[1]));
+    }
+    return [...numbers];
+}
+
+export function selectMergedPullRequests(pullRequests, since, until) {
+    const sinceTime = since ? Date.parse(since) : Number.NEGATIVE_INFINITY;
+    const untilTime = Date.parse(until);
+    if (Number.isNaN(untilTime)) {
+        throw new Error(`Invalid target merged_at: ${until}`);
+    }
+
+    return pullRequests
+        .filter((pullRequest) => {
+            if (!pullRequest.merged_at || pullRequest.base?.ref !== "develop") {
+                return false;
+            }
+            const mergedAt = Date.parse(pullRequest.merged_at);
+            return mergedAt > sinceTime && mergedAt <= untilTime;
+        })
+        .sort((left, right) => Date.parse(left.merged_at) - Date.parse(right.merged_at));
+}
+
+export function isTargetCoveredByCompareStatus(status) {
+    return status === "ahead" || status === "identical";
+}
+
+function normalizeIssue(issue) {
+    return {
+        number: issue.number,
+        title: issue.title,
+        body: truncate(issue.body),
+        url: issue.html_url ?? issue.url,
+        labels: (issue.labels?.nodes ?? issue.labels ?? []).map((label) =>
+            typeof label === "string" ? label : label.name,
+        ),
+    };
+}
+
+function normalizePullRequest(pullRequest, issues) {
+    return {
+        number: pullRequest.number,
+        title: pullRequest.title,
+        body: truncate(pullRequest.body),
+        url: pullRequest.html_url,
+        mergedAt: pullRequest.merged_at,
+        mergeCommitSha: pullRequest.merge_commit_sha,
+        author: pullRequest.user?.login,
+        labels: (pullRequest.labels ?? []).map((label) => label.name),
+        closingIssues: issues.map(normalizeIssue),
+    };
+}
+
+async function requestJson(url, token, options = {}) {
+    const response = await fetch(url, {
+        ...options,
+        headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${token}`,
+            "X-GitHub-Api-Version": "2022-11-28",
+            ...options.headers,
+        },
+    });
+    if (!response.ok) {
+        const body = truncate(await response.text(), 2_000);
+        throw new Error(`${options.method ?? "GET"} ${url} failed (${response.status}): ${body}`);
+    }
+    return response.json();
+}
+
+async function listClosedDevelopPullRequests(apiUrl, repository, token) {
+    const pullRequests = [];
+    for (let page = 1; page <= MAX_PULL_REQUEST_PAGES; page += 1) {
+        const query = new URLSearchParams({
+            state: "closed",
+            base: "develop",
+            sort: "updated",
+            direction: "desc",
+            per_page: "100",
+            page: String(page),
+        });
+        const pageItems = await requestJson(
+            `${apiUrl}/repos/${repository}/pulls?${query.toString()}`,
+            token,
+        );
+        pullRequests.push(...pageItems);
+        if (pageItems.length < 100) {
+            return pullRequests;
+        }
+    }
+    throw new Error(
+        `More than ${MAX_PULL_REQUEST_PAGES * 100} closed develop PRs require pagination`,
+    );
+}
+
+async function loadClosingIssues(graphqlUrl, repository, pullRequest, token) {
+    const [owner, name] = repository.split("/");
+    const query = `
+        query($owner: String!, $name: String!, $number: Int!) {
+          repository(owner: $owner, name: $name) {
+            pullRequest(number: $number) {
+              closingIssuesReferences(first: ${MAX_ISSUES_PER_PULL_REQUEST}) {
+                nodes {
+                  number
+                  title
+                  body
+                  url
+                  labels(first: 20) { nodes { name } }
+                }
+              }
+            }
+          }
+        }
+    `;
+    const result = await requestJson(graphqlUrl, token, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query, variables: { owner, name, number: pullRequest.number } }),
+    });
+    if (result.errors?.length) {
+        throw new Error(`GraphQL closing issue query failed: ${JSON.stringify(result.errors)}`);
+    }
+
+    const issues = result.data?.repository?.pullRequest?.closingIssuesReferences?.nodes ?? [];
+    if (issues.length > 0) {
+        return issues;
+    }
+
+    const fallbackNumbers = extractClosingIssueNumbers(pullRequest.body).slice(
+        0,
+        MAX_ISSUES_PER_PULL_REQUEST,
+    );
+    const fallbackIssues = [];
+    for (const issueNumber of fallbackNumbers) {
+        const issue = await requestJson(
+            `${process.env.GITHUB_API_URL ?? "https://api.github.com"}/repos/${repository}/issues/${issueNumber}`,
+            token,
+        );
+        if (!issue.pull_request) {
+            fallbackIssues.push(issue);
+        }
+    }
+    return fallbackIssues;
+}
+
+async function targetCoveredBySuccessfulRun(apiUrl, repository, targetSha, runSha, token) {
+    if (!runSha) {
+        return false;
+    }
+    const comparison = await requestJson(
+        `${apiUrl}/repos/${repository}/compare/${targetSha}...${runSha}`,
+        token,
+    );
+    return isTargetCoveredByCompareStatus(comparison.status);
+}
+
+async function main() {
+    const token = process.env.GITHUB_TOKEN;
+    const repository = process.env.GITHUB_REPOSITORY;
+    const targetPullRequestNumber = Number(process.env.TARGET_PR_NUMBER);
+    const outputPath = process.env.DEPLOYMENT_CONTEXT_PATH;
+    const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+    const graphqlUrl = process.env.GITHUB_GRAPHQL_URL ?? "https://api.github.com/graphql";
+
+    if (!token || !repository || !targetPullRequestNumber || !outputPath) {
+        throw new Error(
+            "GITHUB_TOKEN, GITHUB_REPOSITORY, TARGET_PR_NUMBER, and DEPLOYMENT_CONTEXT_PATH are required",
+        );
+    }
+
+    const targetPullRequest = await requestJson(
+        `${apiUrl}/repos/${repository}/pulls/${targetPullRequestNumber}`,
+        token,
+    );
+    assertMergedDevelopPullRequest(targetPullRequest);
+
+    const workflowRunsQuery = new URLSearchParams({
+        branch: "develop",
+        event: "workflow_dispatch",
+        status: "success",
+        per_page: "20",
+    });
+    const workflowRuns = await requestJson(
+        `${apiUrl}/repos/${repository}/actions/workflows/release-distribution.yml/runs?${workflowRunsQuery.toString()}`,
+        token,
+    );
+    const successfulRuns = workflowRuns.workflow_runs ?? [];
+    const latestSuccessfulRun = successfulRuns[0] ?? null;
+    const covered = latestSuccessfulRun
+        ? await targetCoveredBySuccessfulRun(
+              apiUrl,
+              repository,
+              targetPullRequest.merge_commit_sha,
+              latestSuccessfulRun.head_sha,
+              token,
+          )
+        : false;
+
+    let baselineRun = latestSuccessfulRun;
+    if (
+        baselineRun &&
+        !covered &&
+        Date.parse(baselineRun.run_started_at) > Date.parse(targetPullRequest.merged_at)
+    ) {
+        baselineRun =
+            successfulRuns.find(
+                (run) => Date.parse(run.run_started_at) <= Date.parse(targetPullRequest.merged_at),
+            ) ?? null;
+    }
+
+    const allPullRequests = covered
+        ? []
+        : await listClosedDevelopPullRequests(apiUrl, repository, token);
+    const selectedPullRequests = covered
+        ? []
+        : selectMergedPullRequests(
+              allPullRequests,
+              baselineRun?.run_started_at,
+              targetPullRequest.merged_at,
+          );
+    if (selectedPullRequests.length > MAX_PULL_REQUESTS) {
+        throw new Error(
+            `${selectedPullRequests.length} PRs accumulated since the baseline; refusing a truncated decision`,
+        );
+    }
+
+    const normalizedPullRequests = [];
+    for (const pullRequest of selectedPullRequests) {
+        const issues = await loadClosingIssues(graphqlUrl, repository, pullRequest, token);
+        normalizedPullRequests.push(normalizePullRequest(pullRequest, issues));
+    }
+
+    const decisionContext = {
+        repository,
+        targetPullRequest: normalizePullRequest(
+            targetPullRequest,
+            await loadClosingIssues(graphqlUrl, repository, targetPullRequest, token),
+        ),
+        targetCoveredBySuccessfulDistribution: covered,
+        baselineDistribution: baselineRun
+            ? {
+                  id: baselineRun.id,
+                  headSha: baselineRun.head_sha,
+                  runStartedAt: baselineRun.run_started_at,
+                  url: baselineRun.html_url,
+              }
+            : null,
+        pendingPullRequests: normalizedPullRequests,
+    };
+
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, `${JSON.stringify(decisionContext, null, 2)}\n`, "utf8");
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : "";
+if (import.meta.url === invokedPath) {
+    main().catch((error) => {
+        console.error(error instanceof Error ? error.stack : error);
+        process.exitCode = 1;
+    });
+}

--- a/.github/scripts/collect-deployment-decision-context.test.mjs
+++ b/.github/scripts/collect-deployment-decision-context.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    assertMergedDevelopPullRequest,
+    extractClosingIssueNumbers,
+    isTargetCoveredByCompareStatus,
+    selectMergedPullRequests,
+} from "./collect-deployment-decision-context.mjs";
+
+test("accepts only merged PRs targeting develop", () => {
+    assert.doesNotThrow(() =>
+        assertMergedDevelopPullRequest({
+            number: 726,
+            merged_at: "2026-08-04T01:00:00Z",
+            merge_commit_sha: "abc",
+            base: { ref: "develop" },
+        }),
+    );
+    assert.throws(
+        () =>
+            assertMergedDevelopPullRequest({
+                number: 726,
+                merged_at: "2026-08-04T01:00:00Z",
+                merge_commit_sha: "abc",
+                base: { ref: "main" },
+            }),
+        /not develop/,
+    );
+});
+
+test("extracts unique closing issue references only", () => {
+    assert.deepEqual(
+        extractClosingIssueNumbers("Closes #726, fixes: #713 and mentions #999. Resolves #726"),
+        [726, 713],
+    );
+});
+
+test("selects the cumulative merged PR window in merge order", () => {
+    const pullRequests = [
+        {
+            number: 3,
+            merged_at: "2026-08-04T03:00:00Z",
+            base: { ref: "develop" },
+        },
+        {
+            number: 1,
+            merged_at: "2026-08-04T01:00:00Z",
+            base: { ref: "develop" },
+        },
+        {
+            number: 2,
+            merged_at: "2026-08-04T02:00:00Z",
+            base: { ref: "develop" },
+        },
+        {
+            number: 4,
+            merged_at: "2026-08-04T02:30:00Z",
+            base: { ref: "main" },
+        },
+    ];
+
+    assert.deepEqual(
+        selectMergedPullRequests(
+            pullRequests,
+            "2026-08-04T01:30:00Z",
+            "2026-08-04T03:00:00Z",
+        ).map((pullRequest) => pullRequest.number),
+        [2, 3],
+    );
+});
+
+test("recognizes compare statuses that include the target commit", () => {
+    assert.equal(isTargetCoveredByCompareStatus("ahead"), true);
+    assert.equal(isTargetCoveredByCompareStatus("identical"), true);
+    assert.equal(isTargetCoveredByCompareStatus("behind"), false);
+    assert.equal(isTargetCoveredByCompareStatus("diverged"), false);
+});

--- a/.github/scripts/evaluate-deployment-decision.mjs
+++ b/.github/scripts/evaluate-deployment-decision.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const HIGH_RISK_PATHS = [
+    /^\.github\/workflows\//,
+    /(^|\/)(auth|login|onboarding|signup|signing|keystore)(\/|\.|$)/i,
+    /(^|\/)(data|network|api)(\/|$)/i,
+    /(^|\/)(build\.gradle(?:\.kts)?|settings\.gradle(?:\.kts)?|gradle\.properties)$/,
+    /^gradle\/libs\.versions\.toml$/,
+];
+const HIGH_RISK_TEXT =
+    /로그인|회원가입|인증|온보딩|데이터\s*(?:손실|삭제)|API\s*계약|서명|배포|release|signing|authentication|data[ -]?loss/i;
+const RUNTIME_NEUTRAL_PATHS = [
+    /(^|\/)README(?:\.[^/]*)?$/i,
+    /(^|\/)docs?\//i,
+    /\.md$/i,
+    /(^|\/)(test|tests|androidTest)\//,
+    /(?:Test|Tests)\.(?:kt|java)$/,
+];
+
+function unique(values) {
+    return [...new Set(values)];
+}
+
+function parseTitle(title) {
+    const match = /^([a-z]+)(?:\(([^)]+)\))?:/i.exec(String(title ?? ""));
+    return {
+        type: match?.[1]?.toLowerCase() ?? "",
+        scope: match?.[2]?.toLowerCase() ?? "",
+    };
+}
+
+export function extractQaPoints(body) {
+    const points = [];
+    let capturing = false;
+    for (const line of String(body ?? "").split(/\r?\n/)) {
+        const heading = /^#{1,6}\s+(.+?)\s*$/.exec(line);
+        if (heading) {
+            if (capturing) {
+                break;
+            }
+            capturing = /qa\s*포인트/i.test(heading[1]);
+            continue;
+        }
+        if (!capturing) {
+            continue;
+        }
+        const point = line
+            .replace(/^\s*[-*]\s*/, "")
+            .replace(/^\s*\d+\.\s*/, "")
+            .trim();
+        if (point && point.toLowerCase() !== "no response") {
+            points.push(point);
+        }
+    }
+    return unique(points);
+}
+
+function issueMap(context) {
+    const issues = new Map();
+    const pullRequests = [context.targetPullRequest, ...(context.pendingPullRequests ?? [])];
+    for (const pullRequest of pullRequests) {
+        for (const issue of pullRequest?.closingIssues ?? []) {
+            issues.set(issue.number, issue);
+        }
+    }
+    return issues;
+}
+
+function defaultQaPoints(issues, pullRequests) {
+    if (issues.size > 0) {
+        return [...issues.values()].map(
+            (issue) =>
+                `#${issue.number} 관련 동작을 재현하고 수정 후 기대 결과가 충족되는지 확인`,
+        );
+    }
+    return pullRequests.map(
+        (pullRequest) =>
+            `PR #${pullRequest.number}의 변경 흐름을 실행하고 기존 동작이 회귀하지 않는지 확인`,
+    );
+}
+
+function isHighRiskFile(file) {
+    return HIGH_RISK_PATHS.some((pattern) => pattern.test(file));
+}
+
+function isRuntimeNeutralFile(file) {
+    return RUNTIME_NEUTRAL_PATHS.some((pattern) => pattern.test(file));
+}
+
+export function evaluateDeploymentDecision(context, changedFiles) {
+    const pullRequests = context.pendingPullRequests ?? [];
+    const issues = issueMap(context);
+    const includedIssues = [...issues.keys()].sort((left, right) => left - right);
+    const explicitQaPoints = unique(
+        pullRequests.flatMap((pullRequest) => extractQaPoints(pullRequest.body)),
+    );
+    const qaPoints =
+        explicitQaPoints.length > 0
+            ? explicitQaPoints
+            : defaultQaPoints(issues, pullRequests.length > 0 ? pullRequests : [context.targetPullRequest]);
+
+    if (context.targetCoveredBySuccessfulDistribution) {
+        return {
+            decision: "hold",
+            risk: "low",
+            reason: "대상 머지 커밋이 이미 성공한 develop QA 배포에 포함되어 추가 배포가 필요하지 않습니다.",
+            includedIssues,
+            qaPoints,
+        };
+    }
+
+    if (!context.baselineDistribution) {
+        return {
+            decision: "deploy",
+            risk: "normal",
+            reason: "성공한 develop QA 배포 기준점이 없어 현재 상태를 첫 QA 기준 빌드로 배포해야 합니다.",
+            includedIssues,
+            qaPoints,
+        };
+    }
+
+    const highRiskFiles = changedFiles.filter(isHighRiskFile);
+    const highRiskPullRequests = pullRequests.filter((pullRequest) =>
+        HIGH_RISK_TEXT.test(`${pullRequest.title}\n${pullRequest.body ?? ""}`),
+    );
+    if (highRiskFiles.length > 0 || highRiskPullRequests.length > 0) {
+        const evidence = [
+            ...highRiskFiles.slice(0, 3),
+            ...highRiskPullRequests.slice(0, 3).map((pullRequest) => `PR #${pullRequest.number}`),
+        ];
+        return {
+            decision: "deploy",
+            risk: "high",
+            reason: `고위험 변경이 포함됐습니다: ${unique(evidence).join(", ")}. 다른 변경을 기다리지 않고 QA 배포합니다.`,
+            includedIssues,
+            qaPoints,
+        };
+    }
+
+    const parsedTitles = pullRequests.map((pullRequest) => ({
+        pullRequest,
+        ...parseTitle(pullRequest.title),
+    }));
+    const visibleFixes = parsedTitles.filter(({ type }) => type === "fix");
+    if (visibleFixes.length > 0) {
+        return {
+            decision: "deploy",
+            risk: "normal",
+            reason: `테스터 확인이 필요한 결함 수정이 머지됐습니다: ${visibleFixes.map(({ pullRequest }) => `PR #${pullRequest.number}`).join(", ")}.`,
+            includedIssues,
+            qaPoints,
+        };
+    }
+
+    const completedFeatures = parsedTitles.filter(({ type }) => type === "feat");
+    if (completedFeatures.length > 0) {
+        return {
+            decision: "deploy",
+            risk: "normal",
+            reason: `새 사용자 흐름을 검증할 기능 변경이 완료됐습니다: ${completedFeatures.map(({ pullRequest }) => `PR #${pullRequest.number}`).join(", ")}.`,
+            includedIssues,
+            qaPoints,
+        };
+    }
+
+    if (includedIssues.length >= 3) {
+        return {
+            decision: "deploy",
+            risk: "normal",
+            reason: `마지막 배포 이후 독립 이슈 ${includedIssues.length}건이 누적돼 회귀 원인 분리 전에 배포합니다.`,
+            includedIssues,
+            qaPoints,
+        };
+    }
+
+    if (explicitQaPoints.length >= 6) {
+        return {
+            decision: "deploy",
+            risk: "normal",
+            reason: `명시된 QA 포인트가 ${explicitQaPoints.length}개로 배포 경계에 도달했습니다.`,
+            includedIssues,
+            qaPoints,
+        };
+    }
+
+    const scopes = unique(parsedTitles.map(({ scope }) => scope).filter(Boolean));
+    if (pullRequests.length >= 5 || scopes.length >= 3) {
+        return {
+            decision: "deploy",
+            risk: "normal",
+            reason: `누적 PR ${pullRequests.length}건·영향 스코프 ${scopes.length}개로 더 쌓이면 회귀 원인 분리가 어려워집니다.`,
+            includedIssues,
+            qaPoints,
+        };
+    }
+
+    const runtimeNeutral = changedFiles.length > 0 && changedFiles.every(isRuntimeNeutralFile);
+    if (runtimeNeutral) {
+        return {
+            decision: "hold",
+            risk: "low",
+            reason: "문서·테스트 등 런타임에 영향을 주지 않는 변경만 있어 다음 사용자 노출 변경과 함께 배포합니다.",
+            includedIssues,
+            qaPoints,
+        };
+    }
+
+    return {
+        decision: "hold",
+        risk: "low",
+        reason: `현재 누적 변경은 PR ${pullRequests.length}건·이슈 ${includedIssues.length}건으로 즉시 QA가 필요한 위험 또는 묶음 크기에 도달하지 않았습니다.`,
+        includedIssues,
+        qaPoints,
+    };
+}
+
+function changedFilesFor(context) {
+    const baseSha = context.baselineDistribution?.headSha;
+    const headSha = context.targetPullRequest?.mergeCommitSha;
+    if (!baseSha || !headSha || context.targetCoveredBySuccessfulDistribution) {
+        return [];
+    }
+    const output = execFileSync("git", ["diff", "--name-only", `${baseSha}..${headSha}`], {
+        encoding: "utf8",
+    });
+    return unique(output.split(/\r?\n/).filter(Boolean));
+}
+
+async function main() {
+    const [contextPath, outputPath] = process.argv.slice(2);
+    if (!contextPath || !outputPath) {
+        throw new Error("context path and decision output path are required");
+    }
+    const context = JSON.parse(await fs.readFile(contextPath, "utf8"));
+    const decision = evaluateDeploymentDecision(context, changedFilesFor(context));
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, `${JSON.stringify(decision, null, 2)}\n`, "utf8");
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : "";
+if (import.meta.url === invokedPath) {
+    main().catch((error) => {
+        console.error(error instanceof Error ? error.stack : error);
+        process.exitCode = 1;
+    });
+}

--- a/.github/scripts/evaluate-deployment-decision.test.mjs
+++ b/.github/scripts/evaluate-deployment-decision.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    evaluateDeploymentDecision,
+    extractQaPoints,
+} from "./evaluate-deployment-decision.mjs";
+
+function context(overrides = {}) {
+    const issue = { number: 726, title: "배포 판단", body: "", labels: [] };
+    return {
+        targetCoveredBySuccessfulDistribution: false,
+        baselineDistribution: { headSha: "base" },
+        targetPullRequest: {
+            number: 800,
+            title: "refactor(core): 내부 정리",
+            body: "",
+            mergeCommitSha: "head",
+            closingIssues: [issue],
+        },
+        pendingPullRequests: [
+            {
+                number: 800,
+                title: "refactor(core): 내부 정리",
+                body: "",
+                closingIssues: [issue],
+            },
+        ],
+        ...overrides,
+    };
+}
+
+test("holds when the target is already distributed", () => {
+    const result = evaluateDeploymentDecision(
+        context({ targetCoveredBySuccessfulDistribution: true }),
+        ["feature/home/HomeScreen.kt"],
+    );
+    assert.equal(result.decision, "hold");
+    assert.match(result.reason, /이미 성공한/);
+});
+
+test("deploys a high-risk release path change immediately", () => {
+    const result = evaluateDeploymentDecision(context(), [".github/workflows/release-distribution.yml"]);
+    assert.equal(result.decision, "deploy");
+    assert.equal(result.risk, "high");
+});
+
+test("deploys a user-visible bug fix", () => {
+    const pendingPullRequest = {
+        number: 801,
+        title: "fix(home): 새로고침 실패 복구",
+        body: "",
+        closingIssues: [{ number: 704, title: "새로고침 실패", body: "", labels: ["bug"] }],
+    };
+    const result = evaluateDeploymentDecision(
+        context({ pendingPullRequests: [pendingPullRequest] }),
+        ["feature/home/HomeScreen.kt"],
+    );
+    assert.equal(result.decision, "deploy");
+    assert.match(result.reason, /결함 수정/);
+});
+
+test("holds documentation-only changes", () => {
+    const result = evaluateDeploymentDecision(context(), ["README.md", "docs/release.md"]);
+    assert.equal(result.decision, "hold");
+    assert.match(result.reason, /런타임/);
+});
+
+test("deploys when three issues accumulate", () => {
+    const pendingPullRequests = [1, 2, 3].map((number) => ({
+        number: 810 + number,
+        title: `refactor(scope${number}): 정리`,
+        body: "",
+        closingIssues: [
+            {
+                number: number === 1 ? 726 : 720 + number,
+                title: "정리",
+                body: "",
+                labels: [],
+            },
+        ],
+    }));
+    const result = evaluateDeploymentDecision(
+        context({ pendingPullRequests }),
+        ["feature/record/RecordState.kt"],
+    );
+    assert.equal(result.decision, "deploy");
+    assert.match(result.reason, /독립 이슈 3건/);
+});
+
+test("reads explicit QA points from a PR body", () => {
+    assert.deepEqual(
+        extractQaPoints("## QA 포인트\n- 저장 후 목록에 표시되는지 확인\n- 재진입 시 값이 유지되는지 확인\n\n## 기타\n- 제외"),
+        ["저장 후 목록에 표시되는지 확인", "재진입 시 값이 유지되는지 확인"],
+    );
+});

--- a/.github/scripts/render-distribution-release-notes.sh
+++ b/.github/scripts/render-distribution-release-notes.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+output_path="${1:?release notes output path is required}"
+event_name="${EVENT_NAME:-}"
+issue_numbers="${ISSUE_NUMBERS:-}"
+qa_points="${QA_POINTS:-}"
+
+extract_section() {
+    local heading="$1"
+    local body_file="$2"
+
+    awk -v expected_heading="$heading" '
+        /^#[#]*[[:space:]]+/ {
+            current_heading = $0
+            sub(/^#[#]*[[:space:]]+/, "", current_heading)
+            sub(/[[:space:]]+$/, "", current_heading)
+
+            if (capturing) {
+                exit
+            }
+
+            if (current_heading == expected_heading) {
+                capturing = 1
+                next
+            }
+        }
+
+        capturing {
+            print
+        }
+    ' "$body_file"
+}
+
+print_main_pr_format() {
+    printf '%s\n' \
+        'main 릴리스 PR 본문에 다음 섹션을 채워 주세요.' \
+        '## 포함 이슈' \
+        '- #123' \
+        '## QA 포인트' \
+        '- 사용자가 실행할 동작과 기대 결과'
+}
+
+case "$event_name" in
+    workflow_dispatch)
+        distribution_title="Afternote QA 배포"
+        qa_points="$(printf '%s\n' "$qa_points" | tr ';' '\n')"
+        ;;
+    push)
+        distribution_title="Afternote 릴리스 후보 배포"
+        release_pr_body_file="${RELEASE_PR_BODY_FILE:-}"
+        if [[ ! -s "$release_pr_body_file" ]]; then
+            printf '::error::main push와 연결된 릴리스 PR 본문을 찾지 못했습니다.\n' >&2
+            print_main_pr_format >&2
+            exit 1
+        fi
+
+        issue_numbers="$(extract_section '포함 이슈' "$release_pr_body_file")"
+        qa_points="$(extract_section 'QA 포인트' "$release_pr_body_file")"
+        ;;
+    *)
+        printf '::error::지원하지 않는 배포 이벤트입니다: %s\n' "${event_name:-<empty>}" >&2
+        exit 1
+        ;;
+esac
+
+normalized_issues="$(
+    printf '%s\n' "$issue_numbers" |
+        awk '
+            {
+                remaining = $0
+                while (match(remaining, /#[0-9]+/)) {
+                    issue = substr(remaining, RSTART, RLENGTH)
+                    if (!seen[issue]++) {
+                        print issue
+                    }
+                    remaining = substr(remaining, RSTART + RLENGTH)
+                }
+            }
+        '
+)"
+
+normalized_qa_points="$(
+    printf '%s\n' "$qa_points" |
+        awk '
+            /^[[:space:]]*<!--/ {
+                in_comment = 1
+            }
+
+            in_comment {
+                if ($0 ~ /-->/) {
+                    in_comment = 0
+                }
+                next
+            }
+
+            {
+                point = $0
+                sub(/^[[:space:]]*[-*][[:space:]]*/, "", point)
+                sub(/^[[:space:]]*[0-9]+\.[[:space:]]*/, "", point)
+                sub(/^[[:space:]]+/, "", point)
+                sub(/[[:space:]]+$/, "", point)
+
+                if (point != "" && tolower(point) != "no response" && !seen[point]++) {
+                    print point
+                }
+            }
+        '
+)"
+
+if [[ -z "$normalized_issues" ]]; then
+    printf '::error::포함 이슈에는 #123 형식의 이슈 번호가 하나 이상 필요합니다.\n' >&2
+    if [[ "$event_name" == "push" ]]; then
+        print_main_pr_format >&2
+    fi
+    exit 1
+fi
+
+if [[ -z "$normalized_qa_points" ]]; then
+    printf '::error::QA 포인트에는 확인할 동작과 기대 결과가 하나 이상 필요합니다.\n' >&2
+    if [[ "$event_name" == "push" ]]; then
+        print_main_pr_format >&2
+    fi
+    exit 1
+fi
+
+source_ref="${SOURCE_REF:-unknown}"
+source_ref="${source_ref#refs/heads/}"
+source_sha="${SOURCE_SHA:-unknown}"
+short_sha="${source_sha:0:7}"
+
+mkdir -p "$(dirname "$output_path")"
+{
+    printf '%s\n' "$distribution_title"
+    printf '기준: %s @ %s\n\n' "$source_ref" "$short_sha"
+    printf '포함 이슈\n'
+    while IFS= read -r issue; do
+        printf -- '- %s\n' "$issue"
+    done <<< "$normalized_issues"
+    printf '\nQA 포인트\n'
+    while IFS= read -r point; do
+        printf -- '- %s\n' "$point"
+    done <<< "$normalized_qa_points"
+} > "$output_path"

--- a/.github/workflows/deployment-decision.yml
+++ b/.github/workflows/deployment-decision.yml
@@ -1,0 +1,104 @@
+name: Evaluate QA Distribution Candidate
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: "다시 판단할 develop 머지 PR 번호"
+        required: true
+        type: number
+
+concurrency:
+  group: qa-distribution-decision-${{ github.event.pull_request.base.ref || 'develop' }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  evaluate:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone merged revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || 'develop' }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Collect pending deployment context
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TARGET_PR_NUMBER: ${{ github.event.pull_request.number || inputs.pull_request_number }}
+          DEPLOYMENT_CONTEXT_PATH: ${{ runner.temp }}/afternote-deployment-decision/context.json
+        run: node .github/scripts/collect-deployment-decision-context.mjs
+
+      - name: Evaluate deployment boundary
+        env:
+          DEPLOYMENT_CONTEXT_PATH: ${{ runner.temp }}/afternote-deployment-decision/context.json
+          DEPLOYMENT_DECISION_PATH: ${{ runner.temp }}/afternote-deployment-decision/decision.json
+        run: |
+          node .github/scripts/evaluate-deployment-decision.mjs \
+            "$DEPLOYMENT_CONTEXT_PATH" \
+            "$DEPLOYMENT_DECISION_PATH"
+
+      - name: Publish decision on the merged PR
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_DECISION_PATH: ${{ runner.temp }}/afternote-deployment-decision/decision.json
+          TARGET_PR_NUMBER: ${{ github.event.pull_request.number || inputs.pull_request_number }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('node:fs');
+            const marker = '<!-- qa-distribution-decision -->';
+            const result = JSON.parse(fs.readFileSync(process.env.DEPLOYMENT_DECISION_PATH, 'utf8'));
+            const clean = (value) => String(value).replaceAll('@', '@\u200b');
+            const title = result.decision === 'deploy' ? '🚀 QA 배포 권장' : '⏸️ QA 배포 보류';
+            const issues = result.includedIssues.map((number) => `#${number}`).join(', ');
+            const qaPoints = result.qaPoints.map((point) => `- ${clean(point)}`).join('\n');
+            const body = [
+              marker,
+              `## ${title}`,
+              '',
+              `- 위험도: \`${result.risk}\``,
+              `- 포함 이슈: ${issues || '연결 이슈 없음'}`,
+              `- 판단 근거: ${clean(result.reason)}`,
+              '',
+              '### QA 포인트',
+              qaPoints,
+              '',
+              '> 이 판단은 배포를 자동 실행하지 않습니다. `deploy`일 때 Release Distribution을 수동 실행하세요.',
+            ].join('\n');
+
+            const issueNumber = Number(process.env.TARGET_PR_NUMBER);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body,
+              });
+            }
+            await core.summary.addRaw(body).write();

--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -8,6 +8,15 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      issue_numbers:
+        description: "포함 이슈 번호 (#716, #723 형식)"
+        required: true
+        type: string
+      qa_points:
+        description: "QA 포인트 (여러 건은 세미콜론으로 구분)"
+        required: true
+        type: string
 
 # 수동 배포 도중 main 릴리스 push 가 들어오면 러너 둘이 같은 App Distribution 앱에 올린다.
 # cancel-in-progress 는 기본값(false) 그대로 — 릴리스 배포가 수동 배포에 밀려 취소되면 안 된다.
@@ -16,6 +25,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   distribute:
@@ -42,6 +52,31 @@ jobs:
 
       - name: Clone repo
         uses: actions/checkout@v4
+
+      - name: Load release metadata from main PR
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_PR_BODY_FILE: ${{ runner.temp }}/main-release-pr-body.md
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+            --jq '[.[] | select(.base.ref == "main" and .merged_at != null)] | sort_by(.merged_at) | last | .body // empty' \
+            > "$RELEASE_PR_BODY_FILE"
+
+      - name: Prepare Firebase release notes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_NUMBERS: ${{ inputs.issue_numbers }}
+          QA_POINTS: ${{ inputs.qa_points }}
+          RELEASE_PR_BODY_FILE: ${{ runner.temp }}/main-release-pr-body.md
+          RELEASE_NOTES_FILE: ${{ runner.temp }}/firebase-app-distribution-release-notes.txt
+          SOURCE_REF: ${{ github.ref }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          bash .github/scripts/render-distribution-release-notes.sh "$RELEASE_NOTES_FILE"
+          cat "$RELEASE_NOTES_FILE" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -123,6 +158,9 @@ jobs:
         env:
           KAKAO_NATIVE_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
           GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
+          RELEASE_NOTES_FILE: ${{ runner.temp }}/firebase-app-distribution-release-notes.txt
         run: |
           export GOOGLE_APPLICATION_CREDENTIALS="$HOME/firebase-service-account.json"
-          ./gradlew assembleRelease appDistributionUploadRelease --no-daemon
+          ./gradlew assembleRelease appDistributionUploadRelease \
+            --releaseNotesFile="$RELEASE_NOTES_FILE" \
+            --no-daemon

--- a/README.md
+++ b/README.md
@@ -98,9 +98,49 @@ keytool -exportcert -alias afternote-debug-shared -keystore ~/afternote-debug-sh
 
 ## 배포 (매 회)
 
-### 자동 — `main` push 시 (기본 경로)
+모든 배포의 릴리스 노트에는 `포함 이슈`와 `QA 포인트`가 필요하다. 둘 중 하나라도 비어 있거나 포함 이슈에 `#123` 형식의 번호가 없으면 Firebase 업로드 전에 실패한다.
 
-`develop` → `main` 머지가 push 되면 GitHub Actions 워크플로 [`release-distribution.yml`](.github/workflows/release-distribution.yml) 가 자동 실행 → APK 빌드 → Firebase App Distribution 업로드 → 테스터 그룹 `afternote` 전원에게 자동 이메일 발송. 운영 정책 *"main 머지된 상태만 배포"* 와 일치.
+### 배포 판단 기준
+
+배포 시점은 일 단위 주기가 아니라 `develop`에 머지된 변경 묶음의 크기와 위험도로 정한다.
+
+- 인증·온보딩·데이터 손실·API 계약·빌드/서명처럼 영향이 큰 변경은 다른 변경을 기다리지 않고 단독 배포한다.
+- 작은 변경은 하나의 QA 세션에서 회귀 원인을 구분할 수 있는 범위까지만 묶는다. 서로 다른 사용자 흐름을 한꺼번에 확인해야 하거나 함께 롤백하기 어려워지는 시점이 배포 경계다.
+- 수정 결과를 테스터가 확인해야 하는 결함이 머지되면, 묶음 크기와 관계없이 확인 가능한 빌드를 배포한다.
+- 현재 묶음의 모든 QA 포인트가 통과한 뒤 `develop`을 `main`으로 승격한다.
+
+### 머지별 자동 판단
+
+`develop` 대상 PR이 머지되면 [`deployment-decision.yml`](.github/workflows/deployment-decision.yml)이 마지막 성공 QA 배포 이후의 누적 PR·연결 이슈·실제 diff를 읽는다. 고위험 경로, 버그·기능 PR, 누적 이슈 수, 명시 QA 포인트 수, 영향 스코프 수를 위 기준으로 판정해 `QA 배포 권장` 또는 `QA 배포 보류`, 포함 이슈, QA 포인트를 머지된 PR에 코멘트한다. 판단만 자동화하며 APK 업로드는 실행하지 않는다.
+
+별도 API나 유료 AI를 호출하지 않으며 기존 GitHub Actions 실행량만 사용한다. Actions의 **Evaluate QA Distribution Candidate**에서 이미 머지된 PR 번호를 입력해 같은 규칙으로 수동 재검증할 수도 있다.
+
+### QA 배포 — `develop` → Firebase App Distribution (수동, 기본 경로)
+
+GitHub Actions의 **Release Distribution**에서 `Run workflow`를 누르고 ref를 `develop`으로 선택한 뒤 다음 값을 입력한다.
+
+- `issue_numbers`: 포함된 이슈 번호. 예: `#716, #723`
+- `qa_points`: 확인할 동작과 기대 결과. 여러 건은 세미콜론(`;`)으로 구분
+
+워크플로가 위 입력을 릴리스 노트로 만들어 APK를 빌드하고 Firebase App Distribution의 `afternote` 그룹에 배포한다.
+
+### 릴리스 후보 배포 — `main` → Firebase App Distribution (자동)
+
+여기서 릴리스 후보 배포는 검증할 `main` 빌드를 Firebase 테스터에게 전달하는 단계이며, Play Store 프로덕션 릴리스를 뜻하지 않는다.
+
+`develop` → `main` 릴리스 PR 본문에 다음 섹션을 채운다.
+
+```markdown
+## 포함 이슈
+- #716
+- #723
+
+## QA 포인트
+- 오프라인에서 오류 안내와 재시도 수단이 표시되는지 확인
+- 주차를 변경한 뒤 최신 리포트가 표시되는지 확인
+```
+
+PR이 `main`에 머지되면 워크플로가 두 섹션을 릴리스 노트로 사용한다. 연결된 PR이나 필수 섹션을 찾지 못하면 배포하지 않는다.
 
 CI 가 사용하는 GitHub Secrets (Settings → Secrets and variables → Actions):
 
@@ -115,13 +155,21 @@ CI 가 사용하는 GitHub Secrets (Settings → Secrets and variables → Actio
 
 > base64 인코딩: `base64 -i ~/afternote-release.jks | pbcopy` (macOS)
 
-### 수동 — 1hyok 머신 (fallback / 긴급 시)
+### 로컬 — 1hyok 머신 (fallback / 긴급 시)
 
 ```bash
-./gradlew assembleRelease appDistributionUploadRelease
+EVENT_NAME=workflow_dispatch \
+ISSUE_NUMBERS="#716, #723" \
+QA_POINTS="오프라인 오류 안내 확인;주차 변경 후 재시도 확인" \
+SOURCE_REF=develop \
+SOURCE_SHA="$(git rev-parse HEAD)" \
+bash .github/scripts/render-distribution-release-notes.sh /tmp/afternote-release-notes.txt
+
+./gradlew assembleRelease appDistributionUploadRelease \
+  --releaseNotesFile=/tmp/afternote-release-notes.txt
 ```
 
-→ 동일하게 APK 빌드 + Firebase 업로드. CI 장애 시 또는 main 머지 없이 임시 배포 필요할 때 사용.
+→ 동일하게 APK 빌드 + Firebase 업로드. CI 장애 시에만 사용한다.
 
 > 같은 `versionCode` 로 재업로드하면 기존 release 갱신. 새 release 만들려면 `app/build.gradle.kts` 의 `versionCode` 증가.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -130,7 +130,6 @@ android {
             signingConfig = signingConfigs.getByName("release")
             firebaseAppDistribution {
                 groups = "afternote"
-                releaseNotes = "Release build for internal distribution"
             }
         }
     }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #726 — chore(ci): 배포 릴리스 노트에 포함 이슈·QA 포인트 필수화

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- 수동 배포 입력과 main 릴리스 PR 본문에서 포함 이슈·QA 포인트를 검증해 Firebase 릴리스 노트로 전달
- 마지막 성공 QA 배포 이후의 누적 PR·연결 이슈·실제 diff를 바탕으로 배포 권장 여부를 판정하고 머지 PR에 코멘트
- 변경 묶음의 크기와 위험도를 기준으로 한 QA 배포·릴리스 후보 배포 절차를 문서화

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — GitHub Actions workflow, 배포 스크립트, 문서만 변경했습니다.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 배포 판단 workflow는 권장·보류 코멘트만 작성하며 APK 배포를 자동 실행하지 않습니다.
- Node 검증: `node --test .github/scripts/collect-deployment-decision-context.test.mjs .github/scripts/evaluate-deployment-decision.test.mjs` 10건 통과
- Workflow 검증: `actionlint .github/workflows/release-distribution.yml .github/workflows/deployment-decision.yml` 통과
- Gradle 검증: `./gradlew appDistributionUploadRelease --releaseNotesFile=<temp> --dry-run --no-daemon` BUILD SUCCESSFUL
