### PR TITLE
fix(setting): 회원 탈퇴 요청 흐름 수정

### DIFF
--- a/feature/setting/presentation/build.gradle.kts
+++ b/feature/setting/presentation/build.gradle.kts
@@ -34,4 +34,6 @@ dependencies {
     implementation(libs.androidx.credentials)
     implementation(libs.androidx.credentials.play.services.auth)
     implementation(libs.googleid)
+
+    testImplementation(libs.coroutines.test)
 }

--- a/feature/setting/presentation/src/main/kotlin/com/afternote/feature/setting/presentation/screen/WithdrawConfirmScreen.kt
+++ b/feature/setting/presentation/src/main/kotlin/com/afternote/feature/setting/presentation/screen/WithdrawConfirmScreen.kt
@@ -14,11 +14,9 @@ import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -36,6 +34,7 @@ import com.afternote.core.ui.topbar.DetailTopBar
 import com.afternote.feature.setting.presentation.R
 import com.afternote.feature.setting.presentation.viewmodel.SettingUiState
 import com.afternote.feature.setting.presentation.viewmodel.SettingViewModel
+import com.afternote.feature.setting.presentation.viewmodel.WithdrawUiState
 
 private const val WITHDRAW_CONFIRM_TEXT = "탈퇴하겠습니다"
 
