### PR TITLE
fix(timeletter): 타임레터 삭제 API 및 확인 흐름 수정 (#550)

### DIFF
--- a/feature/timeletter/data/src/debug/kotlin/com/afternote/feature/timeletter/data/network/TimeLetterDebugMockNetworkInterceptor.kt
+++ b/feature/timeletter/data/src/debug/kotlin/com/afternote/feature/timeletter/data/network/TimeLetterDebugMockNetworkInterceptor.kt
@@ -42,7 +42,7 @@ class TimeLetterDebugMockNetworkInterceptor
                         TimeLetterMockFixtures.MOCK_CREATE_JSON
                     }
 
-                    path == "/api/v1/time-letters/delete" && method == "POST" -> {
+                    path == "/api/v1/time-letters" && method == "DELETE" -> {
                         TimeLetterMockFixtures.MOCK_DELETE_JSON
                     }
 

--- a/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/api/TimeLetterApiService.kt
+++ b/feature/timeletter/data/src/main/kotlin/com/afternote/feature/timeletter/data/api/TimeLetterApiService.kt
@@ -9,6 +9,7 @@ import com.afternote.feature.timeletter.data.dto.TimeLetterUpdateRequestDto
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.HTTP
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -42,7 +43,7 @@ interface TimeLetterApiService {
     ): BaseResponse<TimeLetterDto>
 
     // 타임레터 단일/다건 삭제
-    @POST("time-letters/delete")
+    @HTTP(method = "DELETE", path = "time-letters", hasBody = true)
     suspend fun deleteTimeLetters(
         @Body request: TimeLetterDeleteRequestDto,
     ): BaseResponse<Unit>

--- a/feature/timeletter/data/src/test/kotlin/com/afternote/feature/timeletter/data/api/TimeLetterApiServiceContractTest.kt
+++ b/feature/timeletter/data/src/test/kotlin/com/afternote/feature/timeletter/data/api/TimeLetterApiServiceContractTest.kt
@@ -1,0 +1,23 @@
+package com.afternote.feature.timeletter.data.api
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.http.Body
+import retrofit2.http.HTTP
+
+class TimeLetterApiServiceContractTest {
+    @Test
+    fun `deleteTimeLetters uses DELETE time-letters with a request body`() {
+        val method =
+            TimeLetterApiService::class.java.declaredMethods.single {
+                it.name == "deleteTimeLetters"
+            }
+        val http = requireNotNull(method.getAnnotation(HTTP::class.java))
+
+        assertEquals("DELETE", http.method)
+        assertEquals("time-letters", http.path)
+        assertTrue(http.hasBody)
+        assertTrue(method.parameterAnnotations.flatten().any { it is Body })
+    }
+}

--- a/feature/timeletter/presentation/build.gradle.kts
+++ b/feature/timeletter/presentation/build.gradle.kts
@@ -19,4 +19,5 @@ dependencies {
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.compose.wheel.picker)
     implementation(libs.coil.compose)
+    testImplementation(libs.coroutines.test)
 }

--- a/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/screen/sender/TimeletterScreen.kt
+++ b/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/screen/sender/TimeletterScreen.kt
@@ -12,9 +12,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -22,10 +24,13 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import com.afternote.core.ui.button.FAB.PenFloatingActionButton
+import com.afternote.core.ui.popup.Popup
+import com.afternote.core.ui.popup.PopupType
 import com.afternote.core.ui.topbar.HomeTopBar
 import com.afternote.feature.timeletter.domain.model.TimeLetter
 import com.afternote.feature.timeletter.domain.model.TimeLetterList
 import com.afternote.feature.timeletter.domain.model.TimeLetterStatus
+import com.afternote.feature.timeletter.presentation.R
 import com.afternote.feature.timeletter.presentation.component.EmptyTimeLetterContent
 import com.afternote.feature.timeletter.presentation.component.TimeLetterContent
 import com.afternote.feature.timeletter.presentation.viewmodel.TimeletterUiState
