### PR TITLE
fix(ci): 검증 3종의 base 필터 제거로 스택 PR 검증 누락 차단 (closes 683) [base: develop]

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,9 @@
 name: Static Analysis (Reviewdog)
 
+# base 필터를 두지 않는다 — base 변경(feat/* → develop)은 pull_request 기본 activity type 에
+# 없어 재트리거되지 않으므로, 필터가 있으면 스택 PR 이 검증을 한 번도 거치지 않고 머지된다.
 on:
   pull_request:
-    branches: [main, develop]
 
 permissions:
   contents: read

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -1,8 +1,9 @@
 name: Compose Preview Screenshot Test
 
+# base 필터를 두지 않는다 — base 변경(feat/* → develop)은 pull_request 기본 activity type 에
+# 없어 재트리거되지 않으므로, 필터가 있으면 스택 PR 이 검증을 한 번도 거치지 않고 머지된다.
 on:
   pull_request:
-    branches: [main, develop]
 
 permissions:
   contents: read

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,14 +1,15 @@
 name: Unit Test
 
-# PR 대상 main/develop 일 때 JVM unit test 실행:
+# 모든 PR 에서 JVM unit test 실행:
 #   - ./gradlew testDebugUnitTest : Android 모듈 debug unit test
 #   - :konsist:test : 순수 JVM 모듈(testDebugUnitTest 미보유)이라 별도 명시. 레이어 의존 아키텍처 가드.
 #   - :build-logic:test : included build 라 루트 태스크에 안 묶여 별도 명시. release 키 가드(TestKit) 회귀 가드.
 # lint.yml 과 setup 이 거의 동일하지만 분리 — lint 실패가 test 결과를 가리지 않도록 fail-fast 독립.
 
+# base 필터를 두지 않는다 — base 변경(feat/* → develop)은 pull_request 기본 activity type 에
+# 없어 재트리거되지 않으므로, 필터가 있으면 스택 PR 이 검증을 한 번도 거치지 않고 머지된다.
 on:
   pull_request:
-    branches: [main, develop]
 
 permissions:
   contents: read


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #683 — fix(ci): 검증 3종이 base PATCH 전이를 못 잡아 검증 0건으로 머지 — branches 필터 제거 후 required check 지정

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `lint.yml` · `unit-test.yml` · `screenshot.yml` 의 `on.pull_request.branches: [main, develop]` 를 제거해 트리거를 `on: pull_request:` 만 남김 (b5b565e0)
- 필터를 왜 두지 않는지 세 파일에 주석으로 고정 — base 변경은 `pull_request` 기본 activity type(`opened`·`synchronize`·`reopened`)에 없어 재트리거되지 않으므로, 필터가 있으면 스택 PR 이 검증을 한 번도 거치지 않고 머지된다
- `unit-test.yml` 헤더 주석의 "PR 대상 main/develop 일 때" 를 "모든 PR 에서" 로 정정 — 필터 제거로 사실과 어긋나게 되는 문장

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — diff 가 `.github/workflows` YAML 3개뿐이고 Compose 본문·디자인 토큰·리소스·동적 배선(네비·네트워크·DI) 변경이 0건이라 스크린샷 사이클·실기기 실측 모두 해당 없음.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- **이 PR 은 이슈의 1단계만 담는다.** 이슈 Note 의 2단계인 develop required status check 지정은 레포 설정이라 PR 로 바꿀 수 없고, 작성자 권한이 `admin=false` · `maintain=false` 라 API 로도 못 건다. 레포 admin 이 걸어야 이 필터 제거가 실제 머지 잠금으로 이어진다.
- 조치 순서는 이슈 Note 대로 필터 제거가 먼저다 — 필터를 남긴 채 required check 를 걸면 스택 PR 에서 체크 자체가 생성되지 않아 Pending 으로 남고 머지가 잠긴다.
- 필터를 지워도 base 전이 시점에 재트리거가 생기는 것은 아니다. 효과는 스택 PR 이 열릴 때·push 될 때 검증이 끝나 있어, base 를 develop 으로 PATCH 하는 시점에 그 head SHA 에 이미 성공한 check-run 이 붙어 있게 되는 것이다.
- `mock-cleanup-check.yml` 의 `branches: [main]` 은 같은 갈래지만 #684 가 별건으로 다루므로 이 PR 범위 밖이다.
- Actions 사용량은 스택 PR 만큼 늘지만 public 레포라 분 과금이 없다. 스택 PR 실패가 원인 PR 에 귀속되는 이점도 함께 생긴다.
- 검증: `actionlint` 3개 파일 0 issues, `yaml.safe_load` 로 세 파일 모두 트리거가 `{'pull_request': None}`(기본 activity type + 모든 base)임을 확인. Kotlin 컴파일 대상 변경이 없어 `compileDebugKotlin` 은 해당 없음.
