### PR TITLE
fix(afternote): 수신자 인증·곡 검색 data 계층 취소 소비 제거 (closes 671) [base: develop]

### DIFF
--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/author/MusicSearchRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/author/MusicSearchRepositoryImpl.kt
@@ -1,10 +1,10 @@
 package com.afternote.feature.afternote.data.repositoryimpl.author
 
+import com.afternote.core.common.result.runCatchingCancellable
 import com.afternote.feature.afternote.data.dto.MusicTrackDto
 import com.afternote.feature.afternote.data.service.MusicApiService
 import com.afternote.feature.afternote.domain.model.author.playlist.SearchedSong
 import com.afternote.feature.afternote.domain.repository.author.MusicSearchRepository
-import kotlinx.coroutines.CancellationException
 import javax.inject.Inject
 
 /**
@@ -19,15 +19,8 @@ class MusicSearchRepositoryImpl
         override suspend fun search(keyword: String): Result<List<SearchedSong>> {
             val trimmed = keyword.trim()
             if (trimmed.isEmpty()) return Result.success(emptyList())
-            return try {
-                val tracks = api.search(keyword = trimmed).tracks
-                Result.success(tracks.mapIndexed { index, dto -> dto.toPlaylistSongDisplay(index) })
-            } catch (e: CancellationException) {
-                // runCatching 은 in-flight 취소까지 Result.failure 로 삼켜, 타이핑으로 이전 검색이
-                // 취소될 때마다 유령 "검색 실패"가 화면에 남았다. 취소는 실패가 아니므로 되던진다.
-                throw e
-            } catch (e: Exception) {
-                Result.failure(e)
+            return runCatchingCancellable {
+                api.search(keyword = trimmed).tracks.mapIndexed { index, dto -> dto.toPlaylistSongDisplay(index) }
             }
         }
 

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.afternote.feature.afternote.data.repositoryimpl.receiver
 
+import com.afternote.core.common.result.runCatchingCancellable
 import com.afternote.core.network.model.ApiException
 import com.afternote.core.network.model.requireData
 import com.afternote.core.network.model.requireStatus
@@ -25,10 +26,11 @@ import javax.inject.Singleton
 /**
  * `receiver-auth` 계열 endpoint 의 [ReceiverAuthRepository] 구현.
  *
- * 에러 처리 구조 — 일부 메서드는 try/catch 가 runCatching *안에* 포개져 있다:
+ * 에러 처리 구조 — 일부 메서드는 try/catch 가 [runCatchingCancellable] *안에* 포개져 있다:
  * 안쪽 catch 가 [ApiException](인프라 타입)을 도메인 예외로 바꿔 던지면(exception translation),
- * 그 새 예외는 자기를 만든 try 로 되돌아가지 않고 바깥 runCatching 이 잡아
+ * 그 새 예외는 자기를 만든 try 로 되돌아가지 않고 바깥 [runCatchingCancellable] 이 잡아
  * `Result.failure(도메인 예외)` 로 반환된다 — 호출자에게 예외가 throw 되어 나가는 일은 없다.
+ * 안쪽 catch 는 [ApiException] 만 받으므로 취소는 여기 걸리지 않고 바깥 래퍼가 그대로 되던진다.
  */
 @Singleton
 class ReceiverAuthRepositoryImpl