@@ -43,7 +48,23 @@ fun TimeletterScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var viewMode by remember { mutableStateOf(ViewMode.List) }
+    var pendingDeleteId by rememberSaveable { mutableStateOf<Long?>(null) }
     val snackbarHostState = remember { SnackbarHostState() }
+    val deleteFailureMessage = stringResource(R.string.timeletter_delete_failure)
+
+    pendingDeleteId?.let { timeLetterId ->
+        Popup(
+            type = PopupType.Variant2,
+            message = stringResource(R.string.timeletter_delete_confirm_message),
+            confirmText = stringResource(R.string.timeletter_delete_confirm),
+            dismissText = stringResource(R.string.timeletter_delete_dismiss),
+            onConfirm = {
+                pendingDeleteId = null
+                viewModel.deleteTimeLetter(timeLetterId)
+            },
+            onDismiss = { pendingDeleteId = null },
+        )
+    }
 
     val errorMessage = (uiState as? TimeletterUiState.Success)?.errorMessage
     LaunchedEffect(errorMessage) {
@@ -53,6 +74,17 @@ fun TimeletterScreen(
             withDismissAction = true,
         )
         viewModel.consumeErrorMessage()
+    }
+
+    val showDeleteFailure = (uiState as? TimeletterUiState.Success)?.showDeleteFailure == true
+    LaunchedEffect(showDeleteFailure) {
+        if (showDeleteFailure) {
+            snackbarHostState.showSnackbar(
+                message = deleteFailureMessage,
+                withDismissAction = true,
+            )
+            viewModel.consumeDeleteFailure()
+        }
     }
 
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -92,7 +124,7 @@ fun TimeletterScreen(
                     onFilterClick = onFilterRecipientClick,
                     onLetterClick = onLetterClick,
                     onEditClick = onEditClick,
-                    onDeleteClick = viewModel::deleteTimeLetter,
+                    onDeleteClick = { pendingDeleteId = it },
                     modifier = Modifier.padding(paddingValues),
                 )
             }

--- a/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/screen/sender/TimeletterScreen.kt
+++ b/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/screen/sender/TimeletterScreen.kt
@@ -66,16 +66,6 @@ fun TimeletterScreen(
         )
     }
 
