### PR TITLE
fix(home): 인사말 이름 디스크 캐시 저장·조회 결선 복구 (closes 697) [base: feat/588]

### DIFF
--- a/app/src/main/java/com/afternote/afternote_fe/screen/HomeTabViewModel.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/screen/HomeTabViewModel.kt
@@ -6,6 +6,8 @@ import com.afternote.afternote_fe.reporting.HomeFailureStage
 import com.afternote.afternote_fe.reporting.recordHomeFailure
 import com.afternote.afternote_fe.usecase.GetHomeSummaryUseCase
 import com.afternote.core.common.reporting.ErrorReporter
+import com.afternote.core.common.result.runCatchingCancellable
+import com.afternote.core.domain.repository.UserProfileRepository
 import com.afternote.core.model.HomeSummary
 import com.afternote.core.model.MindRecordCategory
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -21,6 +23,7 @@ class HomeTabViewModel
     @Inject
     constructor(
         private val getHomeSummary: GetHomeSummaryUseCase,
+        private val userProfileRepository: UserProfileRepository,
         private val errorReporter: ErrorReporter,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow<HomeTabUiState>(HomeTabUiState.Loading())
@@ -75,12 +78,13 @@ class HomeTabViewModel
                     } else {
                         // 초기 진입 또는 에러 재시도: 캐시된 이름이 있으면 placeholder로 즉시 노출한다.
                         _uiState.value =
-                            HomeTabUiState.Loading()
+                            HomeTabUiState.Loading(cachedUserName = userProfileRepository.getCachedUserName())
                     }
 
                     getHomeSummary()
                         .onSuccess { summary ->
                             _uiState.value = summary.toHomeTabSuccess()
+                            cacheUserName(summary.userName)
                         }.onFailure { error ->
                             // 화면을 유지하는 자동 갱신 실패도 기록한다. 사용자에게 안 보이는 만큼
                             // 콘솔이 유일한 관측 지점이다.
@@ -93,6 +97,16 @@ class HomeTabViewModel
                                 }
                         }
                 }
+        }
+
+        /**
+         * 다음 콜드스타트에서 placeholder 로 쓸 이름을 디스크에 남긴다.
+         *
+         * 저장 실패는 화면에 반영하지 않는다 — 이름은 이미 응답으로 표시돼 있고, 손실은
+         * 다음 진입의 placeholder 가 한 번 더 비는 것뿐이다.
+         */
+        private suspend fun cacheUserName(name: String) {
+            runCatchingCancellable { userProfileRepository.saveUserName(name) }
         }
     }
 


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #697 — fix(home): 인사말 이름이 항상 '…' — 이름 디스크 캐시 저장·조회 양방향 단절

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `HomeTabViewModel` 에 `UserProfileRepository` 를 주입하고, 홈 요약 조회 성공 시 응답의 이름을 `saveUserName()` 으로 디스크에 남긴다 — 끊겨 있던 캐시 쓰기 복구 (d8e2c8af)
- 초기 진입·에러 재시도의 `HomeTabUiState.Loading` 을 `getCachedUserName()` 으로 채운다 — 끊겨 있던 캐시 읽기 복구. 같은 자리 주석이 이미 "캐시된 이름이 있으면 placeholder로 즉시 노출한다" 라고 서술하고 있었으나 실제 주입은 `da3e3f16` 에서 빠져 있었다
- 저장은 `runCatchingCancellable` 로 감싸 실패가 화면에 닿지 않게 한다. 이름은 이미 응답으로 표시돼 있고, 손실은 다음 진입의 placeholder 가 한 번 더 비는 것뿐이다

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

Compose 본문·리소스 변경은 없다. 화면에 드러나는 차이는 Loading 구간 인사말이며, 에뮬레이터에서 네트워크 지연 20초로 그 구간을 붙잡아 대조했다.

| 캐시 없음 — 수정 전 상시 상태 | 캐시 있음 — 수정 후 |
|---|---|
| <img width="300" alt="Loading 구간 인사말이 …님으로 표시된 홈 화면" src="https://github.com/user-attachments/assets/0ec28486-368d-4d60-a8ce-699bc16afac9" /> | <img width="300" alt="Loading 구간 인사말이 ClaudeQA님으로 표시된 홈 화면" src="https://github.com/user-attachments/assets/e90d7be9-0166-4385-8a40-7286160ffd15" /> |

두 장 모두 오늘의 질문 본문과 일기 TOTAL 이 스켈레톤인 Loading 상태이며, 차이는 인사말 자리뿐이다.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- **base 가 `feat/588`(PR #728) 인 스택 PR 이다.** 그 PR 이 같은 파일에서 미사용 `userRepository` 생성자 파라미터를 제거하는데, 이 이슈의 해야 할 일 3번이 바로 그것이라 거기서 처리된 것으로 보고 이 PR 은 1·2번만 담는다. develop 기준으로 팠다면 생성자 파라미터 목록에서 정면 충돌한다.
- 실측 (Pixel_7_Claude_QA, 실서버 로그인 상태):
  - 쓰기 — 홈 로드 성공 후 `files/datastore/UserProfile.preferences_pb` 에 `user_name` → `ClaudeQA` 저장 확인(xxd, 재시작 포함 2회 재현). 수정 전에는 이 파일에 이름 키가 생긴 적이 없다.
  - 읽기 — 캐시가 있는 상태의 Loading 구간에서 인사말이 "ClaudeQA님".
  - 폴백 — 캐시 파일을 지우고 같은 조건으로 재진입하면 "…님". 캐시가 없을 때 `null` 로 떨어지는 기존 계약은 유지된다.
- 위 스크린샷의 "수신인 지정 미완료" 배지는 Loading 기본값이 확정 표시로 새는 별건이며 #698 이 다룬다. 이 PR 범위 밖이다.
- base 가 `feat/*` 라 Ktlint·Android Lint·Unit Test·Screenshot 이 이 PR 에서 스킵된다(#683 이 다루는 그 구멍이며 PR #748 이 필터를 제거한다). `merge-order-guard` 실패도 base=`feat/*` 에 대한 설계된 차단이다. 아래 로컬 검증으로 대신한다.
- 빌드 검증: `./gradlew :app:compileDebugKotlin :app:ktlintMainSourceSetCheck` BUILD SUCCESSFUL. `HomeTabViewModel` 단위 테스트는 존재하지 않아 생성자 변경으로 깨지는 테스트가 없고, `HomeTabScreenScreenshotTest` 는 `Loading(cachedUserName = "일혁")` 을 직접 주입해 ViewModel 을 타지 않으므로 baseline 영향도 없다.
