### PR TITLE
fix(timeletter): 수신인 검색 안내 문구 수정 (#554)

### DIFF
--- a/feature/setting/presentation/src/main/kotlin/com/afternote/feature/setting/presentation/screen/ReceiverListScreen.kt
+++ b/feature/setting/presentation/src/main/kotlin/com/afternote/feature/setting/presentation/screen/ReceiverListScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -35,6 +36,7 @@ import com.afternote.core.ui.button.AfternoteButton
 import com.afternote.core.ui.button.AfternoteButtonType
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.topbar.DetailTopBar
+import com.afternote.feature.setting.presentation.R
 import com.afternote.feature.setting.presentation.component.ReceiverListItem
 import kotlinx.coroutines.launch
 
@@ -110,7 +112,7 @@ fun ReceiverListScreen(
         ) {
             AfternoteTextField(
                 state = searchState,
-                placeholder = "Text Field",
+                placeholder = stringResource(R.string.setting_receiver_search_placeholder),
                 type = TextFieldType.Search,
                 imeAction = ImeAction.Search,
                 modifier = Modifier.padding(horizontal = 20.dp),

--- a/feature/setting/presentation/src/main/res/values/strings.xml
+++ b/feature/setting/presentation/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="setting_receiver_search_placeholder">이름으로 조회</string>
     <!-- 설정 공통 -->
     <string name="settings_title">설정</string>
     <!-- 섹션 헤더 -->

--- a/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/screen/sender/RecipientListScreen.kt
+++ b/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/screen/sender/RecipientListScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -38,6 +39,7 @@ import com.afternote.core.ui.button.AfternoteButton
 import com.afternote.core.ui.button.AfternoteButtonType
 import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.topbar.DetailTopBar
+import com.afternote.feature.timeletter.presentation.R
 import com.afternote.feature.timeletter.presentation.component.RecipientListItem
 import com.afternote.feature.timeletter.presentation.viewmodel.RecipientListViewModel
 import kotlinx.coroutines.launch
@@ -132,7 +134,7 @@ private fun RecipientListContent(
         ) {
             AfternoteTextField(
                 state = searchState,
-                placeholder = "Text Field",
+                placeholder = stringResource(R.string.timeletter_recipient_search_placeholder),
                 type = TextFieldType.Search,
                 imeAction = ImeAction.Search,
                 modifier = Modifier.padding(horizontal = 20.dp),

--- a/feature/timeletter/presentation/src/main/res/values/strings.xml
+++ b/feature/timeletter/presentation/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="timeletter_recipient_search_placeholder">이름으로 조회</string>
+</resources>


### PR DESCRIPTION
## 변경 사항
- 타임레터 수신인 선택 검색창의 Text Field를 이름으로 조회로 변경
- 설정 수신자 목록 검색창에도 동일한 안내 문구 적용
- 두 모듈 모두 string resource로 문구 관리

## 검증
- :feature:timeletter:presentation:compileDebugKotlin`n- :feature:setting:presentation:compileDebugKotlin`n- 두 모듈 ktlintCheck`n- git diff --check`n
Closes #554