-    val errorMessage = (uiState as? TimeletterUiState.Success)?.errorMessage
-    LaunchedEffect(errorMessage) {
-        errorMessage ?: return@LaunchedEffect
-        snackbarHostState.showSnackbar(
-            message = errorMessage,
-            withDismissAction = true,
-        )
-        viewModel.consumeErrorMessage()
-    }
-
     val showDeleteFailure = (uiState as? TimeletterUiState.Success)?.showDeleteFailure == true
     LaunchedEffect(showDeleteFailure) {
         if (showDeleteFailure) {

--- a/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/viewmodel/TimeletterUiState.kt
+++ b/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/viewmodel/TimeletterUiState.kt
@@ -11,10 +11,7 @@ sealed interface TimeletterUiState {
         val selectedFilterReceiverIds: Set<Long> = emptySet(),
         val isDeleting: Boolean = false,
         val showDeleteFailure: Boolean = false,
-        val errorMessage: String? = null,
     ) : TimeletterUiState
 
-    data class Error(
-        val message: String,
-    ) : TimeletterUiState
+    data object Error : TimeletterUiState
 }

--- a/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/viewmodel/TimeletterUiState.kt
+++ b/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/viewmodel/TimeletterUiState.kt
@@ -9,6 +9,8 @@ sealed interface TimeletterUiState {
         val letters: TimeLetterList,
         val receiverNameMap: Map<Long, String>,
         val selectedFilterReceiverIds: Set<Long> = emptySet(),
+        val isDeleting: Boolean = false,
+        val showDeleteFailure: Boolean = false,
         val errorMessage: String? = null,
     ) : TimeletterUiState
 

--- a/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/viewmodel/TimeletterViewModel.kt
+++ b/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/viewmodel/TimeletterViewModel.kt
@@ -2,6 +2,7 @@ package com.afternote.feature.timeletter.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.afternote.core.common.result.runCatchingCancellable
 import com.afternote.core.domain.repository.UserRepository
 import com.afternote.feature.timeletter.domain.model.TimeLetterList
 import com.afternote.feature.timeletter.domain.repository.TimeLetterRepository
@@ -35,6 +36,7 @@ class TimeletterViewModel
         private fun applyFilter() {
             val letters = allLetters ?: return
             val filterIds = selectedFilterReceiverIds
+            val currentState = _uiState.value as? TimeletterUiState.Success
             val filteredLetters =
                 if (filterIds.isEmpty()) {
                     letters
@@ -50,6 +52,9 @@ class TimeletterViewModel
                     letters = filteredLetters,
                     receiverNameMap = receiverNameMap,
                     selectedFilterReceiverIds = filterIds,
+                    isDeleting = currentState?.isDeleting ?: false,
+                    showDeleteFailure = currentState?.showDeleteFailure ?: false,
+                    errorMessage = currentState?.errorMessage,
                 )
         }
 
@@ -76,14 +81,26 @@ class TimeletterViewModel
         }
 
         fun deleteTimeLetter(timeLetterId: Long) {
+            val currentState = _uiState.value as? TimeletterUiState.Success ?: return
+            if (currentState.isDeleting) return
+            _uiState.value =
+                currentState.copy(
+                    isDeleting = true,
+                    showDeleteFailure = false,
+                    errorMessage = null,
+                )
+
             viewModelScope.launch {
-                runCatching { timeLetterRepository.deleteTimeLetters(listOf(timeLetterId)) }
+                runCatchingCancellable { timeLetterRepository.deleteTimeLetters(listOf(timeLetterId)) }
                     .onSuccess { load() }
                     .onFailure {
-                        val currentState = _uiState.value
-                        if (currentState is TimeletterUiState.Success) {
+                        val latestState = _uiState.value
+                        if (latestState is TimeletterUiState.Success) {
                             _uiState.value =
-                                currentState.copy(errorMessage = "타임레터를 삭제할 수 없습니다.")
+                                latestState.copy(
+                                    isDeleting = false,
+                                    showDeleteFailure = true,
+                                )
                         }
                     }
             }
@@ -93,6 +110,13 @@ class TimeletterViewModel
             val currentState = _uiState.value
             if (currentState is TimeletterUiState.Success) {
                 _uiState.value = currentState.copy(errorMessage = null)
+            }
+        }
+
+        fun consumeDeleteFailure() {
+            val currentState = _uiState.value
+            if (currentState is TimeletterUiState.Success) {
+                _uiState.value = currentState.copy(showDeleteFailure = false)
             }
         }
     }

--- a/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/viewmodel/TimeletterViewModel.kt
+++ b/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/viewmodel/TimeletterViewModel.kt
@@ -54,7 +54,6 @@ class TimeletterViewModel
                     selectedFilterReceiverIds = filterIds,
                     isDeleting = currentState?.isDeleting ?: false,
                     showDeleteFailure = currentState?.showDeleteFailure ?: false,
-                    errorMessage = currentState?.errorMessage,
                 )
         }
 
@@ -75,7 +74,7 @@ class TimeletterViewModel
                         allLetters = letters
                         applyFilter()
                     }.onFailure {
-                        _uiState.value = TimeletterUiState.Error("타임레터를 불러올 수 없습니다.")
+                        _uiState.value = TimeletterUiState.Error
                     }
             }
         }
