### PR TITLE
fix(afternote): 수신 목록 카드에 종류 enum 대신 서버가 준 서비스명 표시 (closes 617) [base: feat/689]

### DIFF
--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/ReceiverAfternoteDto.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/dto/ReceiverAfternoteDto.kt
@@ -12,7 +12,7 @@ data class ReceivedAfternoteListDto(
 @Serializable
 data class ReceivedAfternoteDto(
     @SerialName("id") val id: Long,
-    @SerialName("title") val title: String? = null,
+    @SerialName("title") val title: String,
     @SerialName("category") val category: String? = null,
     @SerialName("leaveMessage") val leaveMessage: String? = null,
     @SerialName("senderId") val senderId: Long? = null,

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/ReceiverAfternoteListItemDtoToDomain.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/mapper/ReceiverAfternoteListItemDtoToDomain.kt
@@ -7,7 +7,7 @@ import com.afternote.feature.afternote.domain.model.receiver.AfterNoteListItem
 fun ReceivedAfternoteDto.toDomain(): AfterNoteListItem =
     AfterNoteListItem(
         id = id,
-        title = title,
+        serviceName = title,
         type = category?.let(::afternoteTypeFromServerCategory),
         lastUpdatedAt = createdAt?.let { formatDateFromServer(it) },
     )

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/ReceiverAfternoteListItemDtoToDomainTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/mapper/ReceiverAfternoteListItemDtoToDomainTest.kt
@@ -23,7 +23,7 @@ class ReceiverAfternoteListItemDtoToDomainTest {
             ).toDomain()
 
         assertEquals(9L, result.id)
-        assertEquals("사진첩", result.title)
+        assertEquals("사진첩", result.serviceName)
         assertEquals(AfternoteType.GALLERY_AND_FILES, result.type)
         assertEquals("2025.11.26", result.lastUpdatedAt)
     }
@@ -59,7 +59,7 @@ class ReceiverAfternoteListItemDtoToDomainTest {
 
     private fun resp(
         id: Long = 1L,
-        title: String? = "t",
+        title: String = "t",
         category: String? = "SOCIAL",
         createdAt: String? = "2025-01-01T00:00:00",
     ) = ReceivedAfternoteDto(

--- a/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/model/receiver/ReceiverAfternoteModels.kt
+++ b/feature/afternote/domain/src/main/java/com/afternote/feature/afternote/domain/model/receiver/ReceiverAfternoteModels.kt
@@ -9,7 +9,7 @@ data class AfterNotesListResult(
 
 data class AfterNoteListItem(
     val id: Long,
-    val title: String?,
+    val serviceName: String,
     val type: AfternoteType?,
     val lastUpdatedAt: String?,
 )

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/home/ReceiverAfternoteHomeViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/home/ReceiverAfternoteHomeViewModel.kt
@@ -10,8 +10,7 @@ import com.afternote.feature.afternote.domain.AfternoteType
 import com.afternote.feature.afternote.domain.model.receiver.AfterNoteListItem
 import com.afternote.feature.afternote.domain.repository.receiver.ReceiverRepository
 import com.afternote.feature.afternote.presentation.shared.body.infinite.content.list.item.ListItemUiModel
-import com.afternote.feature.afternote.presentation.shared.util.getIconResForType
-import com.afternote.feature.afternote.presentation.shared.util.getServiceNameForTypeKey
+import com.afternote.feature.afternote.presentation.shared.util.getIconResForService
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -58,14 +57,15 @@ class ReceiverAfternoteHomeViewModel
         }
     }
 
-private fun AfterNoteListItem.toUiModel(): ListItemUiModel {
+/** 카드 주 텍스트는 발신자가 고른 서비스명이다 — 종류는 아이콘과 필터 탭이 담는다. */
+internal fun AfterNoteListItem.toUiModel(): ListItemUiModel {
     // 서버가 종류를 안 줬거나 모르는 값이면 표시할 것이 없어 소셜네트워크로 떨어진다.
     val resolvedType = type ?: AfternoteType.SOCIAL_NETWORK
     return ListItemUiModel(
         id = id.toString(),
-        serviceName = getServiceNameForTypeKey(resolvedType.name),
+        serviceName = serviceName,
         date = lastUpdatedAt.orEmpty(),
-        iconResId = getIconResForType(resolvedType),
+        iconResId = getIconResForService(serviceName, resolvedType),
         type = resolvedType,
     )
 }

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/shared/util/AfternoteDisplayRes.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/shared/util/AfternoteDisplayRes.kt
@@ -5,12 +5,6 @@ import com.afternote.feature.afternote.domain.AfternoteType
 import com.afternote.feature.afternote.presentation.R
 import com.afternote.feature.afternote.presentation.shared.model.AfternoteService
 
-/** Label and icon drawable resource IDs for an afternote type key. */
-data class AfternoteRes(
-    val stringResId: Int,
-    val drawableResId: Int,
-)
-
 /**
  * 종류 필터 탭 순서. `null` 은 "전체" 탭이다.
  * 비즈니스·재산 처리는 목록 조회 미지원(Afternote-BE#110, #491)이라 빠져 있다.
@@ -35,22 +29,7 @@ fun categoryLabelResFor(type: AfternoteType?): Int =
         AfternoteType.MEMORIAL -> R.string.afternote_category_memorial
     }
 
-/**
- * @param typeKey Writer: e.g. SOCIAL_NETWORK, GALLERY_AND_FILES, MEMORIAL. Receiver: e.g. INSTAGRAM, GALLERY, GUIDE, NAVER_MAIL.
- */
-fun getAfternoteDisplayRes(typeKey: String): AfternoteRes {
-    AfternoteService.fromTypeKeyOrNull(typeKey)?.let { svc ->
-        return AfternoteRes(stringResId = svc.stringResId, drawableResId = svc.iconResId)
-    }
-    val drawableResId =
-        AfternoteService.fromDisplayKeyOrNull(typeKey)?.iconResId
-            ?: R.drawable.feature_afternote_img_logo
-    return AfternoteRes(stringResId = R.string.afternote_category_social_network, drawableResId = drawableResId)
-}
-
-/**
- * Icon drawable res for an [AfternoteType]. Same mapping as [getAfternoteDisplayRes]; use when you have [AfternoteType].
- */
+/** Icon drawable res for an [AfternoteType]. */
 fun getIconResForType(type: AfternoteType): Int =
     AfternoteService.fromTypeKeyOrNull(type.name)?.iconResId
         ?: R.drawable.feature_afternote_img_logo
@@ -68,9 +47,3 @@ fun getIconResForService(
 ): Int =
     AfternoteService.fromDisplayKeyOrNull(serviceName)?.iconResId
         ?: getIconResForType(type)
-
-/**
- * API typeKey(예: "INSTAGRAM") → 화면 표시명(예: "인스타그램") 변환.
- * 매핑이 없으면 typeKey를 그대로 반환합니다.
- */
-fun getServiceNameForTypeKey(typeKey: String): String = AfternoteService.fromTypeKeyOrNull(typeKey)?.displayKey ?: typeKey

--- a/feature/afternote/presentation/src/test/kotlin/com/afternote/feature/afternote/presentation/receiver/home/ReceiverAfternoteListMappingTest.kt
+++ b/feature/afternote/presentation/src/test/kotlin/com/afternote/feature/afternote/presentation/receiver/home/ReceiverAfternoteListMappingTest.kt
@@ -1,0 +1,81 @@
+package com.afternote.feature.afternote.presentation.receiver.home
+
+import com.afternote.feature.afternote.domain.AfternoteType
+import com.afternote.feature.afternote.domain.model.receiver.AfterNoteListItem
+import com.afternote.feature.afternote.presentation.shared.model.AfternoteService
+import com.afternote.feature.afternote.presentation.shared.util.getIconResForType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * 수신 목록 카드가 발신자가 고른 서비스명을 보여준다는 계약 (이슈 #617).
+ *
+ * 종류는 아이콘과 필터 탭이 담으므로 카드 주 텍스트로 새어 나오면 안 된다.
+ */
+class ReceiverAfternoteListMappingTest {
+    private fun listItem(
+        serviceName: String,
+        type: AfternoteType? = AfternoteType.SOCIAL_NETWORK,
+    ) = AfterNoteListItem(
+        id = 5,
+        serviceName = serviceName,
+        type = type,
+        lastUpdatedAt = "2026.07.29",
+    )
+
+    @Test
+    fun `카드 주 텍스트는 서버가 준 서비스명이다`() {
+        val uiModel = listItem(serviceName = "인스타그램").toUiModel()
+
+        assertEquals("인스타그램", uiModel.serviceName)
+    }
+
+    @Test
+    fun `어떤 종류에서도 enum 이름이 카드 주 텍스트로 새지 않는다`() {
+        AfternoteType.entries.forEach { type ->
+            val uiModel = listItem(serviceName = "네이버 메일", type = type).toUiModel()
+
+            assertNotEquals(
+                "$type 카드에 종류 enum 이름이 그대로 노출됐다",
+                type.name,
+                uiModel.serviceName,
+            )
+        }
+    }
+
+    @Test
+    fun `종류를 모르는 응답도 서비스명은 그대로 보여준다`() {
+        val uiModel = listItem(serviceName = "갤러리", type = null).toUiModel()
+
+        assertEquals("갤러리", uiModel.serviceName)
+        assertEquals(AfternoteType.SOCIAL_NETWORK, uiModel.type)
+    }
+
+    @Test
+    fun `카탈로그에 있는 서비스명이면 그 서비스 아이콘을 쓴다`() {
+        val uiModel =
+            listItem(
+                serviceName = AfternoteService.INSTAGRAM.displayKey,
+                type = AfternoteType.SOCIAL_NETWORK,
+            ).toUiModel()
+
+        assertEquals(AfternoteService.INSTAGRAM.iconResId, uiModel.iconResId)
+    }
+
+    /**
+     * 카탈로그 밖 이름은 #490 이전에 저장된 "직접 추가하기" 데이터에서만 온다.
+     * MEMORIAL 은 저장 라벨 "추억 노트" 가 카탈로그에 걸려 이 경로를 타지 않으므로 검증에 쓰지 않는다.
+     */
+    @Test
+    fun `카탈로그에 없는 이름은 소셜이 아니라 그 항목의 종류 아이콘으로 떨어진다`() {
+        val uiModel =
+            listItem(
+                serviceName = "내가 직접 적은 서비스",
+                type = AfternoteType.GALLERY_AND_FILES,
+            ).toUiModel()
+
+        assertEquals(getIconResForType(AfternoteType.GALLERY_AND_FILES), uiModel.iconResId)
+        assertNotEquals(getIconResForType(AfternoteType.SOCIAL_NETWORK), uiModel.iconResId)
+    }
+}


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #617 — fix(afternote): 수신 애프터노트 목록이 제목 대신 카테고리 enum 원문 표시 — MEMORIAL·GALLERY_AND_FILES·SOCIAL_NETWORK 노출

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- 수신 목록 카드의 주 텍스트를 서버가 준 서비스명으로 교체. 종류 키를 그대로 넣고 있어 `MEMORIAL`·`GALLERY_AND_FILES`·`SOCIAL_NETWORK` 가 화면에 노출됐다 — `AfternoteService` 의 카테고리 3종은 `displayKey` 가 한글이 아니라 enum 키 문자열이라 매핑에 성공하고도 영문이 나온다.
- 아이콘도 발신자 경로(`getIconResForService`)로 통일. 서비스명이 카탈로그에 있으면 그 로고, 없으면 종류 아이콘으로 떨어진다.
- `ReceivedAfternoteDto.title` 을 non-null 로 정정하고 도메인 필드명을 `AfterNoteListItem.serviceName` 으로 맞춤. 서버 `title` 은 에디터에서 고른 서비스명이 실리는 필드이고 `AfternoteCreateRequest` 의 required 라 응답에서 빠질 수 없는데, 발신자 DTO 는 non-null 인 반면 수신자만 nullable 이었다.
- 호출처가 사라진 `getServiceNameForTypeKey` 와, #689 에서 이미 호출처가 0이 된 `getAfternoteDisplayRes`·`AfternoteRes` 제거.
- `ReceiverAfternoteListMappingTest` 5건 추가. `AfternoteType.entries` 전체를 돌며 종류 이름이 카드 주 텍스트로 새지 않는지 확인하므로 종류가 늘어도 같은 결함이 다시 나면 잡힌다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

수신자 목록 화면은 앱에 재현 경로가 없어 미촬영 — 받은 기록함~발신자 상세가 로컬 stub 이라(#607) 서버가 200 을 줘도 화면이 열람 불가로 수렴한다. 대신 세 갈래로 검증했다.

- **서버 응답 실측** — `GET receiver-auth/after-notes` 200, 5건. `title` 이 `인스타그램`·`인스타그램2`·`인스타그램3`·`추억 노트`·`소셜 계정 정리 부탁해` 로 온다. 앞 넷은 에디터가 실어 보낸 서비스명, 마지막은 QA 로 직접 넣은 자유 문장이다.
- **같은 공유 컴포넌트 화면 실측** — 발신자 목록(`AfternoteListItem` 동일 사용)에서 카드가 서버 `title` 을 주 텍스트로 그리고, 카탈로그 밖 이름("우리집 사진 백업 드라이브")이 종류 아이콘으로 떨어지는 것을 확인했다. 이 PR 이 수신자에 맞추는 계약이 그대로 동작하는 화면이다.
- **단위 테스트** — 위 5건.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- **stack base = `feat/689`(#747).** 그 PR 이 `AfterNoteListItem` 을 `AfternoteType` 기반으로 바꾸면서 같은 파일 4개를 이미 건드리고 있어 develop 에서 파면 충돌한다. #747 머지 후 자동으로 develop 대상이 된다.
- **`ReceiverAfternoteDto.kt` 에서 #746(feat/509)과 인접 2줄 충돌이 예상된다.** 그쪽은 바로 다음 줄인 `leaveMessage` 를 배열로 바꾼다. 서로 다른 필드라 동작·빌드에는 영향이 없어 의존은 걸지 않았고, 나중에 머지되는 쪽에서 한 번 풀면 된다.
- 아이콘을 종류로 떨어뜨리는 처리 자체는 #622 가 정한 계약을 그대로 따랐다. 다만 시안 대조에서 그 처리의 근거가 확인되지 않아 별도로 #753 에 정리했다 — 목록 카드 시안 네 개가 전부 서비스 아이콘을 쓰고, 보드의 카테고리 아이콘은 그라데이션 세트로 카드 것과 다른 아이콘이다. 종류 인자를 걷어내는 작업은 그 이슈에서 발신자·수신자 양쪽을 함께 다룬다.
- 빌드 검증: `./gradlew :feature:afternote:presentation:compileDebugKotlin :feature:afternote:data:compileDebugKotlin :feature:afternote:domain:compileDebugKotlin` BUILD SUCCESSFUL, 3개 모듈 ktlintCheck 통과, data·presentation 단위 테스트 11건 통과.
