### PR TITLE
fix(afternote): 업로드 진행 중 열람 신청 잠금 — 진행 중 서류 누락 방지 (closes 711) [base: feat/740]

### DIFF
--- a/feature/afternote/presentation/build.gradle.kts
+++ b/feature/afternote/presentation/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
     implementation(libs.androidx.paging.runtime)
     implementation(libs.androidx.paging.compose)
 
+    testImplementation(libs.coroutines.test)
+
     // Compose Preview Screenshot Testing (#330) — 1hyok 영역 마무리 묶음
     screenshotTestImplementation(libs.screenshot.validation.api)
     screenshotTestImplementation(libs.androidx.compose.ui.tooling)

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadUiState.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadUiState.kt
@@ -74,10 +74,16 @@ data class DocumentUploadUiState(
     /** 제출 성공 신호 — UI 가 LaunchedEffect 로 완료 화면 이동 후 [DocumentUploadViewModel.onSubmittedConsumed] 로 reset. */
     val isSubmitted: Boolean = false,
 ) {
-    /** 두 서류 중 하나 이상 업로드되면 제출 가능 — 서버도 최소 1개만 요구한다 (이슈 #380). */
+    /**
+     * 두 서류 중 하나 이상 업로드되면 제출 가능 — 서버도 최소 1개만 요구한다 (이슈 #380).
+     * 단 어느 슬롯이든 업로드 진행 중이면 잠근다 — 이미 성공한 URL 만 실려 진행 중 파일이
+     * 신청에서 조용히 빠지는 것 방지 (#711).
+     */
     val canSubmit: Boolean
         get() =
             !isSubmitting &&
+                !deathCertificate.isUploading &&
+                !familyRelationCertificate.isUploading &&
                 (deathCertificate.fileUrl != null || familyRelationCertificate.fileUrl != null)
 }
 