@@ -87,13 +86,17 @@ class TimeletterViewModel
                 currentState.copy(
                     isDeleting = true,
                     showDeleteFailure = false,
-                    errorMessage = null,
                 )
 
             viewModelScope.launch {
                 runCatchingCancellable { timeLetterRepository.deleteTimeLetters(listOf(timeLetterId)) }
-                    .onSuccess { load() }
-                    .onFailure {
+                    .onSuccess {
+                        val latestState = _uiState.value
+                        if (latestState is TimeletterUiState.Success) {
+                            _uiState.value = latestState.copy(isDeleting = false)
+                        }
+                        load()
+                    }.onFailure {
                         val latestState = _uiState.value
                         if (latestState is TimeletterUiState.Success) {
                             _uiState.value =
@@ -103,13 +106,6 @@ class TimeletterViewModel
                                 )
                         }
                     }
-            }
-        }
-
-        fun consumeErrorMessage() {
-            val currentState = _uiState.value
-            if (currentState is TimeletterUiState.Success) {
-                _uiState.value = currentState.copy(errorMessage = null)
             }
         }
 

--- a/feature/timeletter/presentation/src/main/res/values/strings.xml
+++ b/feature/timeletter/presentation/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="timeletter_delete_confirm_message">타임레터를 삭제하시겠습니까?</string>
+    <string name="timeletter_delete_confirm">예</string>
+    <string name="timeletter_delete_dismiss">아니오</string>
+    <string name="timeletter_delete_failure">타임레터를 삭제하지 못했습니다. 다시 시도해 주세요.</string>
+</resources>

--- a/feature/timeletter/presentation/src/test/kotlin/com/afternote/feature/timeletter/presentation/viewmodel/TimeletterViewModelTest.kt
+++ b/feature/timeletter/presentation/src/test/kotlin/com/afternote/feature/timeletter/presentation/viewmodel/TimeletterViewModelTest.kt
@@ -60,7 +60,8 @@ class TimeletterViewModelTest {
 
         assertEquals(listOf(1L), deletedIds)
         assertEquals(2, loadCount)
-        assertTrue(viewModel.uiState.value is TimeletterUiState.Success)
+        val state = viewModel.uiState.value as TimeletterUiState.Success
+        assertFalse(state.isDeleting)
     }
 
     @Test
@@ -86,6 +87,22 @@ class TimeletterViewModelTest {
         viewModel.consumeDeleteFailure()
 
         assertFalse((viewModel.uiState.value as TimeletterUiState.Success).showDeleteFailure)
+    }
+
+    @Test
+    fun `load failure exposes error state`() {
+        val repository =
+            timeLetterRepository { methodName, _ ->
+                when (methodName) {
+                    "getTimeLetters" -> throw IllegalStateException("load failed")
+                    else -> error("Unexpected repository call: $methodName")
+                }
+            }
+        val viewModel = TimeletterViewModel(repository, userRepository())
+
+        viewModel.load()
+
+        assertEquals(TimeletterUiState.Error, viewModel.uiState.value)
     }
 
     private fun timeLetterRepository(handler: (String, Array<out Any?>?) -> Any?): TimeLetterRepository =

