### PR TITLE
fix(timeletter): 타임레터 화면 배경색 수정

### DIFF
--- a/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/screen/recipient/RecipientTimeletterScreen.kt
+++ b/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/screen/recipient/RecipientTimeletterScreen.kt
@@ -59,6 +59,7 @@ fun RecipientTimeletterScreen(
 
     Scaffold(
         modifier = modifier,
+        containerColor = AfternoteDesign.colors.gray1,
         topBar = { HomeTopBar() },
     ) { innerPadding ->
         when (val state = uiState) {
@@ -266,6 +267,7 @@ private val previewLetters =
 @Composable
 private fun RecipientTimeletterScreenPreview() {
     Scaffold(
+        containerColor = AfternoteDesign.colors.gray1,
         topBar = { HomeTopBar() },
     ) { innerPadding ->
         RecipientTimeletterContent(

--- a/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/screen/recipient/RecipientTimeletterScreen.kt
+++ b/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/screen/recipient/RecipientTimeletterScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -59,7 +60,7 @@ fun RecipientTimeletterScreen(
 
     Scaffold(
         modifier = modifier,
-        containerColor = AfternoteDesign.colors.gray1,
+        containerColor = Color.Transparent,
         topBar = { HomeTopBar() },
     ) { innerPadding ->
         when (val state = uiState) {

--- a/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/screen/sender/TimeletterScreen.kt
+++ b/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/screen/sender/TimeletterScreen.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import com.afternote.core.ui.button.FAB.PenFloatingActionButton
+import com.afternote.core.ui.theme.AfternoteDesign
 import com.afternote.core.ui.topbar.HomeTopBar
 import com.afternote.feature.timeletter.domain.model.TimeLetter
 import com.afternote.feature.timeletter.domain.model.TimeLetterList
@@ -64,6 +65,7 @@ fun TimeletterScreen(
 
     Scaffold(
         modifier = modifier,
+        containerColor = AfternoteDesign.colors.gray1,
         topBar = { HomeTopBar() },
         floatingActionButton = { PenFloatingActionButton(onClick = onWriteClick) },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },

--- a/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/screen/sender/TimeletterScreen.kt
+++ b/feature/timeletter/presentation/src/main/kotlin/com/afternote/feature/timeletter/presentation/screen/sender/TimeletterScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -65,7 +66,7 @@ fun TimeletterScreen(
 
     Scaffold(
         modifier = modifier,
-        containerColor = AfternoteDesign.colors.gray1,
+        containerColor = Color.Transparent,
         topBar = { HomeTopBar() },
         floatingActionButton = { PenFloatingActionButton(onClick = onWriteClick) },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },


### PR DESCRIPTION
## Summary
- 발신자와 수신자 타임레터 메인 Scaffold 배경을 gray1로 지정했습니다.
- 수신자 Preview에도 동일한 배경색을 적용했습니다.
- Material3 기본 surface 색이 노출되어 탭 간 배경이 달라지는 문제를 수정했습니다.

## Test
- .\gradlew.bat :feature:timeletter:presentation:compileDebugKotlin
- .\gradlew.bat :feature:timeletter:presentation:ktlintCheck
- git diff --check

Closes #692