### PR TITLE
fix(afternote): 증빙 서류 읽기 실패 무음 제거·업로드 실패 시 기존 첨부 보존 (closes 740) [base: develop]

### DIFF
--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadScreen.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadScreen.kt
@@ -177,7 +177,13 @@ private fun handlePickedUri(
     slot: DocumentSlot,
     uri: Uri,
 ) {
-    val result = contentResolver.readDocumentUri(uri) ?: return
+    val result = contentResolver.readDocumentUri(uri)
+    if (result == null) {
+        // 클라우드 전용 사진 등 provider 가 스트림을 못 여는 Uri — 무음으로 삼키면
+        // "선택했는데 아무 일도 없는" 화면이 된다 (#740).
+        viewModel.onDocumentReadFailed()
+        return
+    }
     viewModel.uploadDocument(
         slot = slot,
         bytes = result.bytes,

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadViewModel.kt
@@ -42,7 +42,12 @@ class DocumentUploadViewModel
             extension: String,
             displayName: String,
         ) {
-            if (bytes.isEmpty()) return
+            if (bytes.isEmpty()) {
+                onDocumentReadFailed()
+                return
+            }
+            // 실패 시 이 상태로 복원 — 재첨부 실패가 이미 성공해 둔 첨부(fileUrl)까지 지우면 안 된다 (#740).
+            val previous = _uiState.value.slotOf(slot)
             updateSlot(slot) { it.copy(displayName = displayName, isUploading = true) }
             viewModelScope.launch {
                 uploadRepository
@@ -56,12 +61,17 @@ class DocumentUploadViewModel
                         }
                     }.onFailure { throwable ->
                         errorReporter.recordAfternoteFailure(AfternoteFailureStage.DOCUMENT_UPLOAD, throwable)
-                        updateSlot(slot) { DocumentSlotState() }
+                        updateSlot(slot) { previous }
                         _uiState.update {
                             it.copy(error = ErrorPayload.Res(R.string.receiver_verify_document_upload_failed))
                         }
                     }
             }
+        }
+
+        /** picker 가 돌려준 Uri 에서 바이트 추출이 실패한 경우 — 업로드 요청 전이므로 슬롯은 건드리지 않는다 (#740). */
+        fun onDocumentReadFailed() {
+            _uiState.update { it.copy(error = ErrorPayload.Res(R.string.receiver_verify_document_read_failed)) }
         }
 
         fun submit() {
@@ -121,4 +131,10 @@ class DocumentUploadViewModel
                 }
             }
         }
+
+        private fun DocumentUploadUiState.slotOf(slot: DocumentSlot): DocumentSlotState =
+            when (slot) {
+                DocumentSlot.DeathCertificate -> deathCertificate
+                DocumentSlot.FamilyRelationCertificate -> familyRelationCertificate
+            }
     }

--- a/feature/afternote/presentation/src/main/res/values/strings.xml
+++ b/feature/afternote/presentation/src/main/res/values/strings.xml
@@ -185,6 +185,7 @@
     <string name="receiver_verify_complete_confirm">확인</string>
     <string name="receiver_verify_documents_required">사망진단서 또는 가족관계증명서 중 하나 이상 업로드해주세요.</string>
     <string name="receiver_verify_document_upload_failed">서류 업로드에 실패했습니다.</string>
+    <string name="receiver_verify_document_read_failed">선택한 파일을 불러오지 못했습니다. 다시 선택해 주세요.</string>
     <string name="receiver_verify_submit_failed">열람 신청에 실패했습니다.</string>
     <string name="receiver_verify_complete_title">열람 신청 완료</string>
     <string name="receiver_verify_status_pending">현재 서류 확인중입니다.\n빠르게 처리하여 열람하실 수 있도록 하겠습니다.</string>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #740 — fix(afternote): 수신자 증빙 서류 업로드가 완료되지 않아 열람 신청 진행 불가

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- picker Uri 바이트 추출 실패(`readDocumentUri` null)와 빈 바이트를 무음 return 대신 실패 스낵바 안내로 연결 — 문자열 `receiver_verify_document_read_failed` 신설
- 업로드 실패 시 슬롯을 `DocumentSlotState()` 통째 리셋 대신 업로드 시작 전 상태로 복원 — 재첨부 실패가 이미 성공해 둔 첨부(fileUrl·파일명·"다음" 활성)를 지우지 않음

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

에뮬 실측 (연결 실패 상태에서 성공 첨부 위 재첨부 시도):

| 수정 전 — 기존 첨부까지 소실 | 수정 후 — 실패 스낵바 + 기존 첨부 보존 |
|---|---|
| <img width="1080" height="2400" alt="수정 전: 사망진단서 슬롯이 placeholder로 리셋" src="https://github.com/user-attachments/assets/2e213795-bd8a-4240-b8b1-42cb760b89cc" /> | <img width="900" height="2000" alt="수정 후: 실패 스낵바가 뜨고 기존 첨부 유지" src="https://github.com/user-attachments/assets/ceb1a9a1-6ed3-45c8-939d-4ca91fb21e4b" /> |

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 원인 조사 실측(서버 presigned·S3 PUT 정상, debug/release(R8)×이미지/파일 picker 3조합 업로드 성공, "선택해도 무반응"을 만드는 경로는 무음 처리 2곳뿐)은 #740 이슈 코멘트에 정리했습니다
- 배포 앱(실기기)의 무음 증상은 클라우드 전용(미캐시) 사진처럼 provider 가 스트림을 못 여는 Uri 로 추정 — 에뮬로는 재현 불가라, 읽기 실패 안내는 코드 경로 검증, 실패 시 복원은 네트워크 차단 에뮬 실측(위 캡처)으로 검증했습니다
- 수정 빌드로 정상 업로드(이미지·pdf) 회귀 실측 통과
- 빌드 검증: `./gradlew :feature:afternote:presentation:compileDebugKotlin :feature:afternote:presentation:ktlintCheck` BUILD SUCCESSFUL