--- a/feature/timeletter/presentation/src/test/kotlin/com/afternote/feature/timeletter/presentation/viewmodel/TimeletterViewModelTest.kt
+++ b/feature/timeletter/presentation/src/test/kotlin/com/afternote/feature/timeletter/presentation/viewmodel/TimeletterViewModelTest.kt
@@ -1,0 +1,127 @@
+package com.afternote.feature.timeletter.presentation.viewmodel
+
+import com.afternote.core.domain.repository.UserRepository
+import com.afternote.feature.timeletter.domain.model.TimeLetter
+import com.afternote.feature.timeletter.domain.model.TimeLetterList
+import com.afternote.feature.timeletter.domain.model.TimeLetterStatus
+import com.afternote.feature.timeletter.domain.repository.TimeLetterRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.lang.reflect.Proxy
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TimeletterViewModelTest {
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `delete success reloads the time letter list`() {
+        var loadCount = 0
+        var deletedIds: List<Long>? = null
+        val repository =
+            timeLetterRepository { methodName, args ->
+                when (methodName) {
+                    "getTimeLetters" -> {
+                        testLetters.also { loadCount += 1 }
+                    }
+
+                    "deleteTimeLetters" -> {
+                        Unit.also {
+                            deletedIds = (args?.first() as? List<*>)?.filterIsInstance<Long>()
+                        }
+                    }
+
+                    else -> {
+                        error("Unexpected repository call: $methodName")
+                    }
+                }
+            }
+        val viewModel = TimeletterViewModel(repository, userRepository())
+
+        viewModel.load()
+        viewModel.deleteTimeLetter(1L)
+
+        assertEquals(listOf(1L), deletedIds)
+        assertEquals(2, loadCount)
+        assertTrue(viewModel.uiState.value is TimeletterUiState.Success)
+    }
+
+    @Test
+    fun `delete failure keeps the list and exposes a consumable failure state`() {
+        val repository =
+            timeLetterRepository { methodName, _ ->
+                when (methodName) {
+                    "getTimeLetters" -> testLetters
+                    "deleteTimeLetters" -> throw IllegalStateException("delete failed")
+                    else -> error("Unexpected repository call: $methodName")
+                }
+            }
+        val viewModel = TimeletterViewModel(repository, userRepository())
+
+        viewModel.load()
+        viewModel.deleteTimeLetter(1L)
+
+        val failedState = viewModel.uiState.value as TimeletterUiState.Success
+        assertEquals(testLetters, failedState.letters)
+        assertFalse(failedState.isDeleting)
+        assertTrue(failedState.showDeleteFailure)
+
+        viewModel.consumeDeleteFailure()
+
+        assertFalse((viewModel.uiState.value as TimeletterUiState.Success).showDeleteFailure)
+    }
+
+    private fun timeLetterRepository(handler: (String, Array<out Any?>?) -> Any?): TimeLetterRepository =
+        Proxy.newProxyInstance(
+            TimeLetterRepository::class.java.classLoader,
+            arrayOf(TimeLetterRepository::class.java),
+        ) { _, method, args -> handler(method.name, args) } as TimeLetterRepository
+
+    private fun userRepository(): UserRepository =
+        Proxy.newProxyInstance(
+            UserRepository::class.java.classLoader,
+            arrayOf(UserRepository::class.java),
+        ) { _, method, _ ->
+            when (method.name) {
+                "getReceiverListFlow" -> flowOf(emptyList<Any>())
+                "getReceivers" -> emptyList<Any>()
+                else -> error("Unexpected user repository call: ${method.name}")
+            }
+        } as UserRepository
+
+    private companion object {
+        val testLetters =
+            TimeLetterList(
+                timeLetters =
+                    listOf(
+                        TimeLetter(
+                            id = 1L,
+                            title = "제목",
+                            sendAt = null,
+                            deliveredAt = null,
+                            status = TimeLetterStatus.SCHEDULED,
+                            blocks = emptyList(),
+                            receiverIds = emptyList(),
+                        ),
+                    ),
+                totalCount = 1,
+            )
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- closes #550
- Related: #637

## 변경 사항
- 타임레터 삭제 요청을 DELETE /api/v1/time-letters와 request body 계약으로 수정
- Debug mock interceptor도 실제 서버와 동일한 삭제 계약으로 변경
- 목록형·블록형 삭제 전에 예/아니오 확인 팝업 표시
- 삭제 중 중복 요청 방지 및 정상적인 코루틴 취소 보존
- 삭제 성공 후 목록 재조회, 실패 시 기존 목록 유지 및 Snackbar 안내
- 사용자 노출 문구를 문자열 리소스로 분리

## 테스트
- Retrofit 삭제 메서드·경로·body 계약 테스트
- 삭제 성공 후 목록 재조회 테스트
- 삭제 실패 시 목록 유지 및 실패 상태 소비 테스트
- data/presentation unit test, ktlintCheck, compileDebugKotlin, git diff --check 통과

## 기기 확인
- DELETE body {timeLetterIds:[55]} 전송 확인
- 서버 200 응답 및 후속 GET 목록 갱신 확인
- 삭제 확인 팝업과 실제 항목 삭제 확인