--- a/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadViewModel.kt
+++ b/feature/afternote/presentation/src/main/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadViewModel.kt
@@ -76,6 +76,14 @@ class DocumentUploadViewModel
 
         fun submit() {
             val state = _uiState.value
+            // 버튼 비활성(canSubmit)과 별개의 최종 방어선 — 탭 시점과 recomposition 사이 race 로
+            // 업로드 중에도 도달할 수 있고, 그대로 보내면 진행 중 파일이 신청에서 빠진다 (#711).
+            if (state.deathCertificate.isUploading || state.familyRelationCertificate.isUploading) {
+                _uiState.update {
+                    it.copy(error = ErrorPayload.Res(R.string.receiver_verify_document_upload_in_progress))
+                }
+                return
+            }
             val deathUrl = state.deathCertificate.fileUrl
             val famRelUrl = state.familyRelationCertificate.fileUrl
             if ((deathUrl == null && famRelUrl == null) || state.isSubmitting) {

--- a/feature/afternote/presentation/src/main/res/values/strings.xml
+++ b/feature/afternote/presentation/src/main/res/values/strings.xml
@@ -186,6 +186,7 @@
     <string name="receiver_verify_documents_required">사망진단서 또는 가족관계증명서 중 하나 이상 업로드해주세요.</string>
     <string name="receiver_verify_document_upload_failed">서류 업로드에 실패했습니다.</string>
     <string name="receiver_verify_document_read_failed">선택한 파일을 불러오지 못했습니다. 다시 선택해 주세요.</string>
+    <string name="receiver_verify_document_upload_in_progress">서류 업로드가 진행 중입니다. 완료된 후 신청해 주세요.</string>
     <string name="receiver_verify_submit_failed">열람 신청에 실패했습니다.</string>
     <string name="receiver_verify_complete_title">열람 신청 완료</string>
     <string name="receiver_verify_status_pending">현재 서류 확인중입니다.\n빠르게 처리하여 열람하실 수 있도록 하겠습니다.</string>

--- a/feature/afternote/presentation/src/test/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadViewModelTest.kt
+++ b/feature/afternote/presentation/src/test/kotlin/com/afternote/feature/afternote/presentation/receiver/deliveryverification/DocumentUploadViewModelTest.kt
@@ -1,0 +1,191 @@
+package com.afternote.feature.afternote.presentation.receiver.deliveryverification
+
+import com.afternote.core.common.reporting.ErrorReporter
+import com.afternote.feature.afternote.presentation.R
+import com.afternote.feature.receiver.domain.model.DeliveryVerification
+import com.afternote.feature.receiver.domain.model.DeliveryVerificationStatus
+import com.afternote.feature.receiver.domain.model.ReceiverAuthPresignedUrl
+import com.afternote.feature.receiver.domain.model.ReceiverEmailAuthResult
+import com.afternote.feature.receiver.domain.model.ReceiverIdentity
+import com.afternote.feature.receiver.domain.model.SenderMessageInfo
+import com.afternote.feature.receiver.domain.repository.ReceiverAuthRepository
+import com.afternote.feature.receiver.domain.repository.ReceiverDeliveryDocumentUploadRepository
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * [DocumentUploadViewModel] 교차 슬롯 상태 전이 가드 (#711).
+ *
+ * 계약 — 어느 슬롯이든 업로드 진행 중이면 [DocumentUploadUiState.canSubmit] 이 잠기고
+ * [DocumentUploadViewModel.submit] 도 진행 안내로 거절한다. 이미 성공한 URL 만 실려
+ * 진행 중 파일이 신청에서 조용히 빠지는 것 방지. 진행 중 업로드가 완료·실패로 끝나면
+ * 잠금이 풀리고, 한 장만으로도 제출 가능한 최소 1개 정책(#380)은 유지된다.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DocumentUploadViewModelTest {
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    /** 관심사는 상태 전이뿐이라 계측은 버린다. */
+    private object NoopErrorReporter : ErrorReporter {
+        override fun writeFailure(
+            throwable: Throwable,
+            attributes: Map<String, String>,
+        ) = Unit
+    }
+
+    private fun viewModel(
+        uploads: FakeUploadRepository,
+        auth: FakeReceiverAuthRepository = FakeReceiverAuthRepository(),
+    ): DocumentUploadViewModel =
+        DocumentUploadViewModel(
+            uploadRepository = uploads,
+            receiverAuthRepository = auth,
+            errorReporter = NoopErrorReporter,
+        )
+
+    private fun DocumentUploadViewModel.startUpload(slot: DocumentSlot) {
+        uploadDocument(slot = slot, bytes = byteArrayOf(1), extension = "jpg", displayName = "서류.jpg")
+    }
+
+    @Test
+    fun `한쪽 완료 후 다른 쪽 업로드 중 - canSubmit 잠기고 완료되면 풀림`() {
+        val uploads = FakeUploadRepository()
+        val viewModel = viewModel(uploads)
+
+        viewModel.startUpload(DocumentSlot.DeathCertificate)
+        uploads.completeOldest(Result.success("url-death"))
+        assertTrue(viewModel.uiState.value.canSubmit)
+
+        viewModel.startUpload(DocumentSlot.FamilyRelationCertificate)
+        assertTrue(viewModel.uiState.value.familyRelationCertificate.isUploading)
+        assertFalse(viewModel.uiState.value.canSubmit)
+
+        uploads.completeOldest(Result.success("url-family"))
+        assertTrue(viewModel.uiState.value.canSubmit)
+    }
+
+    @Test
+    fun `업로드 진행 중 submit - 진행 안내로 거절되고 신청 API 미호출`() {
+        val uploads = FakeUploadRepository()
+        val auth = FakeReceiverAuthRepository()
+        val viewModel = viewModel(uploads, auth)
+        viewModel.startUpload(DocumentSlot.DeathCertificate)
+        uploads.completeOldest(Result.success("url-death"))
+        viewModel.startUpload(DocumentSlot.FamilyRelationCertificate)
+
+        viewModel.submit()
+
+        val state = viewModel.uiState.value
+        assertEquals(ErrorPayload.Res(R.string.receiver_verify_document_upload_in_progress), state.error)
+        assertFalse(state.isSubmitting)
+        assertTrue(auth.submittedPayloads.isEmpty())
+    }
+
+    @Test
+    fun `업로드 실패로 끝난 슬롯 - 잠금이 풀려 기존 첨부만으로 제출 가능 (#380 정책 유지)`() {
+        val uploads = FakeUploadRepository()
+        val viewModel = viewModel(uploads)
+        viewModel.startUpload(DocumentSlot.DeathCertificate)
+        uploads.completeOldest(Result.success("url-death"))
+
+        viewModel.startUpload(DocumentSlot.FamilyRelationCertificate)
+        uploads.completeOldest(Result.failure(Exception("S3 PUT 실패")))
+
+        val state = viewModel.uiState.value
+        assertFalse(state.familyRelationCertificate.isUploading)
+        assertTrue(state.canSubmit)
+    }
+
+    @Test
+    fun `모든 업로드 완료 후 submit - 두 URL 이 모두 페이로드에 실림`() {
+        val uploads = FakeUploadRepository()
+        val auth = FakeReceiverAuthRepository()
+        val viewModel = viewModel(uploads, auth)
+        viewModel.startUpload(DocumentSlot.DeathCertificate)
+        uploads.completeOldest(Result.success("url-death"))
+        viewModel.startUpload(DocumentSlot.FamilyRelationCertificate)
+        uploads.completeOldest(Result.success("url-family"))
+
+        viewModel.submit()
+
+        assertEquals(listOf("url-death" to "url-family"), auth.submittedPayloads)
+        assertTrue(viewModel.uiState.value.isSubmitted)
+    }
+}
+
+/**
+ * [ReceiverDeliveryDocumentUploadRepository] 가짜 — [upload] 를 호출 순서대로 [CompletableDeferred]
+ * 에 매달아 두어, 테스트가 "업로드 진행 중" 상태를 원하는 시점까지 유지·해소할 수 있게 한다.
+ */
+private class FakeUploadRepository : ReceiverDeliveryDocumentUploadRepository {
+    private val pending = ArrayDeque<CompletableDeferred<Result<String>>>()
+
+    override suspend fun upload(
+        bytes: ByteArray,
+        extension: String,
+    ): Result<String> {
+        val deferred = CompletableDeferred<Result<String>>()
+        pending.addLast(deferred)
+        return deferred.await()
+    }
+
+    fun completeOldest(result: Result<String>) {
+        pending.removeFirst().complete(result)
+    }
+}
+
+/** [ReceiverAuthRepository] 가짜 — 제출 페이로드만 기록하고, 미지정 경로 호출은 error 로 드러낸다. */
+private class FakeReceiverAuthRepository : ReceiverAuthRepository {
+    val submittedPayloads = mutableListOf<Pair<String?, String?>>()
+
+    override suspend fun submitDeliveryVerification(
+        deathCertificateUrl: String?,
+        familyRelationCertificateUrl: String?,
+    ): Result<DeliveryVerification> {
+        submittedPayloads += deathCertificateUrl to familyRelationCertificateUrl
+        return Result.success(
+            DeliveryVerification(
+                id = 1L,
+                status = DeliveryVerificationStatus.PENDING,
+                deathCertificateUrl = deathCertificateUrl,
+                familyRelationCertificateUrl = familyRelationCertificateUrl,
+                adminNote = null,
+                createdAt = null,
+            ),
+        )
+    }
+
+    override suspend fun verifyMasterKey(authCode: String): Result<ReceiverIdentity> = error("verifyMasterKey 는 이 시나리오에서 호출되면 안 됨")
+
+    override suspend fun sendEmailAuthCode(email: String): Result<Unit> = error("sendEmailAuthCode 는 이 시나리오에서 호출되면 안 됨")
+
+    override suspend fun verifyEmailAuthCode(
+        email: String,
+        authCode: String,
+    ): Result<ReceiverEmailAuthResult> = error("verifyEmailAuthCode 는 이 시나리오에서 호출되면 안 됨")
+
+    override suspend fun getPresignedUrl(extension: String): Result<ReceiverAuthPresignedUrl> = error("getPresignedUrl 은 이 시나리오에서 호출되면 안 됨")
+
+    override suspend fun getDeliveryVerificationStatus(): Result<DeliveryVerification> =
+        error("getDeliveryVerificationStatus 는 이 시나리오에서 호출되면 안 됨")
+
+    override suspend fun getSenderMessage(): Result<SenderMessageInfo> = error("getSenderMessage 는 이 시나리오에서 호출되면 안 됨")
+}


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #711 — fix(afternote): 다른 증빙 서류 업로드 중에도 열람 신청 가능 — 진행 중 파일 누락

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- `DocumentUploadUiState.canSubmit` 이 두 슬롯의 `isUploading` 을 검사 — 어느 슬롯이든 업로드 진행 중이면 열람 신청 버튼 잠금 (최소 1개 제출 정책 #380 은 유지)
- `DocumentUploadViewModel.submit()` 에 같은 검사를 최종 방어선으로 추가 — 탭과 recomposition 사이 race 로 도달해도 진행 안내 문구로 거절하고 신청 API 를 호출하지 않음
- 진행 중 제출 시도 안내 문구 `receiver_verify_document_upload_in_progress` 추가
- `DocumentUploadViewModelTest` 신규 — 교차 슬롯 상태 전이 4건: 진행 중 잠금→완료 시 해제, 진행 중 submit 거절+신청 API 미호출, 실패 종료 시 잠금 해제(한 장 제출 유지), 완료 후 두 URL 모두 페이로드 적재. 이를 위해 모듈에 `coroutines-test` 테스트 의존성 추가

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

UI 변경 없음 — 버튼 활성 조건과 guard 로직만 변경. 기존 Preview 는 전부 `isUploading=false` 상태라 렌더 불변 (screenshotTest baseline 영향 없음).

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- **stack base 의존**: base 가 `feat/740`(#761) — `DocumentUploadViewModel.kt` 등 파일 겹침으로 스택. #761 머지 후 develop 으로 재타겟 필요 (이슈 Relationships 에 blocked_by #740 기재)
- "업로드 진행 중" 상태는 실서버 S3 업로드 타이밍에 의존해 에뮬 재현이 비결정적 — 교차 슬롯 전이는 VM 단위 테스트로 커버
- 빌드 검증: `./gradlew :feature:afternote:presentation:compileDebugKotlin` BUILD SUCCESSFUL · `testDebugUnitTest --tests '*DocumentUploadViewModelTest'` 4건 통과 · `ktlintCheck` 통과