@@ -37,7 +39,7 @@ class ReceiverAuthRepositoryImpl
         private val api: ReceiverAuthApiService,
     ) : ReceiverAuthRepository {
         override suspend fun verifyMasterKey(authCode: String): Result<ReceiverIdentity> =
-            runCatching {
+            runCatchingCancellable {
                 try {
                     api.verifyMasterKey(ReceiverAuthVerifyRequestDto(authCode)).requireData().toDomain()
                 } catch (e: ApiException) {
@@ -46,7 +48,7 @@ class ReceiverAuthRepositoryImpl
             }
 
         override suspend fun sendEmailAuthCode(email: String): Result<Unit> =
-            runCatching {
+            runCatchingCancellable {
                 try {
                     api.sendEmailAuthCode(ReceiverAuthCodeEmailSendRequestDto(email)).requireStatus()
                 } catch (e: ApiException) {
@@ -58,7 +60,7 @@ class ReceiverAuthRepositoryImpl
             email: String,
             authCode: String,
         ): Result<ReceiverEmailAuthResult> =
-            runCatching {
+            runCatchingCancellable {
                 try {
                     api
                         .verifyEmailAuthCode(
@@ -71,7 +73,7 @@ class ReceiverAuthRepositoryImpl
             }
 
         override suspend fun getPresignedUrl(extension: String): Result<ReceiverAuthPresignedUrl> =
-            runCatching {
+            runCatchingCancellable {
                 api.getPresignedUrl(ReceiverAuthPresignedUrlRequestDto(extension)).requireData().toDomain()
             }
 
@@ -79,7 +81,7 @@ class ReceiverAuthRepositoryImpl
             deathCertificateUrl: String?,
             familyRelationCertificateUrl: String?,
         ): Result<DeliveryVerification> =
-            runCatching {
+            runCatchingCancellable {
                 try {
                     api
                         .submitDeliveryVerification(
@@ -99,12 +101,12 @@ class ReceiverAuthRepositoryImpl
             }
 
         override suspend fun getDeliveryVerificationStatus(): Result<DeliveryVerification> =
-            runCatching {
+            runCatchingCancellable {
                 api.getDeliveryVerificationStatus().requireData().toDomain()
             }
 
         override suspend fun getSenderMessage(): Result<SenderMessageInfo> =
-            runCatching {
+            runCatchingCancellable {
                 api.getSenderMessage().requireData().toDomain()
             }
     }

--- a/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverRepositoryImpl.kt
+++ b/feature/afternote/data/src/main/kotlin/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.afternote.feature.afternote.data.repositoryimpl.receiver
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
+import com.afternote.core.common.result.runCatchingCancellable
 import com.afternote.core.network.model.requireData
 import com.afternote.feature.afternote.data.local.ReceiverAuthCodeDataSource
 import com.afternote.feature.afternote.data.mapper.response.toDomain
@@ -62,7 +63,7 @@ class ReceiverRepositoryImpl
             )
 
         override suspend fun getReceivedAfternoteDetail(afternoteId: Long): Result<ReceivedAfternoteDetail> =
-            runCatching {
+            runCatchingCancellable {
                 api
                     .getReceiverAfternoteDetail(afternoteId = afternoteId)
                     .requireData()

--- a/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImplEmailAuthTest.kt
+++ b/feature/afternote/data/src/test/java/com/afternote/feature/afternote/data/repositoryimpl/receiver/ReceiverAuthRepositoryImplEmailAuthTest.kt
@@ -14,8 +14,12 @@ import com.afternote.feature.afternote.data.dto.ReceiverEmailAuthVerifyRequestDt
 import com.afternote.feature.afternote.data.dto.ReceiverMessageDto
 import com.afternote.feature.afternote.data.service.ReceiverAuthApiService
 import com.afternote.feature.afternote.domain.error.ReceiverEmailAuthException
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.IOException
@@ -27,6 +31,9 @@ import java.io.IOException
  * Impl 이 serverMessage 를 보존해 변환하는지가 계약. 에러 메시지·code 값은
  * 2026-06-11 라이브 서버 실응답 캡처 — 404 `{"code":1901,"message":"등록된 수신자 이메일이 아닙니다."}`,
  * 400 `{"code":1902,"message":"인증번호가 만료되었거나 존재하지 않습니다. 다시 요청해주세요."}`.
+ *
+ * 취소 전파도 여기서 함께 지킨다 (#671) — 예외를 Result 로 바꾸는 경계라 취소까지 삼키면
+ * 취소된 코루틴에서 호출부의 onFailure 갈래가 돈다.
  */
 class ReceiverAuthRepositoryImplEmailAuthTest {
     @Test
@@ -93,6 +100,23 @@ class ReceiverAuthRepositoryImplEmailAuthTest {
     }
 
     @Test
+    fun `sendEmailAuthCode - in-flight 취소는 Result 로 삼키지 않고 CancellationException 을 전파`() =
+        runBlocking {
+            val repository =
+                ReceiverAuthRepositoryImpl(
+                    FakeReceiverAuthApiService(onSendEmailAuthCode = { awaitCancellation() }),
+                )
+
+            var result: Result<Unit>? = null
+            val job = launch { result = repository.sendEmailAuthCode("a@b.com") }
+            yield() // job 이 api 호출 지점(awaitCancellation)까지 진행하도록
+            job.cancel()
+            job.join()
+
+            assertNull(result) // 취소가 Result 로 둔갑했다면 non-null 로 남는다
+        }
+
+    @Test
     fun `verifyEmailAuthCode - 성공 응답을 도메인 모델로 매핑`() {
         val repository =
             ReceiverAuthRepositoryImpl(
@@ -125,8 +149,8 @@ class ReceiverAuthRepositoryImplEmailAuthTest {
 
 /** 이메일 인증 두 메서드만 주입 가능한 fake — 나머지 endpoint 는 본 테스트 대상 아님. */
 private class FakeReceiverAuthApiService(
-    private val onSendEmailAuthCode: (ReceiverAuthCodeEmailSendRequestDto) -> BaseResponse<Unit> = { error("unused") },
-    private val onVerifyEmailAuthCode: (
+    private val onSendEmailAuthCode: suspend (ReceiverAuthCodeEmailSendRequestDto) -> BaseResponse<Unit> = { error("unused") },
+    private val onVerifyEmailAuthCode: suspend (
         ReceiverEmailAuthVerifyRequestDto,
     ) -> BaseResponse<ReceiverEmailAuthVerifyDto> = { error("unused") },
 ) : ReceiverAuthApiService {


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #671 — fix(afternote): 수신자 인증·곡 검색 data 계층 runCatching 취소 소비 — #661 잔여 3파일

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `ReceiverAuthRepositoryImpl` 7곳의 stdlib `runCatching` 을 `core:common` 의 `runCatchingCancellable` 로 교체
- `ReceiverRepositoryImpl.getReceivedAfternoteDetail` 1곳 동일 교체
- `MusicSearchRepositoryImpl` 은 손으로 `CancellationException` 을 되던지던 try/catch 3갈래를 같은 래퍼로 수렴
- `ReceiverAuthRepositoryImplEmailAuthTest` 에 취소 전파 회귀 테스트 1개 추가 (fake 람다를 suspend 로 전환)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — data 계층 4파일만 바뀌어 Compose 본문·리소스·디자인 토큰 변경이 0이다.

회귀 확인용으로 곡 검색 화면(추억 노트 → 추억 플레이리스트 → 플레이리스트 추가)을 에뮬레이터에서 실측했다. 검색어 입력 시 결과가 정상 표시되고, 연속 타이핑으로 이전 요청이 취소되는 동안 유령 "검색 실패" 안내가 뜨지 않는다. logcat 예외 0건.

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 이슈 본문이 적은 "11곳" 은 2026-08-01 기준이고 develop 실측은 8곳이다. 그 사이 `MusicSearchRepositoryImpl` 은 #511 에서 이미 손으로 취소를 되던지도록 고쳐져 결함이 해소돼 있었다 — 이번엔 래퍼로 수렴만 했다.
- 그 수렴으로 곡 검색의 포착 범위가 `Exception` → `Throwable` 로 넓어진다. 나머지 repositoryimpl 이 전부 `runCatching`(=Throwable) 이라 방향은 일치한다.
- `AfternoteAuthoringFailureMapper.kt:33` 의 `runCatching` 은 동기 JSON 파싱이라 그대로 뒀다. 래퍼 KDoc 이 명시한 제외 대상이다.
- `ReceiverAuthRepositoryImpl` 안쪽 try/catch 는 `ApiException` 만 받으므로 취소가 거기 걸리지 않고 바깥 래퍼가 되던진다 — 클래스 KDoc 에 그 근거를 한 줄 추가했다.
- 빌드 검증: `./gradlew :feature:afternote:data:compileDebugKotlin :feature:afternote:data:ktlintCheck` BUILD SUCCESSFUL, `:feature:afternote:data:testDebugUnitTest` 통과, `./gradlew assembleDebug` BUILD SUCCESSFUL
