### PR TITLE
feat(app): FCM 수신 기반 연동 (closes 779) [base: develop]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -136,6 +136,13 @@ android {
     }
 }
 
+configurations.configureEach {
+    if (name == "debugScreenshotTestCompileClasspath") {
+        // Keep the renderer from loading firebase-datatransport R classes from two different versions.
+        exclude(group = "com.google.firebase", module = "firebase-datatransport")
+    }
+}
+
 dependencies {
     implementation(libs.coil.compose)
     implementation(libs.androidx.hilt.navigation.compose)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -152,6 +152,7 @@ dependencies {
     // 그래서 로그에 "Could not register handler for breadcrumbs events" 가 뜨는 건 정상이다.
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.crashlytics)
+    implementation(libs.firebase.messaging)
 
     // Core
     implementation(projects.core.common)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,23 @@
         <meta-data
                 android:name="google_analytics_default_allow_ad_personalization_signals"
                 android:value="false" />
+        <meta-data
+                android:name="firebase_messaging_installation_id_enabled"
+                android:value="true" />
+        <meta-data
+                android:name="com.google.firebase.messaging.default_notification_icon"
+                android:resource="@drawable/core_common_logo" />
+        <meta-data
+                android:name="com.google.firebase.messaging.default_notification_channel_id"
+                android:value="@string/fcm_notification_channel_id" />
+
+        <service
+                android:name=".messaging.AfternoteFirebaseMessagingService"
+                android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
 
         <activity
                 android:name=".MainActivity"

--- a/app/src/main/java/com/afternote/afternote_fe/GlobalApplication.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/GlobalApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.SingletonImageLoader
+import com.afternote.afternote_fe.messaging.FcmNotificationChannel
 import com.afternote.core.network.di.CoilImageLoaderEntryPoint
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.HiltAndroidApp
@@ -20,6 +21,7 @@ class GlobalApplication :
 
     override fun onCreate() {
         super.onCreate()
-        // 초기화 로직은 전부 core:startup의 App Startup Initializer로 둔다.
+        FcmNotificationChannel.create(this)
+        // 공통 초기화는 core:startup에 두고, app 전용 Firebase 채널만 여기서 생성한다.
     }
 }