@@ -51,22 +50,33 @@ fun WithdrawConfirmScreen(
     val userEmail = (uiState as? SettingUiState.Success)?.email.orEmpty()
     val textState = rememberTextFieldState()
     var showError by remember { mutableStateOf(false) }
-    var showCompletionDialog by remember { mutableStateOf(false) }
-    val withdrawCompleted by viewModel.withdrawCompleted.collectAsStateWithLifecycle()
-    val currentOnWithdrawSuccess by rememberUpdatedState(onWithdrawSuccess)
+    val withdrawUiState by viewModel.withdrawUiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(withdrawCompleted) {
-        if (withdrawCompleted) currentOnWithdrawSuccess()
-    }
+    when (withdrawUiState) {
+        WithdrawUiState.Success -> {
+            Popup(
+                type = PopupType.Default,
+                message = stringResource(R.string.withdraw_complete_message),
+                confirmText = stringResource(R.string.withdraw_complete_button),
+                onConfirm = onWithdrawSuccess,
+                onDismiss = onWithdrawSuccess,
+            )
+        }
 
-    if (showCompletionDialog) {
-        Popup(
-            type = PopupType.Default,
-            message = stringResource(R.string.withdraw_complete_message),
-            confirmText = stringResource(R.string.withdraw_complete_button),
-            onConfirm = viewModel::deleteAccount,
-            onDismiss = {},
-        )
+        WithdrawUiState.Error -> {
+            Popup(
+                type = PopupType.Variant2,
+                message = stringResource(R.string.withdraw_failed_message),
+                confirmText = stringResource(R.string.withdraw_retry_button),
+                dismissText = stringResource(R.string.withdraw_close_button),
+                onConfirm = viewModel::deleteAccount,
+                onDismiss = viewModel::dismissWithdrawError,
+            )
+        }
+
+        WithdrawUiState.Idle,
+        WithdrawUiState.Loading,
+        -> {}
     }
 
     Scaffold(
@@ -113,11 +123,13 @@ fun WithdrawConfirmScreen(
                 onBackClick = onBackClick,
                 onWithdrawClick = {
                     if (textState.text.toString() == WITHDRAW_CONFIRM_TEXT) {
-                        showCompletionDialog = true
+                        showError = false
+                        viewModel.deleteAccount()
                     } else {
                         showError = true
                     }
                 },
+                isLoading = withdrawUiState == WithdrawUiState.Loading,
             )
             Spacer(Modifier.height(24.dp))
         }
@@ -165,6 +177,7 @@ private fun WithdrawAccountSection(
 private fun WithdrawConfirmBottomButtons(
     onBackClick: () -> Unit,
     onWithdrawClick: () -> Unit,
+    isLoading: Boolean,
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -180,6 +193,7 @@ private fun WithdrawConfirmBottomButtons(
             text = stringResource(R.string.withdraw_confirm_button),
             onClick = onWithdrawClick,
             type = AfternoteButtonType.Default,
+            isLoading = isLoading,
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/feature/setting/presentation/src/main/kotlin/com/afternote/feature/setting/presentation/viewmodel/SettingViewModel.kt
+++ b/feature/setting/presentation/src/main/kotlin/com/afternote/feature/setting/presentation/viewmodel/SettingViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.afternote.core.domain.repository.UserRepository
 import com.afternote.core.domain.repository.auth.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -21,6 +22,16 @@ sealed interface SettingUiState {
     data class Error(
         val message: String,
     ) : SettingUiState
+}
+
+sealed interface WithdrawUiState {
+    data object Idle : WithdrawUiState
+
+    data object Loading : WithdrawUiState
+
+    data object Success : WithdrawUiState
+
+    data object Error : WithdrawUiState
 }
 
 /**
@@ -71,13 +82,28 @@ class SettingViewModel
             }
         }
 
-        private val _withdrawCompleted = MutableStateFlow(false)
-        val withdrawCompleted = _withdrawCompleted.asStateFlow()
+        private val _withdrawUiState = MutableStateFlow<WithdrawUiState>(WithdrawUiState.Idle)
+        val withdrawUiState = _withdrawUiState.asStateFlow()
 
         fun deleteAccount() {
+            if (_withdrawUiState.value == WithdrawUiState.Loading) return
+            _withdrawUiState.value = WithdrawUiState.Loading
+
             viewModelScope.launch {
-                runCatching { userRepository.deleteAccount() }
-                    .onSuccess { _withdrawCompleted.value = true }
+                try {
+                    userRepository.deleteAccount()
+                    _withdrawUiState.value = WithdrawUiState.Success
+                } catch (exception: CancellationException) {
+                    throw exception
+                } catch (_: Exception) {
+                    _withdrawUiState.value = WithdrawUiState.Error
+                }
+            }
+        }
+
+        fun dismissWithdrawError() {
+            if (_withdrawUiState.value == WithdrawUiState.Error) {
+                _withdrawUiState.value = WithdrawUiState.Idle
             }
         }
     }

--- a/feature/setting/presentation/src/main/res/values/strings.xml
+++ b/feature/setting/presentation/src/main/res/values/strings.xml
@@ -73,6 +73,9 @@
     <string name="withdraw_confirm_prev_button">이전으로</string>
     <string name="withdraw_complete_message">회원 탈퇴가 완료되었습니다.\n애프터노트를 이용해 주셔서 감사합니다.</string>
     <string name="withdraw_complete_button">확인하기</string>
+    <string name="withdraw_failed_message">회원 탈퇴에 실패했습니다. 잠시 후 다시 시도해 주세요.</string>
+    <string name="withdraw_retry_button">재시도</string>
+    <string name="withdraw_close_button">닫기</string>
 
     <!-- 설정 - 회원 탈퇴 메뉴 -->
     <string name="settings_account_withdraw">회원 탈퇴</string>

--- a/feature/setting/presentation/src/test/kotlin/com/afternote/feature/setting/presentation/viewmodel/SettingViewModelTest.kt
+++ b/feature/setting/presentation/src/test/kotlin/com/afternote/feature/setting/presentation/viewmodel/SettingViewModelTest.kt
@@ -1,0 +1,92 @@
+package com.afternote.feature.setting.presentation.viewmodel
+
+import com.afternote.core.domain.repository.UserRepository
+import com.afternote.core.domain.repository.auth.AuthRepository
+import com.afternote.core.model.user.User
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.lang.reflect.Proxy
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `deleteAccount 성공 시 Loading을 거쳐 Success가 된다`() =
+        runTest(dispatcher) {
+            val viewModel = viewModel(onDeleteAccount = {})
+
+            viewModel.deleteAccount()
+
+            assertEquals(WithdrawUiState.Loading, viewModel.withdrawUiState.value)
+            runCurrent()
+            assertEquals(WithdrawUiState.Success, viewModel.withdrawUiState.value)
+        }
+
+    @Test
+    fun `deleteAccount 실패 시 Error가 되고 오류를 닫으면 Idle로 돌아간다`() =
+        runTest(dispatcher) {
+            val viewModel = viewModel(onDeleteAccount = { throw IllegalStateException("failure") })
+
+            viewModel.deleteAccount()
+            runCurrent()
+
+            assertEquals(WithdrawUiState.Error, viewModel.withdrawUiState.value)
+            viewModel.dismissWithdrawError()
+            assertEquals(WithdrawUiState.Idle, viewModel.withdrawUiState.value)
+        }
+
+    @Test
+    fun `Loading 중에는 탈퇴 요청을 중복 실행하지 않는다`() =
+        runTest(dispatcher) {
+            var requestCount = 0
+            val viewModel = viewModel(onDeleteAccount = { requestCount++ })
+
+            viewModel.deleteAccount()
+            viewModel.deleteAccount()
+            runCurrent()
+
+            assertEquals(1, requestCount)
+        }
+
+    private fun viewModel(onDeleteAccount: () -> Unit): SettingViewModel =
+        SettingViewModel(
+            authRepository =
+                repositoryProxy { methodName ->
+                    error("Unexpected AuthRepository call: $methodName")
+                },
+            userRepository =
+                repositoryProxy { methodName ->
+                    when (methodName) {
+                        "getMyProfile" -> User("name", "user@example.com", null, null)
+                        "deleteAccount" -> onDeleteAccount()
+                        else -> error("Unexpected UserRepository call: $methodName")
+                    }
+                },
+        )
+
+    private inline fun <reified T> repositoryProxy(crossinline onCall: (String) -> Any?): T =
+        Proxy.newProxyInstance(
+            T::class.java.classLoader,
+            arrayOf(T::class.java),
+        ) { _, method, _ -> onCall(method.name) } as T
+}


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
- closes #585

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
- 탈퇴 API 성공 이후에만 완료 팝업이 노출되도록 요청 흐름을 수정했습니다.
- 탈퇴 요청 상태를 Idle/Loading/Success/Error로 관리하고, 로딩 중 중복 요청을 차단했습니다.
- 실패 시 닫기 및 재시도 경로를 추가하고 ViewModel 회귀 테스트를 작성했습니다.

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
- UI 구조 변경 없음

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
- 성공 전에는 완료 안내가 노출되지 않으며, 실패 팝업에서 닫기 또는 재시도가 가능합니다.
- 검증: `:feature:setting:presentation:ktlintCheck`, `:feature:setting:presentation:testDebugUnitTest`, `:feature:setting:presentation:compileDebugKotlin`