### PR TITLE
fix(timeletter): 수신인 화면 왕복 시 작성 내용 보존 (#569)

### DIFF
--- a/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/navigation/TimeLetterNavGraph.kt
+++ b/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/navigation/TimeLetterNavGraph.kt
@@ -57,7 +57,12 @@ fun NavGraphBuilder.timeLetterNavGraph(
                 onDraftClick = { title, textContents -> viewModel.saveDraft(title, textContents) },
                 onNavigateToDraft = actions::onNavigateToDraft,
                 onErrorShown = { viewModel.clearError() },
-                onRecipientClick = actions::onNavigateToRecipient,
+                onRecipientClick = { title, textContents ->
+                    viewModel.updateDraftContent(title, textContents)
+                    actions.onNavigateToRecipient()
+                },
+                onTitleChanged = viewModel::updateDraftTitle,
+                onTextContentChanged = viewModel::updateDraftTextContent,
                 onDateSelected = { viewModel.setSendAt(it) },
                 onTimeSelected = { h, m -> viewModel.setSendTime(h, m) },
                 onAddImageBlock = { uri -> viewModel.addImageBlock(uri) },

--- a/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/screen/sender/TimeLetterWriteScreen.kt
+++ b/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/screen/sender/TimeLetterWriteScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -76,6 +77,7 @@ import com.afternote.feature.timeletter.presentation.component.TimeLetterTitleTe
 import com.afternote.feature.timeletter.presentation.component.TimeWheelPicker
 import com.afternote.feature.timeletter.presentation.viewmodel.EditorBlock
 import com.afternote.feature.timeletter.presentation.viewmodel.TimeLetterWriteUiState
+import kotlinx.coroutines.flow.distinctUntilChanged
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -84,10 +86,12 @@ import java.time.LocalTime
 fun TimeLetterWriteScreen(
     modifier: Modifier = Modifier,
     uiState: TimeLetterWriteUiState = TimeLetterWriteUiState(),
-    titleState: TextFieldState = rememberTextFieldState(),
+    titleState: TextFieldState = rememberTextFieldState(uiState.initialTitle.orEmpty()),
     onBackClick: () -> Unit = {},
     onRegisterClick: (title: String, textContents: Map<Long, String>) -> Unit = { _, _ -> },
-    onRecipientClick: () -> Unit = {},
+    onRecipientClick: (title: String, textContents: Map<Long, String>) -> Unit = { _, _ -> },
+    onTitleChanged: (String) -> Unit = {},
+    onTextContentChanged: (blockId: Long, content: String) -> Unit = { _, _ -> },
     onDateSelected: (String) -> Unit = {},
     onTimeSelected: (hour: Int, minute: Int) -> Unit = { _, _ -> },
     onDraftClick: (title: String, textContents: Map<Long, String>) -> Unit = { _, _ -> },
@@ -139,11 +143,10 @@ fun TimeLetterWriteScreen(
         onErrorShown()
     }
 
-    LaunchedEffect(uiState.editingTimeLetterId, uiState.initialTitle) {
-        val title = uiState.initialTitle
-        if (uiState.editingTimeLetterId == null || title != null) {
-            titleState.edit { replace(0, length, title.orEmpty()) }
-        }
+    LaunchedEffect(titleState) {
+        snapshotFlow { titleState.text.toString() }
+            .distinctUntilChanged()
+            .collect(onTitleChanged)
     }
 
     if (uiState.isLoadingEditingLetter) {
@@ -369,7 +372,12 @@ fun TimeLetterWriteScreen(
             item(key = "recipient") {
                 RecipientCard(
                     recipientName = uiState.recipientNames.joinToString(", "),
-                    onClick = onRecipientClick,
+                    onClick = {
+                        onRecipientClick(
+                            titleState.text.toString(),
+                            collectTextContents(),
+                        )
+                    },
                 )
             }
             item(key = "divider_1") {
@@ -398,6 +406,7 @@ fun TimeLetterWriteScreen(
                             initialText = uiState.initialTextContents[block.id].orEmpty(),
                             textAlign = uiState.textAlign,
                             onFocused = { onSetFocusedBlock(block.id) },
+                            onTextChanged = { content -> onTextContentChanged(block.id, content) },
                         )
                     }
 
@@ -444,14 +453,17 @@ private fun TextBlockItem(
     initialText: String,
     textAlign: TextAlign,
     onFocused: () -> Unit,
+    onTextChanged: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val state =
         remember(blockId) {
             textBlockStates.getOrPut(blockId) { TextFieldState(initialText) }
         }
-    LaunchedEffect(blockId, initialText) {
-        state.edit { replace(0, length, initialText) }
+    LaunchedEffect(state) {
+        snapshotFlow { state.text.toString() }
+            .distinctUntilChanged()
+            .collect(onTextChanged)
     }
     DisposableEffect(blockId) {
         onDispose { textBlockStates.remove(blockId) }

--- a/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/viewmodel/TimeLetterWriteViewModel.kt
+++ b/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/viewmodel/TimeLetterWriteViewModel.kt
@@ -81,6 +81,33 @@ class TimeLetterWriteViewModel
             }
         }
 
+        fun updateDraftContent(
+            title: String,
+            textContents: Map<Long, String>,
+        ) {
+            val savedTextContents = textContents.toMap()
+            _uiState.update {
+                it.copy(
+                    initialTitle = title,
+                    initialTextContents = savedTextContents,
+                )
+            }
+        }
+
+        fun updateDraftTitle(title: String) {
+            updateDraftContent(title, _uiState.value.initialTextContents)
+        }
+
+        fun updateDraftTextContent(
+            blockId: Long,
+            content: String,
+        ) {
+            updateDraftContent(
+                title = _uiState.value.initialTitle.orEmpty(),
+                textContents = _uiState.value.initialTextContents + (blockId to content),
+            )
+        }
+
         fun setSendAt(sendAt: String) {
             _uiState.update { it.copy(sendAt = sendAt) }
         }
@@ -333,6 +360,13 @@ class TimeLetterWriteViewModel
                             nextBlockId = (editorBlocks.maxOfOrNull { block -> block.id } ?: 0L) + 1L,
                         )
                     }
+                    updateDraftContent(
+                        title = letter.title.orEmpty(),
+                        textContents =
+                            letter.blocks
+                                .filter { block -> block.blockType == TimeLetterBlockType.TEXT }
+                                .associate { block -> block.id to (block.textContent ?: "") },
+                    )
                 }.onFailure {
                     _uiState.update { it.copy(isLoadingEditingLetter = false) }
                     _uiState.update { it.copy(errorMessage = "타임레터를 불러올 수 없습니다.") }


### PR DESCRIPTION
수신인 선택 화면으로 이동하기 전 제목과 텍스트 블록 내용을 TimeLetterWriteViewModel에 동기화하고, 복귀 시 해당 상태를 다시 표시하도록 수정했습니다. SavedStateHandle에 긴 본문을 저장하지 않고 내비게이션 왕복 범위만 안전하게 처리합니다. 검증: :feature:timeletter:presentation:compileDebugKotlin, :feature:timeletter:presentation:ktlintCheck, git diff --check 통과. Closes #569