--- a/app/src/main/java/com/afternote/afternote_fe/messaging/AfternoteFirebaseMessagingService.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/messaging/AfternoteFirebaseMessagingService.kt
@@ -1,0 +1,129 @@
+package com.afternote.afternote_fe.messaging
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.util.Log
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.afternote.afternote_fe.R
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import java.util.concurrent.atomic.AtomicInteger
+import com.afternote.core.common.R as CommonR
+
+class AfternoteFirebaseMessagingService : FirebaseMessagingService() {
+    override fun onCreate() {
+        super.onCreate()
+        FcmNotificationChannel.create(this)
+    }
+
+    override fun onRegistered(installationId: String) {
+        super.onRegistered(installationId)
+        Log.d(TAG, "FCM installation registered")
+    }
+
+    override fun onUnregistered(installationId: String) {
+        super.onUnregistered(installationId)
+        Log.d(TAG, "FCM installation unregistered")
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        val content =
+            FcmNotificationContentResolver.resolve(
+                notificationTitle = message.notification?.title,
+                notificationBody = message.notification?.body,
+                data = message.data,
+                fallbackTitle = getString(R.string.fcm_notification_fallback_title),
+            ) ?: return
+
+        showNotification(content, notificationId(message.messageId))
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun showNotification(
+        content: FcmNotificationContent,
+        notificationId: Int,
+    ) {
+        if (
+            ActivityCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            return
+        }
+
+        val notification =
+            NotificationCompat
+                .Builder(this, getString(R.string.fcm_notification_channel_id))
+                .setSmallIcon(CommonR.drawable.core_common_logo)
+                .setContentTitle(content.title)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
+                .setAutoCancel(true)
+                .apply {
+                    content.body?.let { body ->
+                        setContentText(body)
+                        setStyle(NotificationCompat.BigTextStyle().bigText(body))
+                    }
+                    buildContentPendingIntent(notificationId)?.let(::setContentIntent)
+                }.build()
+
+        NotificationManagerCompat.from(this).notify(notificationId, notification)
+    }
+
+    private fun buildContentPendingIntent(notificationId: Int): PendingIntent? {
+        val launchIntent =
+            packageManager
+                .getLaunchIntentForPackage(packageName)
+                ?.apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                }
+                ?: return null
+
+        return PendingIntent.getActivity(
+            this,
+            notificationId,
+            launchIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+
+    private fun notificationId(messageId: String?): Int = messageId?.hashCode() ?: nextNotificationId.incrementAndGet()
+
+    private companion object {
+        const val TAG = "AfternoteFCM"
+        val nextNotificationId = AtomicInteger(FCM_NOTIFICATION_ID_START)
+        const val FCM_NOTIFICATION_ID_START = 2_000
+    }
+}
+
+internal data class FcmNotificationContent(
+    val title: String,
+    val body: String?,
+)
+
+internal object FcmNotificationContentResolver {
+    fun resolve(
+        notificationTitle: String?,
+        notificationBody: String?,
+        data: Map<String, String>,
+        fallbackTitle: String,
+    ): FcmNotificationContent? {
+        val title = notificationTitle.nonBlankOrNull() ?: data[KEY_TITLE].nonBlankOrNull()
+        val body = notificationBody.nonBlankOrNull() ?: data[KEY_BODY].nonBlankOrNull()
+        if (title == null && body == null) return null
+
+        return FcmNotificationContent(
+            title = title ?: fallbackTitle,
+            body = body,
+        )
+    }
+
+    private fun String?.nonBlankOrNull(): String? = this?.trim()?.takeIf(String::isNotEmpty)
+
+    private const val KEY_TITLE = "title"
+    private const val KEY_BODY = "body"
+}

--- a/app/src/main/java/com/afternote/afternote_fe/messaging/FcmNotificationChannel.kt
+++ b/app/src/main/java/com/afternote/afternote_fe/messaging/FcmNotificationChannel.kt
@@ -1,0 +1,18 @@
+package com.afternote.afternote_fe.messaging
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import com.afternote.afternote_fe.R
+
+internal object FcmNotificationChannel {
+    fun create(context: Context) {
+        val channel =
+            NotificationChannel(
+                context.getString(R.string.fcm_notification_channel_id),
+                context.getString(R.string.fcm_notification_channel_name),
+                NotificationManager.IMPORTANCE_DEFAULT,
+            )
+        context.getSystemService(NotificationManager::class.java)?.createNotificationChannel(channel)
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,8 @@
 <resources>
     <string name="app_name">afternote-fe</string>
+    <string name="fcm_notification_channel_id" translatable="false">afternote_fcm</string>
+    <string name="fcm_notification_channel_name">애프터노트 알림</string>
+    <string name="fcm_notification_fallback_title" translatable="false">AFTERNOTE</string>
 
     <!-- 홈 탭 -->
     <string name="home_tab_greeting">안녕하세요,\n%1$s님</string>

--- a/app/src/test/java/com/afternote/afternote_fe/messaging/FcmNotificationContentResolverTest.kt
+++ b/app/src/test/java/com/afternote/afternote_fe/messaging/FcmNotificationContentResolverTest.kt
@@ -1,0 +1,46 @@
+package com.afternote.afternote_fe.messaging
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FcmNotificationContentResolverTest {
+    @Test
+    fun `notification payload takes priority over data payload`() {
+        val content =
+            FcmNotificationContentResolver.resolve(
+                notificationTitle = "알림 제목",
+                notificationBody = "알림 본문",
+                data = mapOf("title" to "data 제목", "body" to "data 본문"),
+                fallbackTitle = "AFTERNOTE",
+            )
+
+        assertEquals(FcmNotificationContent(title = "알림 제목", body = "알림 본문"), content)
+    }
+
+    @Test
+    fun `data body uses fallback title when title is absent`() {
+        val content =
+            FcmNotificationContentResolver.resolve(
+                notificationTitle = null,
+                notificationBody = null,
+                data = mapOf("body" to "data 본문"),
+                fallbackTitle = "AFTERNOTE",
+            )
+
+        assertEquals(FcmNotificationContent(title = "AFTERNOTE", body = "data 본문"), content)
+    }
+
+    @Test
+    fun `blank payload does not create a notification`() {
+        val content =
+            FcmNotificationContentResolver.resolve(
+                notificationTitle = " ",
+                notificationBody = null,
+                data = mapOf("body" to ""),
+                fallbackTitle = "AFTERNOTE",
+            )
+
+        assertNull(content)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -115,6 +115,7 @@ screenshot-validation-api = { group = "com.android.tools.screenshot", name = "sc
 konsist = { group = "com.lemonappdev", name = "konsist", version.ref = "konsist" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
+firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴

Closes #779 — feat(app): FCM 수신 기반 연동 — 메시징 SDK·서비스·알림 표시

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯

- Firebase BoM 아래 Messaging SDK를 추가하고 `FirebaseMessagingService`를 앱에 등록
- notification/data payload의 제목·본문 해석, 알림 권한 확인, 전용 채널 기반 알림 표시 구현
- 알림 탭 시 앱 런처 진입과 FID 등록·해제 콜백 경계 구성
- payload 우선순위·fallback·빈 payload에 대한 단위 테스트 추가 (`05b5a491`)

## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵

Compose UI 변경 없음.

- 전용 QA 에뮬레이터에서 Firebase Console notification 메시지의 백그라운드 수신 확인
- 앱 포그라운드 상태에서 `onMessageReceived → showNotification → notify` 커스텀 알림 생성 경로 실행 확인

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- Firebase Messaging 25.1.1의 FID 기반 `onRegistered`를 사용하며 deprecated `onNewToken`은 구현하지 않음
- 서버 FID 업로드와 개별 화면 딥링크는 현재 서버·payload 계약이 없어 이슈 범위에서 제외
- 빌드 검증: `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --tests 'com.afternote.afternote_fe.messaging.FcmNotificationContentResolverTest' ktlintCheck` BUILD SUCCESSFUL
